### PR TITLE
Fix aliased subcharts handling

### DIFF
--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -446,12 +446,6 @@ func (r *HelmChartReconciler) reconcileFromTarballArtifact(ctx context.Context,
 	isDir := chartFileInfo.IsDir()
 	switch {
 	case isDir:
-		// Load dependencies
-		if err = chartutil.ProcessDependencies(helmChart, helmChart.Values); err != nil {
-			err = fmt.Errorf("failed to process chart dependencies: %w", err)
-			return sourcev1.HelmChartNotReady(chart, sourcev1.StorageOperationFailedReason, err.Error()), err
-		}
-
 		// Determine chart dependencies
 		deps := helmChart.Dependencies()
 		reqs := helmChart.Metadata.Dependencies

--- a/controllers/testdata/charts/helmchartwithdeps/Chart.yaml
+++ b/controllers/testdata/charts/helmchartwithdeps/Chart.yaml
@@ -24,6 +24,10 @@ dependencies:
   - name: helmchart
     version: "0.1.0"
     repository: "file://../helmchart"
+  - name: helmchart
+    alias: aliased
+    version: "0.1.0"
+    repository: "file://../helmchart"
   - name: grafana
     version: ">=5.7.0"
     repository: "https://grafana.github.io/helm-charts"


### PR DESCRIPTION
It looks like the use of chartutil.ProcessDependencies in the HelmChart
Controller was not correct, this method seems to be used in Helm only
during install/upgrade. The intention was to load the dependencies but
this seems to not be needed as it's [already done](https://github.com/helm/helm/blob/v3.3.4/pkg/chart/loader/load.go#L150-L182) through the loaders
(loader.Load).

The use of this method caused a regression where Chart.yaml files would
be overwritten and registered subcharts that had aliases would be
renamed using the alias name. While this is [an expected behaviour](https://github.com/helm/helm/blob/v3.3.4/pkg/chartutil/dependencies.go#L109-L111) of
chartutil.ProcessDependencies it is not what the controller should do
to the chart during (re)packaging.