### PR TITLE
git: fix revision for git tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o source-c
 
 FROM alpine:3.11
 
-RUN apk add --no-cache openssh-client ca-certificates tini 'git>=2.12.0' socat curl bash
+RUN apk add --no-cache openssh-client ca-certificates tar tini 'git>=2.12.0' socat curl bash
 
 COPY --from=builder /workspace/source-controller /usr/local/bin/
 

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -321,6 +321,9 @@ func (r *GitRepositoryReconciler) sync(ctx context.Context, repository sourcev1.
 
 	if revision == "" {
 		revision = fmt.Sprintf("%s/%s", branch, ref.Hash().String())
+		if repository.Spec.Reference.Tag != "" {
+			revision = fmt.Sprintf("%s/%s", repository.Spec.Reference.Tag, ref.Hash().String())
+		}
 	}
 
 	artifact := r.Storage.ArtifactFor(repository.Kind, repository.ObjectMeta.GetObjectMeta(),


### PR DESCRIPTION
The revision contains the branch instead of the git tag, this PR fixes this bug.