### PR TITLE
e2e: use podinfo chart for valuesfile tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,8 +63,8 @@ jobs:
       - name: Run HelmChart values file tests
         run: |
           kubectl -n source-system apply -f ./config/testdata/helmchart-valuesfile
-          kubectl -n source-system wait helmchart/mariadb --for=condition=ready --timeout=5m
-          kubectl -n source-system wait helmchart/mariadb-git --for=condition=ready --timeout=5m
+          kubectl -n source-system wait helmchart/podinfo --for=condition=ready --timeout=5m
+          kubectl -n source-system wait helmchart/podinfo-git --for=condition=ready --timeout=5m
           kubectl -n source-system delete -f ./config/testdata/helmchart-valuesfile
       - name: Setup Minio
         env:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,11 +26,11 @@ jobs:
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.3.0
       - name: Setup Kustomize
-        uses: fluxcd/pkg/actions/kustomize@master
+        uses: fluxcd/pkg/actions/kustomize@main
       - name: Setup Kubebuilder
-        uses: fluxcd/pkg/actions/kubebuilder@master
+        uses: fluxcd/pkg/actions/kubebuilder@main
       - name: Setup Helm
-        uses: fluxcd/pkg/actions/helm@master
+        uses: fluxcd/pkg/actions/helm@main
       - name: Run tests
         run: make test
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Kustomize
-        uses: fluxcd/pkg/actions/kustomize@master
+        uses: fluxcd/pkg/actions/kustomize@main
       - name: Prepare
         id: prep
         run: |

--- a/config/testdata/helmchart-valuesfile/gitrepository.yaml
+++ b/config/testdata/helmchart-valuesfile/gitrepository.yaml
@@ -1,12 +1,12 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: GitRepository
 metadata:
-  name: bitnami-charts
+  name: podinfo
 spec:
-  interval: 1m
-  url: https://github.com/bitnami/charts
+  interval: 5m
+  url: https://github.com/stefanprodan/podinfo
   ref:
-    branch: master
+    branch: v5.x
   ignore:
     /*
-    !/bitnami/
+    !/charts/

--- a/config/testdata/helmchart-valuesfile/helmchart_gitrepository.yaml
+++ b/config/testdata/helmchart-valuesfile/helmchart_gitrepository.yaml
@@ -1,11 +1,11 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmChart
 metadata:
-  name: mariadb-git
+  name: podinfo-git
 spec:
-  chart: bitnami/mariadb
-  valuesFile: values-production.yaml
+  interval: 1m
   sourceRef:
     kind: GitRepository
-    name: bitnami-charts
-  interval: 1m
+    name: podinfo
+  chart: charts/podinfo
+  valuesFile: values-prod.yaml

--- a/config/testdata/helmchart-valuesfile/helmchart_helmrepository.yaml
+++ b/config/testdata/helmchart-valuesfile/helmchart_helmrepository.yaml
@@ -1,11 +1,11 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmChart
 metadata:
-  name: mariadb
+  name: podinfo
 spec:
-  chart: mariadb
-  valuesFile: values-production.yaml
+  interval: 1m
   sourceRef:
     kind: HelmRepository
-    name: bitnami-charts
-  interval: 1m
+    name: podinfo
+  chart: podinfo
+  valuesFile: values-prod.yaml

--- a/config/testdata/helmchart-valuesfile/helmrepository.yaml
+++ b/config/testdata/helmchart-valuesfile/helmrepository.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 metadata:
-  name: bitnami-charts
+  name: podinfo
 spec:
-  interval: 1m
-  url: https://charts.bitnami.com/bitnami
+  interval: 5m
+  url: https://stefanprodan.github.io/podinfo


### PR DESCRIPTION
This requires a new `podinfo` Helm chart release for the test to pass.