### PR TITLE
git: add archive integrity check

### DIFF
--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -341,8 +341,8 @@ func (r *GitRepositoryReconciler) sync(ctx context.Context, repository sourcev1.
 	}
 	defer unlock()
 
-	// archive artifact
-	err = r.Storage.Archive(artifact, tmpGit, "")
+	// archive artifact and check integrity
+	err = r.Storage.Archive(artifact, tmpGit, "", true)
 	if err != nil {
 		err = fmt.Errorf("storage archive error: %w", err)
 		return sourcev1.GitRepositoryNotReady(repository, sourcev1.StorageOperationFailedReason, err.Error()), err


### PR DESCRIPTION
While running tests with kustomize controller I noticed that the tar.gz can get corrupted. This PR adds an integrity check for the artifact archive, so that an invalid artifact will be refetched if the tar.gz is corrupted.