### PR TITLE
 controllers: add HelmChart reconciler tests 

### DIFF
--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -269,7 +269,7 @@ func (r *HelmChartReconciler) shouldResetStatus(chart sourcev1.HelmChart) (bool,
 	}
 
 	// set initial status
-	if len(chart.Status.Conditions) == 0 || resetStatus {
+	if len(chart.Status.Conditions) == 0 {
 		resetStatus = true
 	}
 

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -82,7 +82,6 @@ func (r *HelmChartReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		chart = sourcev1.HelmChartNotReady(*chart.DeepCopy(), sourcev1.ChartPullFailedReason, err.Error())
 		if err := r.Status().Update(ctx, &chart); err != nil {
 			log.Error(err, "unable to update HelmChart status")
-			return ctrl.Result{Requeue: true}, err
 		}
 		return ctrl.Result{Requeue: true}, err
 	}
@@ -97,6 +96,10 @@ func (r *HelmChartReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	pulledChart, err := r.sync(repository, *chart.DeepCopy())
 	if err != nil {
 		log.Error(err, "Helm chart sync failed")
+		if err := r.Status().Update(ctx, &pulledChart); err != nil {
+			log.Error(err, "unable to update HelmChart status")
+		}
+		return ctrl.Result{Requeue: true}, err
 	}
 
 	// update status

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -156,8 +156,6 @@ func (r *HelmChartReconciler) sync(repository sourcev1.HelmRepository, chart sou
 		return sourcev1.HelmChartNotReady(chart, sourcev1.ChartPullFailedReason, err.Error()), err
 	}
 
-	// TODO(hidde): auth options from Helm repository probably need to be
-	//  substituted here
 	c, err := r.Getters.ByScheme(u.Scheme)
 	if err != nil {
 		return sourcev1.HelmChartNotReady(chart, sourcev1.ChartPullFailedReason, err.Error()), err

--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"os"
+	"path"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1alpha1"
+	"github.com/fluxcd/source-controller/internal/testserver"
+)
+
+var _ = Describe("HelmChartReconciler", func() {
+
+	const (
+		timeout       = time.Second * 30
+		interval      = time.Second * 1
+		indexInterval = time.Second * 2
+		pullInterval  = time.Second * 3
+	)
+
+	Context("HelmChart", func() {
+		var (
+			namespace  *corev1.Namespace
+			helmServer *testserver.Helm
+			err        error
+		)
+
+		BeforeEach(func() {
+			namespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "helm-chart-test" + randStringRunes(5)},
+			}
+			err = k8sClient.Create(context.Background(), namespace)
+			Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
+
+			helmServer, err = testserver.NewTempHelmServer()
+			Expect(err).To(Succeed())
+			helmServer.Start()
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(helmServer.Root())
+			helmServer.Stop()
+
+			err = k8sClient.Delete(context.Background(), namespace)
+			Expect(err).NotTo(HaveOccurred(), "failed to delete test namespace")
+		})
+
+		It("Creates artifacts for", func() {
+			Expect(helmServer.PackageChart(path.Join("testdata/helmchart"))).Should(Succeed())
+			Expect(helmServer.GenerateIndex()).Should(Succeed())
+
+			repositoryKey := types.NamespacedName{
+				Name:      "helmrepository-sample-" + randStringRunes(5),
+				Namespace: namespace.Name,
+			}
+			Expect(k8sClient.Create(context.Background(), &sourcev1.HelmRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      repositoryKey.Name,
+					Namespace: repositoryKey.Namespace,
+				},
+				Spec: sourcev1.HelmRepositorySpec{
+					URL:      helmServer.URL(),
+					Interval: metav1.Duration{Duration: indexInterval},
+				},
+			})).Should(Succeed())
+
+			key := types.NamespacedName{
+				Name:      "helmchart-sample-" + randStringRunes(5),
+				Namespace: namespace.Name,
+			}
+			created := &sourcev1.HelmChart{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      key.Name,
+					Namespace: key.Namespace,
+				},
+				Spec: sourcev1.HelmChartSpec{
+					Name:              "helmchart",
+					Version:           "*",
+					HelmRepositoryRef: corev1.LocalObjectReference{Name: repositoryKey.Name},
+					Interval:          metav1.Duration{Duration: pullInterval},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), created)).Should(Succeed())
+
+			By("Expecting artifact")
+			got := &sourcev1.HelmChart{}
+			Eventually(func() bool {
+				_ = k8sClient.Get(context.Background(), key, got)
+				return got.Status.Artifact != nil && storage.ArtifactExist(*got.Status.Artifact)
+			}, timeout, interval).Should(BeTrue())
+
+			By("Packaging a new chart version and regenerating the index")
+			Expect(helmServer.PackageChartWithVersion(path.Join("testdata/helmchart"), "0.2.0")).Should(Succeed())
+			Expect(helmServer.GenerateIndex()).Should(Succeed())
+
+			By("Expecting new artifact revision and GC")
+			Eventually(func() bool {
+				now := &sourcev1.HelmChart{}
+				_ = k8sClient.Get(context.Background(), key, now)
+				// Test revision change and garbage collection
+				return now.Status.Artifact.Revision != got.Status.Artifact.Revision &&
+					!storage.ArtifactExist(*got.Status.Artifact)
+			}, timeout, interval).Should(BeTrue())
+
+			By("Expecting to delete successfully")
+			got = &sourcev1.HelmChart{}
+			Eventually(func() error {
+				_ = k8sClient.Get(context.Background(), key, got)
+				return k8sClient.Delete(context.Background(), got)
+			}, timeout, interval).Should(Succeed())
+
+			By("Expecting delete to finish")
+			Eventually(func() error {
+				c := &sourcev1.HelmChart{}
+				return k8sClient.Get(context.Background(), key, c)
+			}).ShouldNot(Succeed())
+
+			By("Expecting GC on delete")
+			Eventually(storage.ArtifactExist(*got.Status.Artifact), timeout, interval).ShouldNot(BeTrue())
+		})
+
+		It("Filters versions", func() {
+			versions := []string{"0.1.0", "0.1.1", "0.2.0", "0.3.0-rc.1", "1.0.0-alpha.1", "1.0.0"}
+			for k := range versions {
+				Expect(helmServer.PackageChartWithVersion(path.Join("testdata/helmchart"), versions[k])).Should(Succeed())
+			}
+
+			Expect(helmServer.GenerateIndex()).Should(Succeed())
+
+			repositoryKey := types.NamespacedName{
+				Name:      "helmrepository-sample-" + randStringRunes(5),
+				Namespace: namespace.Name,
+			}
+			Expect(k8sClient.Create(context.Background(), &sourcev1.HelmRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      repositoryKey.Name,
+					Namespace: repositoryKey.Namespace,
+				},
+				Spec: sourcev1.HelmRepositorySpec{
+					URL:      helmServer.URL(),
+					Interval: metav1.Duration{Duration: 1 * time.Hour},
+				},
+			})).Should(Succeed())
+
+			key := types.NamespacedName{
+				Name:      "helmchart-sample-" + randStringRunes(5),
+				Namespace: namespace.Name,
+			}
+			chart := &sourcev1.HelmChart{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      key.Name,
+					Namespace: key.Namespace,
+				},
+				Spec: sourcev1.HelmChartSpec{
+					Name:              "helmchart",
+					Version:           "*",
+					HelmRepositoryRef: corev1.LocalObjectReference{Name: repositoryKey.Name},
+					Interval:          metav1.Duration{Duration: 1 * time.Hour},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), chart)).Should(Succeed())
+
+			Eventually(func() string {
+				_ = k8sClient.Get(context.Background(), key, chart)
+				if chart.Status.Artifact != nil {
+					return chart.Status.Artifact.Revision
+				}
+				return ""
+			}, timeout, interval).Should(Equal("1.0.0"))
+
+			chart.Spec.Version = "~0.1.0"
+			Expect(k8sClient.Update(context.Background(), chart)).Should(Succeed())
+			Eventually(func() string {
+				_ = k8sClient.Get(context.Background(), key, chart)
+				if chart.Status.Artifact != nil {
+					return chart.Status.Artifact.Revision
+				}
+				return ""
+			}, timeout, interval).Should(Equal("0.1.1"))
+
+			chart.Spec.Version = "invalid"
+			Expect(k8sClient.Update(context.Background(), chart)).Should(Succeed())
+			Eventually(func() bool {
+				_ = k8sClient.Get(context.Background(), key, chart)
+				for _, c := range chart.Status.Conditions {
+					if c.Reason == sourcev1.ChartPullFailedReason {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+			Expect(chart.Status.Artifact.Revision).Should(Equal("0.1.1"))
+		})
+	})
+})

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -160,6 +160,7 @@ func (r *HelmRepositoryReconciler) sync(repository sourcev1.HelmRepository) (sou
 	if err := yaml.Unmarshal(data, i); err != nil {
 		return sourcev1.HelmRepositoryNotReady(repository, sourcev1.IndexationFailedReason, err.Error()), err
 	}
+	i.SortEntries()
 
 	index, err := yaml.Marshal(i)
 	if err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -117,6 +117,18 @@ var _ = BeforeSuite(func(done Done) {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred(), "failed to setup HelmRepositoryReconciler")
 
+	err = (&HelmChartReconciler{
+		Client:  k8sManager.GetClient(),
+		Log:     ctrl.Log.WithName("controllers").WithName("HelmChart"),
+		Scheme:  scheme.Scheme,
+		Storage: storage,
+		Getters: getter.Providers{getter.Provider{
+			Schemes: []string{"http", "https"},
+			New:     getter.NewHTTPGetter,
+		}},
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred(), "failed to setup HelmChartReconciler")
+
 	go func() {
 		err = k8sManager.Start(ctrl.SetupSignalHandler())
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/testserver/helm.go
+++ b/internal/testserver/helm.go
@@ -36,8 +36,13 @@ func (s *Helm) GenerateIndex() error {
 }
 
 func (s *Helm) PackageChart(path string) error {
+	return s.PackageChartWithVersion(path, "")
+}
+
+func (s *Helm) PackageChartWithVersion(path, version string) error {
 	pkg := action.NewPackage()
 	pkg.Destination = s.HTTP.docroot
+	pkg.Version = version
 	_, err := pkg.Run(path, nil)
 	return err
 }

--- a/internal/testserver/http.go
+++ b/internal/testserver/http.go
@@ -89,6 +89,7 @@ func (s *HTTP) Stop() {
 func (s *HTTP) Root() string {
 	return s.docroot
 }
+
 func (s *HTTP) URL() string {
 	if s.server != nil {
 		return s.server.URL


### PR DESCRIPTION
Covers:

- Artifact creation on `HelmChart` creation
- Artifact update on remote Helm repository update
- Garbage collection on artifact update and resource delete
- Invalid / missing `HelmRepository` reference
- Preserving latest artifact on failures
- Usage of `HelmRepository` credentials for chart pulls
- Usage of supplied `.spec.version` for version (range) filtering

Introduces:

- Versioned packaging for Helm repository test server