### PR TITLE
Support proper semver ranges for Helm charts

### DIFF
--- a/config/samples/source_v1alpha1_helmchart.yaml
+++ b/config/samples/source_v1alpha1_helmchart.yaml
@@ -4,7 +4,7 @@ metadata:
   name: helmchart-sample
 spec:
   name: podinfo
-  version: '^2.0.0'
+  version: '>=2.0.0 <3.0.0'
   helmRepositoryRef:
     name: helmrepository-sample
   interval: 1m

--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -101,7 +101,7 @@ var _ = Describe("HelmChartReconciler", func() {
 				},
 				Spec: sourcev1.HelmChartSpec{
 					Name:              "helmchart",
-					Version:           "*",
+					Version:           "",
 					HelmRepositoryRef: corev1.LocalObjectReference{Name: repositoryKey.Name},
 					Interval:          metav1.Duration{Duration: pullInterval},
 				},
@@ -203,7 +203,6 @@ var _ = Describe("HelmChartReconciler", func() {
 				},
 				Spec: sourcev1.HelmChartSpec{
 					Name:              "helmchart",
-					Version:           "*",
 					HelmRepositoryRef: corev1.LocalObjectReference{Name: repositoryKey.Name},
 					Interval:          metav1.Duration{Duration: 1 * time.Hour},
 				},
@@ -218,7 +217,7 @@ var _ = Describe("HelmChartReconciler", func() {
 				return ""
 			}, timeout, interval).Should(Equal("1.0.0"))
 
-			chart.Spec.Version = "~0.1.0"
+			chart.Spec.Version = "<0.2.0"
 			Expect(k8sClient.Update(context.Background(), chart)).Should(Succeed())
 			Eventually(func() string {
 				_ = k8sClient.Get(context.Background(), key, chart)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 replace github.com/fluxcd/source-controller/api => ./api
 
 require (
-	github.com/blang/semver v3.5.0+incompatible
+	github.com/blang/semver/v4 v4.0.0
 	github.com/fluxcd/pkg/gittestserver v0.0.2
 	github.com/fluxcd/pkg/helmtestserver v0.0.1
 	github.com/fluxcd/pkg/lockedfile v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngE
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1 h1:pgAtgj+A31JBVtEHu2uHuEx0n+2ukqUJnS2vVe5pQNA=

--- a/internal/helm/repository.go
+++ b/internal/helm/repository.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/blang/semver"
+	"github.com/blang/semver/v4"
 	"helm.sh/helm/v3/pkg/repo"
 	"sigs.k8s.io/yaml"
 )

--- a/internal/helm/repository.go
+++ b/internal/helm/repository.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/blang/semver"
+	"helm.sh/helm/v3/pkg/repo"
+	"sigs.k8s.io/yaml"
+)
+
+func GetDownloadableChartVersionFromIndex(path, chart, version string) (*repo.ChartVersion, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Helm repository index file: %w", err)
+	}
+	index := &repo.IndexFile{}
+	if err := yaml.Unmarshal(b, index); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal Helm repository index file: %w", err)
+	}
+
+	var cv *repo.ChartVersion
+	if version == "" || version == "*" {
+		cv, err = index.Get(chart, version)
+		if err != nil {
+			if err == repo.ErrNoChartName {
+				err = fmt.Errorf("chart '%s' could not be found in Helm repository index", chart)
+			}
+			return nil, err
+		}
+	} else {
+		entries, ok := index.Entries[chart]
+		if !ok {
+			return nil, fmt.Errorf("chart '%s' could not be found in Helm repository index", chart)
+		}
+
+		rng, err := semver.ParseRange(version)
+		if err != nil {
+			return nil, fmt.Errorf("semver range parse error: %w", err)
+		}
+		versionEntryLookup := make(map[string]*repo.ChartVersion)
+		var versionsInRange []semver.Version
+		for _, e := range entries {
+			v, _ := semver.ParseTolerant(e.Version)
+			if rng(v) {
+				versionsInRange = append(versionsInRange, v)
+				versionEntryLookup[v.String()] = e
+			}
+		}
+		if len(versionsInRange) == 0 {
+			return nil, fmt.Errorf("no match found for semver: %s", version)
+		}
+		semver.Sort(versionsInRange)
+
+		latest := versionsInRange[len(versionsInRange)-1]
+		cv = versionEntryLookup[latest.String()]
+	}
+
+	if len(cv.URLs) == 0 {
+		return nil, fmt.Errorf("no downloadable URLs for chart '%s' with version '%s'", cv.Name, cv.Version)
+	}
+
+	return cv, nil
+}

--- a/pkg/git/checkout.go
+++ b/pkg/git/checkout.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/blang/semver"
+	"github.com/blang/semver/v4"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"


### PR DESCRIPTION
This PR changes the semver range parser for HelmChart resources to `blang/semver`, which
is also used to parse semver tags for GitRepository sources.