### PR TITLE
Storage: fix a small bug in RemoveAllButCurrent when the directory is invalid

### DIFF
--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -100,6 +100,11 @@ func (s *Storage) RemoveAllButCurrent(artifact sourcev1.Artifact) error {
 	dir := filepath.Dir(artifact.Path)
 	var errors []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			errors = append(errors, err.Error())
+			return nil
+		}
+
 		if path != artifact.Path && !info.IsDir() && info.Mode()&os.ModeSymlink != os.ModeSymlink {
 			if err := os.Remove(path); err != nil {
 				errors = append(errors, info.Name())


### PR DESCRIPTION
filepath.Walk can return a `nil` for the stat value, when it does, the
directory is invalid and the error will be set. This causes a
panic+crash if the directory does not currently exist when
RemoveAllButCurrent is called.

The following patch makes the behavior an error instead.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>