### PR TITLE
Add minimal nsswitch.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN apk add --no-cache ca-certificates tini
 
 COPY --from=builder /workspace/source-controller /usr/local/bin/
 
+# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
+# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 RUN addgroup -S controller && adduser -S -g controller controller
 
 USER controller


### PR DESCRIPTION
Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.