### PR TITLE
Use Masterminds/semver and put charts into a chrono order

### DIFF
--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -220,7 +220,7 @@ var _ = Describe("GitRepositoryReconciler", func() {
 				reference:     &sourcev1.GitRepositoryRef{SemVer: "v1.0.0"},
 				waitForReason: sourcev1.GitOperationFailedReason,
 				expectStatus:  corev1.ConditionFalse,
-				expectMessage: "semver parse range error",
+				expectMessage: "no match found for semver: v1.0.0",
 			}),
 			Entry("semver no match", refTestCase{
 				reference:     &sourcev1.GitRepositoryRef{SemVer: "1.0.0"},

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 replace github.com/fluxcd/source-controller/api => ./api
 
 require (
-	github.com/blang/semver/v4 v4.0.0
+	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/fluxcd/pkg/apis/meta v0.0.2
 	github.com/fluxcd/pkg/gittestserver v0.0.2
 	github.com/fluxcd/pkg/helmtestserver v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,6 @@ github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngE
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
-github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1 h1:pgAtgj+A31JBVtEHu2uHuEx0n+2ukqUJnS2vVe5pQNA=

--- a/internal/helm/repository.go
+++ b/internal/helm/repository.go
@@ -61,69 +61,85 @@ func NewChartRepository(repositoryURL string, providers getter.Providers, opts [
 }
 
 // Get returns the repo.ChartVersion for the given name, the version is expected
-// to be a semver.Constraints compatible string. If version is empty, the latest
-// stable version will be returned and prerelease versions will be ignored.
+// to be a semver.Constraints compatible string. In case of an ambiguous match,
+// takes the freshest chart. If version is empty, the latest stable version will
+// be returned and prerelease versions will be ignored.
 func (r *ChartRepository) Get(name, version string) (*repo.ChartVersion, error) {
-	cvs, ok := r.Index.Entries[name]
+	chartVersions, ok := r.Index.Entries[name]
 	if !ok {
 		return nil, repo.ErrNoChartName
 	}
-	if len(cvs) == 0 {
+	if len(chartVersions) == 0 {
 		return nil, repo.ErrNoChartVersion
 	}
 
-	// Check for exact matches first
-	if len(version) != 0 {
-		for _, cv := range cvs {
-			if version == cv.Version {
-				return cv, nil
-			}
-		}
-	}
-
-	// Continue to look for a (semantic) version match
-	latestStable := len(version) == 0 || version == "*"
-	var match *semver.Constraints
-	if !latestStable {
+	// Parse version constraints if given (default strategy: latest)
+	var versionLatestStable = len(version) == 0 || version == "*"
+	var versionConstraints *semver.Constraints
+	if !versionLatestStable {
 		rng, err := semver.NewConstraint(version)
 		if err != nil {
 			return nil, err
 		}
-		match = rng
+		versionConstraints = rng
 	}
-	var filteredVersions semver.Collection
-	lookup := make(map[string]*repo.ChartVersion)
-	for _, cv := range cvs {
-		v, err := semver.NewVersion(cv.Version)
+
+	// Filter out chart versions that doesn't satisfy constraints if any,
+	// parse semver and build a lookup table
+	matchingVersions := make(semver.Collection, 0)
+	chartVersionLookup := make(map[*semver.Version]*repo.ChartVersion)
+	for _, chartVersion := range chartVersions {
+		// Check for exact matches first
+		if version == chartVersion.Version {
+			return chartVersion, nil
+		}
+
+		version, err := semver.NewVersion(chartVersion.Version)
 		if err != nil {
 			continue
 		}
-		// NB: given the entries are already sorted in LoadIndex,
-		// there is a high probability the first match would be
-		// the right match to return. However, due to the fact that
-		// we use a different semver package than Helm does, we still
-		// need to sort it by our own rules.
-		if match != nil && !match.Check(v) {
+
+		if versionConstraints != nil && !versionConstraints.Check(version) {
 			continue
 		}
-		filteredVersions = append(filteredVersions, v)
-		lookup[v.String()] = cv
+
+		matchingVersions = append(matchingVersions, version)
+		chartVersionLookup[version] = chartVersion
 	}
-	if len(filteredVersions) == 0 {
+	if len(matchingVersions) == 0 {
 		return nil, fmt.Errorf("no chart version found for %s-%s", name, version)
 	}
-	sort.Sort(sort.Reverse(filteredVersions))
 
-	latest := filteredVersions[0]
-	if latestStable {
-		for _, v := range filteredVersions {
+	// Sort versions
+	sort.SliceStable(matchingVersions, func(i, j int) bool {
+		// Reverse
+		return !(func() bool {
+			left := matchingVersions[i]
+			right := matchingVersions[j]
+
+			if !left.Equal(right) {
+				return left.LessThan(right)
+			}
+
+			// Having chart creation timestamp at our disposal, we keep chronological
+			// order for packages with the same version, especially build metadata, since
+			// versions can be equal with different metadata, because it is not considered
+			// a part of the comparable version.
+			return chartVersionLookup[left].Created.Before(chartVersionLookup[right].Created)
+		})()
+	})
+
+	topMatchingVersion := matchingVersions[0]
+	if versionLatestStable {
+		for _, v := range matchingVersions {
 			if len(v.Prerelease()) == 0 {
-				latest = v
+				topMatchingVersion = v
 				break
 			}
 		}
 	}
-	return lookup[latest.String()], nil
+
+	return chartVersionLookup[topMatchingVersion], nil
 }
 
 // DownloadChart confirms the given repo.ChartVersion has a downloadable URL,


### PR DESCRIPTION
In the case of an ambiguous chart version match, take the most recently created chart. 

This is especially valuable for dev environments where it is common to deploy charts of the same (major.minor.patch) version but coming from different builds (hence different build metadata, as per Semver para 10). In such a setup, metadata usually contains build (git) revision that makes the default strategy of lexicographical sorting to pick unpredictable charts.

The Semver spec neither defines nor restricts particular order for such cases so this change doesn't violate the spec.

I also migrated to `Masterminds/semver` for two reasons:
* Better consistency. It is the same lib that Helm itself uses.
* Predictable matching of pre-preleases (fixes #127)

cc @hiddeco @stefanprodan 