### PR TITLE
Reconcile sources in the runtime namespace only

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,17 +51,17 @@ jobs:
           KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin
       - name: Run smoke tests
         run: |
-          kubectl apply -f ./config/samples
+          kubectl -n source-system apply -f ./config/samples
           kubectl -n source-system rollout status deploy/source-controller --timeout=1m
-          kubectl wait gitrepository/gitrepository-sample --for=condition=ready --timeout=1m
-          kubectl wait helmrepository/helmrepository-sample --for=condition=ready --timeout=1m
-          kubectl wait helmchart/helmchart-sample --for=condition=ready --timeout=1m
+          kubectl -n source-system wait gitrepository/gitrepository-sample --for=condition=ready --timeout=1m
+          kubectl -n source-system wait helmrepository/helmrepository-sample --for=condition=ready --timeout=1m
+          kubectl -n source-system wait helmchart/helmchart-sample --for=condition=ready --timeout=1m
           kubectl -n source-system logs deploy/source-controller
       - name: Debug failure
         if: failure()
         run: |
-          kubectl get gitrepositories -oyaml
-          kubectl get helmrepositories -oyaml
-          kubectl get helmcharts -oyaml
+          kubectl -n source-system get gitrepositories -oyaml
+          kubectl -n source-system get helmrepositories -oyaml
+          kubectl -n source-system get helmcharts -oyaml
           kubectl -n source-system get all
           kubectl -n source-system logs deploy/source-controller

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ func main() {
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "305740c0.fluxcd.io",
+		Namespace:          os.Getenv("RUNTIME_NAMESPACE"),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Make the controller watch for resources only in the namespace where it's running if the env var `RUNTIME_NAMESPACE` is present.