### PR TITLE
Update Helm to v3.3.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.5
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
-	helm.sh/helm/v3 v3.3.2
+	helm.sh/helm/v3 v3.3.3
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.8
 	k8s.io/client-go v0.18.8

--- a/go.sum
+++ b/go.sum
@@ -994,8 +994,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 helm.sh/helm/v3 v3.3.0/go.mod h1:cWRDbGk4EiIL0/+jN0GI8T7m96Cps81/ta1kcacl85g=
-helm.sh/helm/v3 v3.3.2 h1:LORtCE5ln4UHwKzUUzD0gzVYXv6Scjjsoj0Fifa2uSo=
-helm.sh/helm/v3 v3.3.2/go.mod h1:CyCGQa53/k1JFxXvXveGwtfJ4cuB9zkaBSGa5rnAiHU=
+helm.sh/helm/v3 v3.3.3 h1:MYPU9PyDBUECEuCYju8shxyBCyCqVmJzZyXnjTOXF1g=
+helm.sh/helm/v3 v3.3.3/go.mod h1:CyCGQa53/k1JFxXvXveGwtfJ4cuB9zkaBSGa5rnAiHU=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Helm v3.3.3 is a hotfix (patch) release from v3.3.2, fixing an issue where Helm cannot load chart repository index files with extra metadata.