### PR TITLE
Change CRD domain to 'source.toolkit.fluxcd.io'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,6 @@ and `HelmRepositoryReconciler`.
 
 This is the first alpha release of source controller.
 The controller is an implementation of the
-[source.fluxcd.io/v1alpha1](https://github.com/fluxcd/source-controller/tree/master/docs/spec/v1alpha1) API
+[source.fluxcd.io/v1alpha1](https://github.com/fluxcd/source-controller/tree/v0.0.1-alpha.1/docs/spec/v1alpha1) API
 based on the specifications described in the
-[Source Controller Proposal](https://github.com/fluxcd/source-controller/tree/master/docs/spec). 
+[Source Controller Proposal](https://github.com/fluxcd/source-controller/tree/v0.0.1-alpha.1/docs/spec). 

--- a/PROJECT
+++ b/PROJECT
@@ -1,4 +1,4 @@
-domain: fluxcd.io
+domain: toolkit.fluxcd.io
 repo: github.com/fluxcd/source-controller
 resources:
 - group: source

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 The source-controller is a Kubernetes operator, specialised in artifacts acquisition
 from external sources such as Git and Helm repositories.
 The source-controller implements the
-[source.fluxcd.io](https://github.com/fluxcd/source-controller/tree/master/docs/spec/v1alpha1) API
+[source.toolkit.fluxcd.io](https://github.com/fluxcd/source-controller/tree/master/docs/spec/v1alpha1) API
 and is a core component of the [GitOps toolkit](https://toolkit.fluxcd.io).
 
 ![overview](docs/diagrams/source-controller-overview.png)

--- a/api/v1alpha1/doc.go
+++ b/api/v1alpha1/doc.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the source v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=source.fluxcd.io
+// +groupName=source.toolkit.fluxcd.io
 package v1alpha1

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "source.fluxcd.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "source.toolkit.fluxcd.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -6,14 +6,14 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
-  name: helmrepositories.source.fluxcd.io
+  name: gitrepositories.source.toolkit.fluxcd.io
 spec:
-  group: source.fluxcd.io
+  group: source.toolkit.fluxcd.io
   names:
-    kind: HelmRepository
-    listKind: HelmRepositoryList
-    plural: helmrepositories
-    singular: helmrepository
+    kind: GitRepository
+    listKind: GitRepositoryList
+    plural: gitrepositories
+    singular: gitrepository
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -32,7 +32,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: HelmRepository is the Schema for the helmrepositories API
+        description: GitRepository is the Schema for the gitrepositories API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -47,32 +47,83 @@ spec:
           metadata:
             type: object
           spec:
-            description: HelmRepositorySpec defines the reference to a Helm repository.
+            description: GitRepositorySpec defines the desired state of a Git repository.
             properties:
-              interval:
-                description: The interval at which to check the upstream for updates.
+              ignore:
+                description: Ignore overrides the set of excluded patterns in the
+                  .sourceignore format (which is the same as .gitignore). If not provided,
+                  a default will be used, consult the documentation for your version
+                  to find out what those are.
                 type: string
+              interval:
+                description: The interval at which to check for repository updates.
+                type: string
+              ref:
+                description: The git reference to checkout and monitor for changes,
+                  defaults to master branch.
+                properties:
+                  branch:
+                    description: The git branch to checkout, defaults to master.
+                    type: string
+                  commit:
+                    description: The git commit sha to checkout, if specified tag
+                      filters will be ignored.
+                    type: string
+                  semver:
+                    description: The git tag semver expression, takes precedence over
+                      tag.
+                    type: string
+                  tag:
+                    description: The git tag to checkout, takes precedence over branch.
+                    type: string
+                type: object
               secretRef:
-                description: The name of the secret containing authentication credentials
-                  for the Helm repository. For HTTP/S basic auth the secret must contain
-                  username and password fields. For TLS the secret must contain caFile,
-                  keyFile and caCert fields.
+                description: The secret name containing the Git credentials. For HTTPS
+                  repositories the secret must contain username and password fields.
+                  For SSH repositories the secret must contain identity, identity.pub
+                  and known_hosts fields.
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-              url:
-                description: The Helm repository URL, a valid URL contains at least
-                  a protocol and host.
+              timeout:
+                description: The timeout for remote git operations like cloning, default
+                  to 20s.
                 type: string
+              url:
+                description: The repository URL, can be a HTTP or SSH address.
+                pattern: ^(http|https|ssh)://
+                type: string
+              verify:
+                description: Verify OpenPGP signature for the commit that HEAD points
+                  to.
+                properties:
+                  mode:
+                    description: Mode describes what git object should be verified,
+                      currently ('head').
+                    enum:
+                    - head
+                    type: string
+                  secretRef:
+                    description: The secret name containing the public keys of all
+                      trusted git authors.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                required:
+                - mode
+                type: object
             required:
             - interval
             - url
             type: object
           status:
-            description: HelmRepositoryStatus defines the observed state of the HelmRepository.
+            description: GitRepositoryStatus defines the observed state of a Git repository.
             properties:
               artifact:
                 description: Artifact represents the output of the last successful
@@ -129,7 +180,8 @@ spec:
                   type: object
                 type: array
               url:
-                description: URL is the download link for the last index fetched.
+                description: URL is the download link for the artifact output of the
+                  last repository sync.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -6,19 +6,25 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
-  name: gitrepositories.source.fluxcd.io
+  name: helmcharts.source.toolkit.fluxcd.io
 spec:
-  group: source.fluxcd.io
+  group: source.toolkit.fluxcd.io
   names:
-    kind: GitRepository
-    listKind: GitRepositoryList
-    plural: gitrepositories
-    singular: gitrepository
+    kind: HelmChart
+    listKind: HelmChartList
+    plural: helmcharts
+    singular: helmchart
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.url
-      name: URL
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.helmRepositoryRef.name
+      name: Repository
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
@@ -32,7 +38,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: GitRepository is the Schema for the gitrepositories API
+        description: HelmChart is the Schema for the helmcharts API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -47,87 +53,40 @@ spec:
           metadata:
             type: object
           spec:
-            description: GitRepositorySpec defines the desired state of a Git repository.
+            description: HelmChartSpec defines the desired state of a Helm chart.
             properties:
-              ignore:
-                description: Ignore overrides the set of excluded patterns in the
-                  .sourceignore format (which is the same as .gitignore). If not provided,
-                  a default will be used, consult the documentation for your version
-                  to find out what those are.
-                type: string
-              interval:
-                description: The interval at which to check for repository updates.
-                type: string
-              ref:
-                description: The git reference to checkout and monitor for changes,
-                  defaults to master branch.
-                properties:
-                  branch:
-                    description: The git branch to checkout, defaults to master.
-                    type: string
-                  commit:
-                    description: The git commit sha to checkout, if specified tag
-                      filters will be ignored.
-                    type: string
-                  semver:
-                    description: The git tag semver expression, takes precedence over
-                      tag.
-                    type: string
-                  tag:
-                    description: The git tag to checkout, takes precedence over branch.
-                    type: string
-                type: object
-              secretRef:
-                description: The secret name containing the Git credentials. For HTTPS
-                  repositories the secret must contain username and password fields.
-                  For SSH repositories the secret must contain identity, identity.pub
-                  and known_hosts fields.
+              helmRepositoryRef:
+                description: The name of the HelmRepository the chart is available
+                  at.
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-              timeout:
-                description: The timeout for remote git operations like cloning, default
-                  to 20s.
+              interval:
+                description: The interval at which to check the Helm repository for
+                  updates.
                 type: string
-              url:
-                description: The repository URL, can be a HTTP or SSH address.
-                pattern: ^(http|https|ssh)://
+              name:
+                description: The name of the Helm chart, as made available by the
+                  referenced Helm repository.
                 type: string
-              verify:
-                description: Verify OpenPGP signature for the commit that HEAD points
-                  to.
-                properties:
-                  mode:
-                    description: Mode describes what git object should be verified,
-                      currently ('head').
-                    enum:
-                    - head
-                    type: string
-                  secretRef:
-                    description: The secret name containing the public keys of all
-                      trusted git authors.
-                    properties:
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                    type: object
-                required:
-                - mode
-                type: object
+              version:
+                description: The chart version semver expression, defaults to latest
+                  when omitted.
+                type: string
             required:
+            - helmRepositoryRef
             - interval
-            - url
+            - name
             type: object
           status:
-            description: GitRepositoryStatus defines the observed state of a Git repository.
+            description: HelmChartStatus defines the observed state of the HelmChart.
             properties:
               artifact:
                 description: Artifact represents the output of the last successful
-                  repository sync.
+                  chart sync.
                 properties:
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to
@@ -180,8 +139,7 @@ spec:
                   type: object
                 type: array
               url:
-                description: URL is the download link for the artifact output of the
-                  last repository sync.
+                description: URL is the download link for the last chart pulled.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -6,25 +6,19 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
-  name: helmcharts.source.fluxcd.io
+  name: helmrepositories.source.toolkit.fluxcd.io
 spec:
-  group: source.fluxcd.io
+  group: source.toolkit.fluxcd.io
   names:
-    kind: HelmChart
-    listKind: HelmChartList
-    plural: helmcharts
-    singular: helmchart
+    kind: HelmRepository
+    listKind: HelmRepositoryList
+    plural: helmrepositories
+    singular: helmrepository
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.name
-      name: Name
-      type: string
-    - jsonPath: .spec.version
-      name: Version
-      type: string
-    - jsonPath: .spec.helmRepositoryRef.name
-      name: Repository
+    - jsonPath: .spec.url
+      name: URL
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
@@ -38,7 +32,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: HelmChart is the Schema for the helmcharts API
+        description: HelmRepository is the Schema for the helmrepositories API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -53,40 +47,36 @@ spec:
           metadata:
             type: object
           spec:
-            description: HelmChartSpec defines the desired state of a Helm chart.
+            description: HelmRepositorySpec defines the reference to a Helm repository.
             properties:
-              helmRepositoryRef:
-                description: The name of the HelmRepository the chart is available
-                  at.
+              interval:
+                description: The interval at which to check the upstream for updates.
+                type: string
+              secretRef:
+                description: The name of the secret containing authentication credentials
+                  for the Helm repository. For HTTP/S basic auth the secret must contain
+                  username and password fields. For TLS the secret must contain caFile,
+                  keyFile and caCert fields.
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-              interval:
-                description: The interval at which to check the Helm repository for
-                  updates.
-                type: string
-              name:
-                description: The name of the Helm chart, as made available by the
-                  referenced Helm repository.
-                type: string
-              version:
-                description: The chart version semver expression, defaults to latest
-                  when omitted.
+              url:
+                description: The Helm repository URL, a valid URL contains at least
+                  a protocol and host.
                 type: string
             required:
-            - helmRepositoryRef
             - interval
-            - name
+            - url
             type: object
           status:
-            description: HelmChartStatus defines the observed state of the HelmChart.
+            description: HelmRepositoryStatus defines the observed state of the HelmRepository.
             properties:
               artifact:
                 description: Artifact represents the output of the last successful
-                  chart sync.
+                  repository sync.
                 properties:
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to
@@ -139,7 +129,7 @@ spec:
                   type: object
                 type: array
               url:
-                description: URL is the download link for the last chart pulled.
+                description: URL is the download link for the last index fetched.
                 type: string
             type: object
         type: object

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- bases/source.fluxcd.io_gitrepositories.yaml
-- bases/source.fluxcd.io_helmrepositories.yaml
-- bases/source.fluxcd.io_helmcharts.yaml
+- bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+- bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+- bases/source.toolkit.fluxcd.io_helmcharts.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
-

--- a/config/rbac/gitrepository_editor_role.yaml
+++ b/config/rbac/gitrepository_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gitrepository-editor-role
 rules:
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - gitrepositories
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - gitrepositories/status
   verbs:

--- a/config/rbac/gitrepository_viewer_role.yaml
+++ b/config/rbac/gitrepository_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gitrepository-viewer-role
 rules:
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - gitrepositories
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - gitrepositories/status
   verbs:

--- a/config/rbac/helmchart_editor_role.yaml
+++ b/config/rbac/helmchart_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: helmchart-editor-role
 rules:
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmcharts
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmcharts/status
   verbs:

--- a/config/rbac/helmchart_viewer_role.yaml
+++ b/config/rbac/helmchart_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: helmchart-viewer-role
 rules:
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmcharts
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmcharts/status
   verbs:

--- a/config/rbac/helmrepository_editor_role.yaml
+++ b/config/rbac/helmrepository_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: helmrepository-editor-role
 rules:
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmrepositories
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmrepositories/status
   verbs:

--- a/config/rbac/helmrepository_viewer_role.yaml
+++ b/config/rbac/helmrepository_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: helmrepository-viewer-role
 rules:
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmrepositories
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmrepositories/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - gitrepositories
   verbs:
@@ -19,7 +19,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - gitrepositories/status
   verbs:
@@ -27,7 +27,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmcharts
   verbs:
@@ -39,7 +39,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmcharts/finalizers
   verbs:
@@ -47,7 +47,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmcharts/status
   verbs:
@@ -55,7 +55,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmrepositories
   verbs:
@@ -67,7 +67,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - helmrepositories/status
   verbs:

--- a/config/samples/source_v1alpha1_gitrepository.yaml
+++ b/config/samples/source_v1alpha1_gitrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: gitrepository-sample

--- a/config/samples/source_v1alpha1_helmchart.yaml
+++ b/config/samples/source_v1alpha1_helmchart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: HelmChart
 metadata:
   name: helmchart-sample

--- a/config/samples/source_v1alpha1_helmrepository.yaml
+++ b/config/samples/source_v1alpha1_helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: HelmRepository
 metadata:
   name: helmrepository-sample

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -53,8 +53,8 @@ type GitRepositoryReconciler struct {
 	ExternalEventRecorder *recorder.EventRecorder
 }
 
-// +kubebuilder:rbac:groups=source.fluxcd.io,resources=gitrepositories,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=source.fluxcd.io,resources=gitrepositories/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=gitrepositories,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=gitrepositories/status,verbs=get;update;patch
 
 func (r *GitRepositoryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -54,8 +54,8 @@ type HelmChartReconciler struct {
 	ExternalEventRecorder *recorder.EventRecorder
 }
 
-// +kubebuilder:rbac:groups=source.fluxcd.io,resources=helmcharts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=source.fluxcd.io,resources=helmcharts/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmcharts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmcharts/status,verbs=get;update;patch
 
 func (r *HelmChartReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -55,9 +55,9 @@ type HelmRepositoryReconciler struct {
 	ExternalEventRecorder *recorder.EventRecorder
 }
 
-// +kubebuilder:rbac:groups=source.fluxcd.io,resources=helmrepositories,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=source.fluxcd.io,resources=helmrepositories/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=source.fluxcd.io,resources=helmcharts/finalizers,verbs=get;update;patch
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmrepositories,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmrepositories/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmcharts/finalizers,verbs=get;update;patch
 
 func (r *HelmRepositoryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -2,20 +2,20 @@
 <p>Packages:</p>
 <ul class="simple">
 <li>
-<a href="#source.fluxcd.io%2fv1alpha1">source.fluxcd.io/v1alpha1</a>
+<a href="#source.toolkit.fluxcd.io%2fv1alpha1">source.toolkit.fluxcd.io/v1alpha1</a>
 </li>
 </ul>
-<h2 id="source.fluxcd.io/v1alpha1">source.fluxcd.io/v1alpha1</h2>
+<h2 id="source.toolkit.fluxcd.io/v1alpha1">source.toolkit.fluxcd.io/v1alpha1</h2>
 <p>Package v1alpha1 contains API Schema definitions for the source v1alpha1 API group</p>
 Resource Types:
 <ul class="simple"><li>
-<a href="#source.fluxcd.io/v1alpha1.GitRepository">GitRepository</a>
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepository">GitRepository</a>
 </li><li>
-<a href="#source.fluxcd.io/v1alpha1.HelmChart">HelmChart</a>
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmChart">HelmChart</a>
 </li><li>
-<a href="#source.fluxcd.io/v1alpha1.HelmRepository">HelmRepository</a>
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmRepository">HelmRepository</a>
 </li></ul>
-<h3 id="source.fluxcd.io/v1alpha1.GitRepository">GitRepository
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.GitRepository">GitRepository
 </h3>
 <p>GitRepository is the Schema for the gitrepositories API</p>
 <div class="md-typeset__scrollwrap">
@@ -33,7 +33,7 @@ Resource Types:
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>source.fluxcd.io/v1alpha1</code>
+<code>source.toolkit.fluxcd.io/v1alpha1</code>
 </td>
 </tr>
 <tr>
@@ -63,7 +63,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepositorySpec">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepositorySpec">
 GitRepositorySpec
 </a>
 </em>
@@ -132,7 +132,7 @@ Kubernetes meta/v1.Duration
 <td>
 <code>ref</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepositoryRef">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepositoryRef">
 GitRepositoryRef
 </a>
 </em>
@@ -147,7 +147,7 @@ master branch.</p>
 <td>
 <code>verify</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepositoryVerification">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepositoryVerification">
 GitRepositoryVerification
 </a>
 </em>
@@ -179,7 +179,7 @@ are.</p>
 <td>
 <code>status</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepositoryStatus">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepositoryStatus">
 GitRepositoryStatus
 </a>
 </em>
@@ -191,7 +191,7 @@ GitRepositoryStatus
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.HelmChart">HelmChart
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.HelmChart">HelmChart
 </h3>
 <p>HelmChart is the Schema for the helmcharts API</p>
 <div class="md-typeset__scrollwrap">
@@ -209,7 +209,7 @@ GitRepositoryStatus
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>source.fluxcd.io/v1alpha1</code>
+<code>source.toolkit.fluxcd.io/v1alpha1</code>
 </td>
 </tr>
 <tr>
@@ -239,7 +239,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.HelmChartSpec">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmChartSpec">
 HelmChartSpec
 </a>
 </em>
@@ -306,7 +306,7 @@ Kubernetes meta/v1.Duration
 <td>
 <code>status</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.HelmChartStatus">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmChartStatus">
 HelmChartStatus
 </a>
 </em>
@@ -318,7 +318,7 @@ HelmChartStatus
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.HelmRepository">HelmRepository
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.HelmRepository">HelmRepository
 </h3>
 <p>HelmRepository is the Schema for the helmrepositories API</p>
 <div class="md-typeset__scrollwrap">
@@ -336,7 +336,7 @@ HelmChartStatus
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>source.fluxcd.io/v1alpha1</code>
+<code>source.toolkit.fluxcd.io/v1alpha1</code>
 </td>
 </tr>
 <tr>
@@ -366,7 +366,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.HelmRepositorySpec">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmRepositorySpec">
 HelmRepositorySpec
 </a>
 </em>
@@ -425,7 +425,7 @@ Kubernetes meta/v1.Duration
 <td>
 <code>status</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.HelmRepositoryStatus">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmRepositoryStatus">
 HelmRepositoryStatus
 </a>
 </em>
@@ -437,13 +437,13 @@ HelmRepositoryStatus
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.Artifact">Artifact
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.Artifact">Artifact
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepositoryStatus">GitRepositoryStatus</a>, 
-<a href="#source.fluxcd.io/v1alpha1.HelmChartStatus">HelmChartStatus</a>, 
-<a href="#source.fluxcd.io/v1alpha1.HelmRepositoryStatus">HelmRepositoryStatus</a>)
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepositoryStatus">GitRepositoryStatus</a>, 
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmChartStatus">HelmChartStatus</a>, 
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmRepositoryStatus">HelmRepositoryStatus</a>)
 </p>
 <p>Artifact represents the output of a source synchronisation</p>
 <div class="md-typeset__scrollwrap">
@@ -510,11 +510,11 @@ update of this artifact.</p>
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.GitRepositoryRef">GitRepositoryRef
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.GitRepositoryRef">GitRepositoryRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepositorySpec">GitRepositorySpec</a>)
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepositorySpec">GitRepositorySpec</a>)
 </p>
 <p>GitRepositoryRef defines the git ref used for pull and checkout operations.</p>
 <div class="md-typeset__scrollwrap">
@@ -579,11 +579,11 @@ string
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.GitRepositorySpec">GitRepositorySpec
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.GitRepositorySpec">GitRepositorySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepository">GitRepository</a>)
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepository">GitRepository</a>)
 </p>
 <p>GitRepositorySpec defines the desired state of a Git repository.</p>
 <div class="md-typeset__scrollwrap">
@@ -656,7 +656,7 @@ Kubernetes meta/v1.Duration
 <td>
 <code>ref</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepositoryRef">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepositoryRef">
 GitRepositoryRef
 </a>
 </em>
@@ -671,7 +671,7 @@ master branch.</p>
 <td>
 <code>verify</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepositoryVerification">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepositoryVerification">
 GitRepositoryVerification
 </a>
 </em>
@@ -700,11 +700,11 @@ are.</p>
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.GitRepositoryStatus">GitRepositoryStatus
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.GitRepositoryStatus">GitRepositoryStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepository">GitRepository</a>)
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepository">GitRepository</a>)
 </p>
 <p>GitRepositoryStatus defines the observed state of a Git repository.</p>
 <div class="md-typeset__scrollwrap">
@@ -721,7 +721,7 @@ are.</p>
 <td>
 <code>conditions</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.SourceCondition">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.SourceCondition">
 []SourceCondition
 </a>
 </em>
@@ -747,7 +747,7 @@ sync.</p>
 <td>
 <code>artifact</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.Artifact">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.Artifact">
 Artifact
 </a>
 </em>
@@ -761,11 +761,11 @@ Artifact
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.GitRepositoryVerification">GitRepositoryVerification
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.GitRepositoryVerification">GitRepositoryVerification
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepositorySpec">GitRepositorySpec</a>)
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepositorySpec">GitRepositorySpec</a>)
 </p>
 <p>GitRepositoryVerification defines the OpenPGP signature verification process.</p>
 <div class="md-typeset__scrollwrap">
@@ -806,11 +806,11 @@ Kubernetes core/v1.LocalObjectReference
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.HelmChartSpec">HelmChartSpec
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.HelmChartSpec">HelmChartSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.fluxcd.io/v1alpha1.HelmChart">HelmChart</a>)
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmChart">HelmChart</a>)
 </p>
 <p>HelmChartSpec defines the desired state of a Helm chart.</p>
 <div class="md-typeset__scrollwrap">
@@ -878,11 +878,11 @@ Kubernetes meta/v1.Duration
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.HelmChartStatus">HelmChartStatus
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.HelmChartStatus">HelmChartStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.fluxcd.io/v1alpha1.HelmChart">HelmChart</a>)
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmChart">HelmChart</a>)
 </p>
 <p>HelmChartStatus defines the observed state of the HelmChart.</p>
 <div class="md-typeset__scrollwrap">
@@ -899,7 +899,7 @@ Kubernetes meta/v1.Duration
 <td>
 <code>conditions</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.SourceCondition">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.SourceCondition">
 []SourceCondition
 </a>
 </em>
@@ -924,7 +924,7 @@ string
 <td>
 <code>artifact</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.Artifact">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.Artifact">
 Artifact
 </a>
 </em>
@@ -938,11 +938,11 @@ Artifact
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.HelmRepositorySpec">HelmRepositorySpec
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.HelmRepositorySpec">HelmRepositorySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.fluxcd.io/v1alpha1.HelmRepository">HelmRepository</a>)
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmRepository">HelmRepository</a>)
 </p>
 <p>HelmRepositorySpec defines the reference to a Helm repository.</p>
 <div class="md-typeset__scrollwrap">
@@ -1002,11 +1002,11 @@ Kubernetes meta/v1.Duration
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.HelmRepositoryStatus">HelmRepositoryStatus
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.HelmRepositoryStatus">HelmRepositoryStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.fluxcd.io/v1alpha1.HelmRepository">HelmRepository</a>)
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmRepository">HelmRepository</a>)
 </p>
 <p>HelmRepositoryStatus defines the observed state of the HelmRepository.</p>
 <div class="md-typeset__scrollwrap">
@@ -1023,7 +1023,7 @@ Kubernetes meta/v1.Duration
 <td>
 <code>conditions</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.SourceCondition">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.SourceCondition">
 []SourceCondition
 </a>
 </em>
@@ -1048,7 +1048,7 @@ string
 <td>
 <code>artifact</code><br>
 <em>
-<a href="#source.fluxcd.io/v1alpha1.Artifact">
+<a href="#source.toolkit.fluxcd.io/v1alpha1.Artifact">
 Artifact
 </a>
 </em>
@@ -1062,16 +1062,16 @@ Artifact
 </table>
 </div>
 </div>
-<h3 id="source.fluxcd.io/v1alpha1.Source">Source
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.Source">Source
 </h3>
 <p>Source interface must be supported by all API types.</p>
-<h3 id="source.fluxcd.io/v1alpha1.SourceCondition">SourceCondition
+<h3 id="source.toolkit.fluxcd.io/v1alpha1.SourceCondition">SourceCondition
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.fluxcd.io/v1alpha1.GitRepositoryStatus">GitRepositoryStatus</a>, 
-<a href="#source.fluxcd.io/v1alpha1.HelmChartStatus">HelmChartStatus</a>, 
-<a href="#source.fluxcd.io/v1alpha1.HelmRepositoryStatus">HelmRepositoryStatus</a>)
+<a href="#source.toolkit.fluxcd.io/v1alpha1.GitRepositoryStatus">GitRepositoryStatus</a>, 
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmChartStatus">HelmChartStatus</a>, 
+<a href="#source.toolkit.fluxcd.io/v1alpha1.HelmRepositoryStatus">HelmRepositoryStatus</a>)
 </p>
 <p>SourceCondition contains condition information for a source.</p>
 <div class="md-typeset__scrollwrap">

--- a/docs/spec/v1alpha1/README.md
+++ b/docs/spec/v1alpha1/README.md
@@ -1,4 +1,4 @@
-# source.fluxcd.io/v1alpha1
+# source.toolkit.fluxcd.io/v1alpha1
 
 This is the v1alpha1 API specification for defining the desired state sources of Kubernetes clusters.
 

--- a/docs/spec/v1alpha1/gitrepositories.md
+++ b/docs/spec/v1alpha1/gitrepositories.md
@@ -141,7 +141,7 @@ entries may overrule default exclusions.
 Another option is to use the `spec.ignore` field, for example:
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -165,7 +165,7 @@ When specified, `spec.ignore` overrides the default exclusion list.
 Pull the master branch of a public repository every minute:
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -177,7 +177,7 @@ spec:
 Pull a specific branch:
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -191,7 +191,7 @@ spec:
 Checkout a specific commit from a branch:
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -206,7 +206,7 @@ spec:
 Pull a specific tag:
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -220,7 +220,7 @@ spec:
 Pull tag based on a [semver range](https://github.com/blang/semver#ranges):
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -234,7 +234,7 @@ spec:
 HTTPS authentication (requires a secret with `username` and `password` fields):
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -257,7 +257,7 @@ data:
 SSH authentication (requires a secret with `identity` and `known_hosts` fields):
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -296,7 +296,7 @@ kubectl create secret generic ssh-credentials \
 Verify the OpenPGP signature for the commit that master branch HEAD points to:
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo

--- a/docs/spec/v1alpha1/helmcharts.md
+++ b/docs/spec/v1alpha1/helmcharts.md
@@ -69,7 +69,7 @@ const (
 Pull a specific chart version every five minutes:
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: HelmChart
 metadata:
   name: redis
@@ -84,7 +84,7 @@ spec:
 Pull the latest chart version that matches the sermver range every ten minutes:
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: HelmChart
 metadata:
   name: redis

--- a/docs/spec/v1alpha1/helmrepositories.md
+++ b/docs/spec/v1alpha1/helmrepositories.md
@@ -67,7 +67,7 @@ const (
 Pull the index of a public Helm repository every ten minutes:
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: HelmRepository
 metadata:
   name: stable
@@ -79,7 +79,7 @@ spec:
 Pull the index of a private Helm repository every minute:
 
 ```yaml
-apiVersion: source.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1alpha1
 kind: HelmRepository
 metadata:
   name: private


### PR DESCRIPTION
Ref: https://github.com/fluxcd/toolkit/issues/136

Due to required domain changes for the helm-controller so that it
can co-exist in a cluster with the Helm Operator, other Toolkit
components are moving to a *.toolklit.fluxcd.io domain too.