### PR TITLE
Pick the most recent chart/tag for ambiguous semver matches

### DIFF
--- a/internal/helm/repository_test.go
+++ b/internal/helm/repository_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/getter"
@@ -104,6 +105,11 @@ func TestChartRepository_Get(t *testing.T) {
 	i.Add(&chart.Metadata{Name: "chart", Version: "exact"}, "chart-exact.tgz", "http://example.com/charts", "sha256:1234567890")
 	i.Add(&chart.Metadata{Name: "chart", Version: "0.1.0"}, "chart-0.1.0.tgz", "http://example.com/charts", "sha256:1234567890abc")
 	i.Add(&chart.Metadata{Name: "chart", Version: "0.1.1"}, "chart-0.1.1.tgz", "http://example.com/charts", "sha256:1234567890abc")
+	i.Add(&chart.Metadata{Name: "chart", Version: "0.1.5+b.min.minute"}, "chart-0.1.5+b.min.minute.tgz", "http://example.com/charts", "sha256:1234567890abc")
+	i.Entries["chart"][len(i.Entries["chart"])-1].Created = time.Now().Add(-time.Minute)
+	i.Add(&chart.Metadata{Name: "chart", Version: "0.1.5+a.min.hour"}, "chart-0.1.5+a.min.hour.tgz", "http://example.com/charts", "sha256:1234567890abc")
+	i.Entries["chart"][len(i.Entries["chart"])-1].Created = time.Now().Add(-time.Hour)
+	i.Add(&chart.Metadata{Name: "chart", Version: "0.1.5+c.now"}, "chart-0.1.5+c.now.tgz", "http://example.com/charts", "sha256:1234567890abc")
 	i.Add(&chart.Metadata{Name: "chart", Version: "0.2.0"}, "chart-0.2.0.tgz", "http://example.com/charts", "sha256:1234567890abc")
 	i.Add(&chart.Metadata{Name: "chart", Version: "1.0.0"}, "chart-1.0.0.tgz", "http://example.com/charts", "sha256:1234567890abc")
 	i.Add(&chart.Metadata{Name: "chart", Version: "1.1.0-rc.1"}, "chart-1.1.0-rc.1.tgz", "http://example.com/charts", "sha256:1234567890abc")
@@ -151,6 +157,12 @@ func TestChartRepository_Get(t *testing.T) {
 			name:      "invalid chart",
 			chartName: "non-existing",
 			wantErr:   true,
+		},
+		{
+			name:         "match newest if ambiguous",
+			chartName:    "chart",
+			chartVersion: "0.1.5",
+			wantVersion:  "0.1.5+c.now",
 		},
 	}
 


### PR DESCRIPTION
As per Semver para 11, `build metadata does not figure into precedence`. This means if two versions have equal `MAJOR`, `MINOR`, `PATCH` tokens, but different build metadata (para 10), the order is 💥 **undefined**. . Given that we don't simply match version string but **chart** versions, we have additional metadata, such as `chartVersion.Created`, that we can use to further clarify the logic without violating Semver. This behavior also fits the principle of least surprise better.

Such a change is useful for dev environments that are expected to get the latest build of the same app/chart. In the current setup, this cannot be done, especially when (and usually does) build metadata contains data that doesn't sort well (git hashes, sigs, etc.).

The same approach applies to GitRepository resources that make use of a semver tag strategy. It is possible to use a timestamp of the tag's target commit: https://github.com/fluxcd/source-controller/pull/172/commits/ebfb1189b77b0a384d0ffea1f1717e84266a0129

Derived from https://github.com/fluxcd/source-controller/pull/171 to decouple this change from migrating to `masterminds/semver`.

Related discussion https://github.com/fluxcd/toolkit/discussions/355

cc @hiddeco @stefanprodan 