### PR TITLE
Add ignore field to GitRepository spec

### DIFF
--- a/api/v1alpha1/gitrepository_types.go
+++ b/api/v1alpha1/gitrepository_types.go
@@ -55,12 +55,12 @@ type GitRepositorySpec struct {
 	// +optional
 	Verification *GitRepositoryVerification `json:"verify,omitempty"`
 
-	// SourceIgnore overrides the set of excluded patterns in the .sourceignore
+	// Ignore overrides the set of excluded patterns in the .sourceignore
 	// format (which is the same as .gitignore). If not provided, a default will
 	// be used, consult the documentation for your version to find out what those
 	// are.
 	// +optional
-	SourceIgnore *string `json:"sourceIgnore,omitempty"`
+	Ignore *string `json:"ignore,omitempty"`
 }
 
 // GitRepositoryRef defines the git ref used for pull and checkout operations.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -140,8 +140,8 @@ func (in *GitRepositorySpec) DeepCopyInto(out *GitRepositorySpec) {
 		*out = new(GitRepositoryVerification)
 		**out = **in
 	}
-	if in.SourceIgnore != nil {
-		in, out := &in.SourceIgnore, &out.SourceIgnore
+	if in.Ignore != nil {
+		in, out := &in.Ignore, &out.Ignore
 		*out = new(string)
 		**out = **in
 	}

--- a/config/crd/bases/source.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.fluxcd.io_gitrepositories.yaml
@@ -49,6 +49,12 @@ spec:
         spec:
           description: GitRepositorySpec defines the desired state of a Git repository.
           properties:
+            ignore:
+              description: Ignore overrides the set of excluded patterns in the .sourceignore
+                format (which is the same as .gitignore). If not provided, a default
+                will be used, consult the documentation for your version to find out
+                what those are.
+              type: string
             interval:
               description: The interval at which to check for repository updates.
               type: string
@@ -82,12 +88,6 @@ spec:
                     TODO: Add other useful fields. apiVersion, kind, uid?'
                   type: string
               type: object
-            sourceIgnore:
-              description: SourceIgnore overrides the set of excluded patterns in
-                the .sourceignore format (which is the same as .gitignore). If not
-                provided, a default will be used, consult the documentation for your
-                version to find out what those are.
-              type: string
             timeout:
               description: The timeout for remote git operations like cloning, default
                 to 20s.

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -268,7 +268,7 @@ func loadExcludePatterns(dir string, spec sourcev1.GitRepositorySpec) ([]gitigno
 		ps = append(ps, gitignore.ParsePattern(p, path))
 	}
 
-	if spec.SourceIgnore == nil {
+	if spec.Ignore == nil {
 		for _, p := range strings.Split(excludeExt, ",") {
 			ps = append(ps, gitignore.ParsePattern(p, path))
 		}
@@ -280,7 +280,7 @@ func loadExcludePatterns(dir string, spec sourcev1.GitRepositorySpec) ([]gitigno
 			return nil, err
 		}
 	} else {
-		ps = append(ps, getPatterns(bytes.NewBufferString(*spec.SourceIgnore), path)...)
+		ps = append(ps, getPatterns(bytes.NewBufferString(*spec.Ignore), path)...)
 	}
 
 	return ps, nil

--- a/controllers/storage_test.go
+++ b/controllers/storage_test.go
@@ -230,7 +230,7 @@ func TestArchiveIgnore(t *testing.T) {
 	}
 
 	t.Run("only vcs ignored files", func(t *testing.T) {
-		testPatterns(t, createArchive(t, filenames, "", sourcev1.GitRepositorySpec{SourceIgnore: stringPtr("")}), table)
+		testPatterns(t, createArchive(t, filenames, "", sourcev1.GitRepositorySpec{Ignore: stringPtr("")}), table)
 	})
 
 	filenames = append(filenames, "test.txt")
@@ -238,7 +238,7 @@ func TestArchiveIgnore(t *testing.T) {
 	sourceIgnoreFile := "*.txt"
 
 	t.Run("sourceignore injected via CRD", func(t *testing.T) {
-		testPatterns(t, createArchive(t, filenames, "", sourcev1.GitRepositorySpec{SourceIgnore: stringPtr(sourceIgnoreFile)}), table)
+		testPatterns(t, createArchive(t, filenames, "", sourcev1.GitRepositorySpec{Ignore: stringPtr(sourceIgnoreFile)}), table)
 	})
 
 	table = ignoreMap{}

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -159,14 +159,14 @@ GitRepositoryVerification
 </tr>
 <tr>
 <td>
-<code>sourceIgnore</code><br>
+<code>ignore</code><br>
 <em>
 string
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>SourceIgnore overrides the set of excluded patterns in the .sourceignore
+<p>Ignore overrides the set of excluded patterns in the .sourceignore
 format (which is the same as .gitignore). If not provided, a default will
 be used, consult the documentation for your version to find out what those
 are.</p>
@@ -683,14 +683,14 @@ GitRepositoryVerification
 </tr>
 <tr>
 <td>
-<code>sourceIgnore</code><br>
+<code>ignore</code><br>
 <em>
 string
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>SourceIgnore overrides the set of excluded patterns in the .sourceignore
+<p>Ignore overrides the set of excluded patterns in the .sourceignore
 format (which is the same as .gitignore). If not provided, a default will
 be used, consult the documentation for your version to find out what those
 are.</p>

--- a/docs/spec/v1alpha1/gitrepositories.md
+++ b/docs/spec/v1alpha1/gitrepositories.md
@@ -39,6 +39,14 @@ type GitRepositorySpec struct {
 	// Verify OpenPGP signature for the commit that HEAD points to.
 	// +optional
 	Verification *GitRepositoryVerification `json:"verify,omitempty"`
+
+	// Ignore overrides the set of excluded patterns in the .sourceignore
+	// format (which is the same as .gitignore). If not provided, a default will
+	// be used, consult the documentation for your version to find out what those
+	// are.
+	// +optional
+	Ignore *string `json:"ignore,omitempty"`
+
 }
 ```
 
@@ -130,6 +138,28 @@ follows [the `.gitignore` pattern
 format](https://git-scm.com/docs/gitignore#_pattern_format), pattern
 entries may overrule default exclusions.
 
+Another option is to use the `spec.ignore` field, for example:
+
+```yaml
+apiVersion: source.fluxcd.io/v1alpha1
+kind: GitRepository
+metadata:
+  name: podinfo
+spec:
+  interval: 5m
+  url: https://github.com/stefanprodan/podinfo
+  ignore: |
+    # exclude all
+    /*
+    # include deploy dir
+    !/deploy
+    # exclude file extensions from deploy dir
+    /deploy/**/*.md
+    /deploy/**/*.txt
+```
+
+When specified, `spec.ignore` overrides the default exclusion list.
+
 ## Spec examples
 
 Pull the master branch of a public repository every minute:
@@ -139,7 +169,6 @@ apiVersion: source.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
-  namespace: default
 spec:
   interval: 1m
   url: https://github.com/stefanprodan/podinfo
@@ -152,7 +181,6 @@ apiVersion: source.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
-  namespace: default
 spec:
   interval: 1m
   url: https://github.com/stefanprodan/podinfo
@@ -167,7 +195,6 @@ apiVersion: source.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
-  namespace: default
 spec:
   interval: 1m
   url: https://github.com/stefanprodan/podinfo
@@ -183,7 +210,6 @@ apiVersion: source.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
-  namespace: default
 spec:
   interval: 1m
   url: https://github.com/stefanprodan/podinfo
@@ -198,7 +224,6 @@ apiVersion: source.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
-  namespace: default
 spec:
   interval: 1m
   url: https://github.com/stefanprodan/podinfo
@@ -213,7 +238,6 @@ apiVersion: source.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
-  namespace: default
 spec:
   url: https://github.com/stefanprodan/podinfo
   secretRef:
@@ -237,7 +261,6 @@ apiVersion: source.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
-  namespace: default
 spec:
   url: ssh://git@github.com/stefanprodan/podinfo
   secretRef:
@@ -277,7 +300,6 @@ apiVersion: source.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
-  namespace: default
 spec:
   interval: 1m
   url: https://github.com/stefanprodan/podinfo


### PR DESCRIPTION
Changes:
- rename the GitRepository field from `SourceIgnore` to `Ignore`
- add the ignore filed to API docs and provide an example