### PR TITLE
status: record progressing as intermediate state

### DIFF
--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -69,4 +69,8 @@ const (
 	// VerificationFailedReason represents the fact that the cryptographic provenance
 	// verification for the source failed.
 	VerificationFailedReason string = "VerificationFailed"
+
+	// ProgressingReason represents the fact that a source reconciliation
+	// is underway.
+	ProgressingReason string = "Progressing"
 )

--- a/api/v1alpha1/gitrepository_types.go
+++ b/api/v1alpha1/gitrepository_types.go
@@ -113,7 +113,7 @@ const (
 )
 
 // GitRepositoryReady sets the given artifact and url on the
-// HelmRepository and resets the conditions to SourceCondition of
+// GitRepository and resets the conditions to SourceCondition of
 // type Ready with status true and the given reason and message.
 // It returns the modified GitRepository.
 func GitRepositoryReady(repository GitRepository, artifact Artifact, url, reason, message string) GitRepository {
@@ -139,7 +139,23 @@ func GitRepositoryReady(repository GitRepository, artifact Artifact, url, reason
 	return repository
 }
 
-// GitRepositoryNotReady resets the conditions of the HelmRepository
+// GitRepositoryProgressing resets the conditions of the GitRepository
+// to SourceCondition of type Ready with status unknown and
+// progressing reason and message. It returns the modified GitRepository.
+func GitRepositoryProgressing(repository GitRepository) GitRepository {
+	repository.Status.Conditions = []SourceCondition{
+		{
+			Type:               ReadyCondition,
+			Status:             corev1.ConditionUnknown,
+			LastTransitionTime: metav1.Now(),
+			Reason:             ProgressingReason,
+			Message:            "reconciliation in progress",
+		},
+	}
+	return repository
+}
+
+// GitRepositoryNotReady resets the conditions of the GitRepository
 // to SourceCondition of type Ready with status false and the given
 // reason and message. It returns the modified GitRepository.
 func GitRepositoryNotReady(repository GitRepository, reason, message string) GitRepository {

--- a/api/v1alpha1/helmchart_types.go
+++ b/api/v1alpha1/helmchart_types.go
@@ -93,6 +93,22 @@ func HelmChartReady(chart HelmChart, artifact Artifact, url, reason, message str
 	return chart
 }
 
+// HelmChartProgressing resets the conditions of the HelmChart
+// to SourceCondition of type Ready with status unknown and
+// progressing reason and message. It returns the modified HelmChart.
+func HelmChartProgressing(chart HelmChart) HelmChart {
+	chart.Status.Conditions = []SourceCondition{
+		{
+			Type:               ReadyCondition,
+			Status:             corev1.ConditionUnknown,
+			LastTransitionTime: metav1.Now(),
+			Reason:             ProgressingReason,
+			Message:            "reconciliation in progress",
+		},
+	}
+	return chart
+}
+
 // HelmChartNotReady resets the conditions of the HelmChart to
 // SourceCondition of type Ready with status false and the given
 // reason and message. It returns the modified HelmChart.

--- a/api/v1alpha1/helmrepository_types.go
+++ b/api/v1alpha1/helmrepository_types.go
@@ -92,6 +92,22 @@ func HelmRepositoryReady(repository HelmRepository, artifact Artifact, url, reas
 	return repository
 }
 
+// HelmRepositoryProgressing resets the conditions of the HelmRepository
+// to SourceCondition of type Ready with status unknown and
+// progressing reason and message. It returns the modified HelmRepository.
+func HelmRepositoryProgressing(repository HelmRepository) HelmRepository {
+	repository.Status.Conditions = []SourceCondition{
+		{
+			Type:               ReadyCondition,
+			Status:             corev1.ConditionUnknown,
+			LastTransitionTime: metav1.Now(),
+			Reason:             ProgressingReason,
+			Message:            "reconciliation in progress",
+		},
+	}
+	return repository
+}
+
 // HelmRepositoryNotReady resets the conditions of the HelmRepository
 // to SourceCondition of type Ready with status false and the given
 // reason and message. It returns the modified HelmRepository.

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -68,6 +68,12 @@ func (r *GitRepositoryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 			log.Error(err, "unable to update GitRepository status")
 			return ctrl.Result{Requeue: true}, err
 		}
+	} else {
+		repo = sourcev1.GitRepositoryProgressing(repo)
+		if err := r.Status().Update(ctx, &repo); err != nil {
+			log.Error(err, "unable to update GitRepository status")
+			return ctrl.Result{Requeue: true}, err
+		}
 	}
 
 	// try to remove old artifacts

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -68,6 +68,12 @@ func (r *HelmChartReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			log.Error(err, "unable to update HelmChart status")
 			return ctrl.Result{Requeue: true}, err
 		}
+	} else {
+		chart = sourcev1.HelmChartProgressing(chart)
+		if err := r.Status().Update(ctx, &chart); err != nil {
+			log.Error(err, "unable to update HelmChart status")
+			return ctrl.Result{Requeue: true}, err
+		}
 	}
 
 	// try to remove old artifacts

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -70,6 +70,12 @@ func (r *HelmRepositoryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 			log.Error(err, "unable to update HelmRepository status")
 			return ctrl.Result{Requeue: true}, err
 		}
+	} else {
+		repository = sourcev1.HelmRepositoryProgressing(repository)
+		if err := r.Status().Update(ctx, &repository); err != nil {
+			log.Error(err, "unable to update HelmRepository status")
+			return ctrl.Result{Requeue: true}, err
+		}
 	}
 
 	// try to remove old artifacts

--- a/docs/spec/v1alpha1/common.md
+++ b/docs/spec/v1alpha1/common.md
@@ -138,6 +138,10 @@ const (
 	// VerificationFailedReason represents the fact that the cryptographic provenance
 	// verification for the source failed.
 	VerificationFailedReason string = "VerificationFailed"
+
+	// ProgressingReason represents the fact that a source reconciliation
+	// is underway.
+	ProgressingReason string = "Progressing"
 )
 ```
 


### PR DESCRIPTION
Set ready condition to unknown while the reconciliation is progressing.
This allows other operators to wait for a sync to complete, e.g.:

```
kubectl annotate --overwrite gitrepository/podinfo source.fluxcd.io/syncAt="$(date +%s)" && \
kubectl wait gitrepository/podinfo --for=condition=ready --timeout=1m
```