### PR TITLE
Setup production logging

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         args:
           - --enable-leader-election
           - --storage-path=/data
+          - --log-level=debug
           - --log-json
         env:
           - name: RUNTIME_NAMESPACE

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/sosedoff/gitkit v0.2.1-0.20191202022816-7182d43c6254
+	go.uber.org/zap v1.10.0
 	helm.sh/helm/v3 v3.2.4
 	k8s.io/api v0.18.4
 	k8s.io/apimachinery v0.18.4


### PR DESCRIPTION
For production the log format is JSON, the timestamps format is ISO8601
and stack traces are logged when the level is set to debug.