### PR TITLE
Patch status sub-resource

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -100,6 +100,9 @@ jobs:
           kubectl -n source-system apply -f ./config/testdata/helmchart-from-bucket/source.yaml
           kubectl -n source-system wait bucket/charts --for=condition=ready --timeout=1m
           kubectl -n source-system wait helmchart/helmchart-bucket --for=condition=ready --timeout=1m
+      - name: Logs
+        run: |
+          kubectl -n source-system logs deploy/source-controller
       - name: Debug failure
         if: failure()
         run: |


### PR DESCRIPTION
This PR replaces status updates with patches to avoid "the object has been modified; please apply your changes to the latest version and try again".