### PR TITLE
Helm: allow configuration of TLS certs without CA

### DIFF
--- a/controllers/helmrepository_controller_test.go
+++ b/controllers/helmrepository_controller_test.go
@@ -310,7 +310,6 @@ var _ = Describe("HelmRepositoryReconciler", func() {
 
 			By("Expecting missing field error")
 			secret.Data["certFile"] = examplePublicKey
-			secret.Data["keyFile"] = examplePrivateKey
 			Expect(k8sClient.Update(context.Background(), secret)).Should(Succeed())
 			Eventually(func() bool {
 				got := &sourcev1.HelmRepository{}
@@ -324,6 +323,7 @@ var _ = Describe("HelmRepositoryReconciler", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By("Expecting artifact")
+			secret.Data["keyFile"] = examplePrivateKey
 			secret.Data["caFile"] = exampleCA
 			Expect(k8sClient.Update(context.Background(), secret)).Should(Succeed())
 			Eventually(func() bool {

--- a/internal/helm/getter_test.go
+++ b/internal/helm/getter_test.go
@@ -114,7 +114,7 @@ func TestTLSClientConfigFromSecret(t *testing.T) {
 		{"certFile, keyFile and caFile", tlsSecretFixture, nil, false, false},
 		{"without certFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "certFile") }, true, true},
 		{"without keyFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "keyFile") }, true, true},
-		{"without caFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "caFile") }, true, true},
+		{"without caFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "caFile") }, false, false},
 		{"empty", corev1.Secret{}, nil, false, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
As they (may) not have a close relationship, and configuring the certificates without providing a CA is a valid configuration option.