### PR TITLE
controllers: check GitRepository reference != nil

### DIFF
--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -321,7 +321,7 @@ func (r *GitRepositoryReconciler) sync(ctx context.Context, repository sourcev1.
 
 	if revision == "" {
 		revision = fmt.Sprintf("%s/%s", branch, ref.Hash().String())
-		if repository.Spec.Reference.Tag != "" {
+		if repository.Spec.Reference != nil && repository.Spec.Reference.Tag != "" {
 			revision = fmt.Sprintf("%s/%s", repository.Spec.Reference.Tag, ref.Hash().String())
 		}
 	}


### PR DESCRIPTION
To prevent the reconciler from panicing when no reference is configured for the GitRepository.