### PR TITLE
Drop single branch strategy for SemVer checkout

### DIFF
--- a/pkg/git/checkout.go
+++ b/pkg/git/checkout.go
@@ -173,7 +173,6 @@ func (c *CheckoutSemVer) Checkout(ctx context.Context, path, url string, auth tr
 		URL:               url,
 		Auth:              auth,
 		RemoteName:        defaultOrigin,
-		SingleBranch:      true,
 		NoCheckout:        false,
 		Depth:             1,
 		RecurseSubmodules: 0,


### PR DESCRIPTION
As this will result in a checkout failure when the default branch on the
remote is not `master`. Surfaced due to Contour switching from `master` to
`main` overnight.