### PR TITLE
Change artifact path format

### DIFF
--- a/api/v1alpha1/artifact.go
+++ b/api/v1alpha1/artifact.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package v1alpha1
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // Artifact represents the output of a source synchronisation
 type Artifact struct {
@@ -38,4 +42,10 @@ type Artifact struct {
 	// update of this artifact.
 	// +required
 	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
+}
+
+// ArtifactPath returns the artifact path in the form of
+// <source-kind>/<source-namespace>/<source-name>/<artifact-filename>
+func ArtifactPath(kind, namespace, name, filename string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", kind, namespace, name, filename)
 }

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/repo"
 	corev1 "k8s.io/api/core/v1"
@@ -149,7 +148,7 @@ func (r *HelmChartReconciler) sync(repository sourcev1.HelmRepository, chart sou
 	ref := cv.URLs[0]
 	u, err := url.Parse(ref)
 	if err != nil {
-		err = errors.Errorf("invalid chart URL format '%s': %w", ref, err)
+		err = fmt.Errorf("invalid chart URL format '%s': %w", ref, err)
 		return sourcev1.HelmChartNotReady(chart, sourcev1.ChartPullFailedReason, err.Error()), err
 	}
 

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -61,7 +61,7 @@ func NewStorage(basePath string, hostname string, timeout time.Duration) (*Stora
 // ArtifactFor returns an artifact for the given Kubernetes object
 func (s *Storage) ArtifactFor(kind string, metadata metav1.Object, fileName, revision string) sourcev1.Artifact {
 	kind = strings.ToLower(kind)
-	path := fmt.Sprintf("%s/%s-%s/%s", kind, metadata.GetNamespace(), metadata.GetName(), fileName)
+	path := sourcev1.ArtifactPath(kind, metadata.GetNamespace(), metadata.GetName(), fileName)
 	localPath := filepath.Join(s.BasePath, path)
 	url := fmt.Sprintf("http://%s/%s", s.Hostname, path)
 

--- a/internal/git/transport_test.go
+++ b/internal/git/transport_test.go
@@ -59,7 +59,7 @@ func TestAuthMethodFromSecret(t *testing.T) {
 	}{
 		{"HTTP", "http://git.example.com/org/repo.git", basicAuthSecretFixture, &http.BasicAuth{}, false},
 		{"HTTPS", "https://git.example.com/org/repo.git", basicAuthSecretFixture, &http.BasicAuth{}, false},
-		{"SSH", "ssh://git.example.com:2222/org/repo.git", privateKeySecretFixture,  &ssh.PublicKeys{}, false},
+		{"SSH", "ssh://git.example.com:2222/org/repo.git", privateKeySecretFixture, &ssh.PublicKeys{}, false},
 		{"unsupported", "protocol://git.example.com/org/repo.git", corev1.Secret{}, nil, false},
 	}
 	for _, tt := range tests {
@@ -83,13 +83,13 @@ func TestBasicAuthFromSecret(t *testing.T) {
 	tests := []struct {
 		name    string
 		secret  corev1.Secret
-		modify 	func(secret *corev1.Secret)
+		modify  func(secret *corev1.Secret)
 		want    *http.BasicAuth
 		wantErr bool
 	}{
 		{"username and password", basicAuthSecretFixture, nil, &http.BasicAuth{Username: "git", Password: "password"}, false},
-		{"without username", basicAuthSecretFixture, func(s *corev1.Secret) { delete(s.Data, "username")}, nil, true},
-		{"without password", basicAuthSecretFixture, func(s *corev1.Secret) { delete(s.Data, "password")}, nil, true},
+		{"without username", basicAuthSecretFixture, func(s *corev1.Secret) { delete(s.Data, "username") }, nil, true},
+		{"without password", basicAuthSecretFixture, func(s *corev1.Secret) { delete(s.Data, "password") }, nil, true},
 		{"empty", corev1.Secret{}, nil, nil, true},
 	}
 	for _, tt := range tests {
@@ -114,7 +114,7 @@ func TestPublicKeysFromSecret(t *testing.T) {
 	tests := []struct {
 		name    string
 		secret  corev1.Secret
-		modify 	func(secret *corev1.Secret)
+		modify  func(secret *corev1.Secret)
 		wantErr bool
 	}{
 		{"private key and known_hosts", privateKeySecretFixture, nil, false},

--- a/internal/helm/getter_test.go
+++ b/internal/helm/getter_test.go
@@ -16,8 +16,8 @@ var (
 	tlsSecretFixture = corev1.Secret{
 		Data: map[string][]byte{
 			"certFile": []byte(`fixture`),
-			"keyFile": []byte(`fixture`),
-			"caFile": []byte(`fixture`),
+			"keyFile":  []byte(`fixture`),
+			"caFile":   []byte(`fixture`),
 		},
 	}
 )
@@ -63,7 +63,7 @@ func TestBasicAuthFromSecret(t *testing.T) {
 		wantErr bool
 		wantNil bool
 	}{
-		{"username and password", basicAuthSecretFixture, nil,false, false},
+		{"username and password", basicAuthSecretFixture, nil, false, false},
 		{"without username", basicAuthSecretFixture, func(s *corev1.Secret) { delete(s.Data, "username") }, true, true},
 		{"without password", basicAuthSecretFixture, func(s *corev1.Secret) { delete(s.Data, "password") }, true, true},
 		{"empty", corev1.Secret{}, nil, false, true},
@@ -95,7 +95,7 @@ func TestTLSClientConfigFromSecret(t *testing.T) {
 		wantErr bool
 		wantNil bool
 	}{
-		{"certFile, keyFile and caFile", tlsSecretFixture, nil,false, false},
+		{"certFile, keyFile and caFile", tlsSecretFixture, nil, false, false},
 		{"without certFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "certFile") }, true, true},
 		{"without keyFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "keyFile") }, true, true},
 		{"without caFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "caFile") }, true, true},


### PR DESCRIPTION
- move artifact path composition to API
- change path format to `<source-kind>/<source-namespace>/<source-name>/<artifact-filename>`
- fix fmt and `Errorf` usage