### PR TITLE
ci: add sanity check for container images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,14 @@ jobs:
           kustomize edit set image fluxcd/source-controller=fluxcd/source-controller:${{ steps.get_version.outputs.VERSION }}
           kustomize build . > source-controller.yaml
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@v1
         with:
           platforms: all
       - name: Setup Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v1
+        with:
+          buildkitd-flags: "--debug"
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
@@ -59,6 +61,14 @@ jobs:
           file: ./Dockerfile
           platforms: linux/arm64
           tags: ghcr.io/fluxcd/source-controller-arm64:${{ steps.get_version.outputs.VERSION }}
+      - name: Check images
+        run: |
+          docker buildx imagetools inspect docker.io/fluxcd/source-controller:${{ steps.get_version.outputs.VERSION }}
+          docker buildx imagetools inspect ghcr.io/fluxcd/source-controller:${{ steps.get_version.outputs.VERSION }}
+          docker buildx imagetools inspect ghcr.io/fluxcd/source-controller-arm64:${{ steps.get_version.outputs.VERSION }}
+          docker pull docker.io/fluxcd/source-controller:${{ steps.get_version.outputs.VERSION }}
+          docker pull ghcr.io/fluxcd/source-controller:${{ steps.get_version.outputs.VERSION }}
+          docker pull ghcr.io/fluxcd/source-controller-arm64:${{ steps.get_version.outputs.VERSION }}
       - name: Create release
         id: create_release
         uses: actions/create-release@latest


### PR DESCRIPTION
Fail build if container images have been pushed with corrupted layers
and enable buildx debug logs.

Ref: https://github.com/fluxcd/toolkit/issues/241