### PR TITLE
Implement source suspension

### DIFF
--- a/api/v1beta1/bucket_types.go
+++ b/api/v1beta1/bucket_types.go
@@ -71,6 +71,10 @@ type BucketSpec struct {
 	// consult the documentation for your version to find out what those are.
 	// +optional
 	Ignore *string `json:"ignore,omitempty"`
+
+	// This flag tells the controller to suspend the reconciliation of this source.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 
 const (

--- a/api/v1beta1/gitrepository_types.go
+++ b/api/v1beta1/gitrepository_types.go
@@ -66,6 +66,10 @@ type GitRepositorySpec struct {
 	// consult the documentation for your version to find out what those are.
 	// +optional
 	Ignore *string `json:"ignore,omitempty"`
+
+	// This flag tells the controller to suspend the reconciliation of this source.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 
 // GitRepositoryRef defines the Git ref used for pull and checkout operations.

--- a/api/v1beta1/helmchart_types.go
+++ b/api/v1beta1/helmchart_types.go
@@ -49,6 +49,10 @@ type HelmChartSpec struct {
 	// relative path in the SourceRef. Ignored when omitted.
 	// +optional
 	ValuesFile string `json:"valuesFile,omitempty"`
+
+	// This flag tells the controller to suspend the reconciliation of this source.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 
 // LocalHelmChartSourceReference contains enough information to let you locate

--- a/api/v1beta1/helmrepository_types.go
+++ b/api/v1beta1/helmrepository_types.go
@@ -54,6 +54,10 @@ type HelmRepositorySpec struct {
 	// +kubebuilder:default:="60s"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
+
+	// This flag tells the controller to suspend the reconciliation of this source.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 
 // HelmRepositoryStatus defines the observed state of the HelmRepository.

--- a/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
@@ -87,6 +87,10 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
               timeout:
                 default: 20s
                 description: The timeout for download operations, defaults to 20s.

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -89,6 +89,10 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
               timeout:
                 default: 20s
                 description: The timeout for remote Git operations like cloning, defaults

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -86,6 +86,10 @@ spec:
                 - kind
                 - name
                 type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
               valuesFile:
                 description: Alternative values file to use as the default chart values,
                   expected to be a relative path in the SourceRef. Ignored when omitted.

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -63,6 +63,10 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
               timeout:
                 default: 60s
                 description: The timeout of index downloading, defaults to 60s.

--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -90,6 +90,12 @@ func (r *BucketReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return r.reconcileDelete(ctx, bucket)
 	}
 
+	// Return early if the object is suspended.
+	if bucket.Spec.Suspend {
+		log.Info("Reconciliation is suspended for this object")
+		return ctrl.Result{}, nil
+	}
+
 	// record reconciliation duration
 	if r.MetricsRecorder != nil {
 		objRef, err := reference.GetReference(r.Scheme, &bucket)

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -89,6 +89,12 @@ func (r *GitRepositoryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		return r.reconcileDelete(ctx, repository)
 	}
 
+	// Return early if the object is suspended.
+	if repository.Spec.Suspend {
+		log.Info("Reconciliation is suspended for this object")
+		return ctrl.Result{}, nil
+	}
+
 	// record reconciliation duration
 	if r.MetricsRecorder != nil {
 		objRef, err := reference.GetReference(r.Scheme, &repository)

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -95,6 +95,12 @@ func (r *HelmChartReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return r.reconcileDelete(ctx, chart)
 	}
 
+	// Return early if the object is suspended.
+	if chart.Spec.Suspend {
+		log.Info("Reconciliation is suspended for this object")
+		return ctrl.Result{}, nil
+	}
+
 	// Record reconciliation duration
 	if r.MetricsRecorder != nil {
 		objRef, err := reference.GetReference(r.Scheme, &chart)

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -90,6 +90,12 @@ func (r *HelmRepositoryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 		return r.reconcileDelete(ctx, repository)
 	}
 
+	// Return early if the object is suspended.
+	if repository.Spec.Suspend {
+		log.Info("Reconciliation is suspended for this object")
+		return ctrl.Result{}, nil
+	}
+
 	// record reconciliation duration
 	if r.MetricsRecorder != nil {
 		objRef, err := reference.GetReference(r.Scheme, &repository)

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -188,6 +188,18 @@ string
 consult the documentation for your version to find out what those are.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This flag tells the controller to suspend the reconciliation of this source.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -363,6 +375,18 @@ string
 consult the documentation for your version to find out what those are.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This flag tells the controller to suspend the reconciliation of this source.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -502,6 +526,18 @@ string
 relative path in the SourceRef. Ignored when omitted.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This flag tells the controller to suspend the reconciliation of this source.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -633,6 +669,18 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>The timeout of index downloading, defaults to 60s.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This flag tells the controller to suspend the reconciliation of this source.</p>
 </td>
 </tr>
 </table>
@@ -869,6 +917,18 @@ string
 <p>Ignore overrides the set of excluded patterns in the .sourceignore format
 (which is the same as .gitignore). If not provided, a default will be used,
 consult the documentation for your version to find out what those are.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This flag tells the controller to suspend the reconciliation of this source.</p>
 </td>
 </tr>
 </tbody>
@@ -1148,6 +1208,18 @@ string
 consult the documentation for your version to find out what those are.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This flag tells the controller to suspend the reconciliation of this source.</p>
+</td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -1366,6 +1438,18 @@ string
 relative path in the SourceRef. Ignored when omitted.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This flag tells the controller to suspend the reconciliation of this source.</p>
+</td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -1530,6 +1614,18 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>The timeout of index downloading, defaults to 60s.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This flag tells the controller to suspend the reconciliation of this source.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/spec/v1beta1/buckets.md
+++ b/docs/spec/v1beta1/buckets.md
@@ -49,6 +49,10 @@ type BucketSpec struct {
 	// consult the documentation for your version to find out what those are.
 	// +optional
 	Ignore *string `json:"ignore,omitempty"`
+
+	// This flag tells the controller to suspend the reconciliation of this source.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 ```
 

--- a/docs/spec/v1beta1/common.md
+++ b/docs/spec/v1beta1/common.md
@@ -6,7 +6,7 @@ Common defines resources used across all source types.
 
 ### Source interface
 
-Source objects should adhere to the `Source` interface. This interface exposes the [interval](#source-synchronization)
+Source objects adhere to the `Source` interface. This interface exposes the [interval](#source-reconciliation)
 and [artifact](#source-status) of the source to clients without the prerequisite of knowing the source kind:
 
 ````go
@@ -21,7 +21,7 @@ type Source interface {
 
 ### Source reconciliation
 
-Source objects should contain a `spec.interval` field that tells the controller at which interval to check for updates:
+Source objects contain a `spec.interval` field that tells the controller at which interval to check for updates:
 
 ```go
 type SourceSpec struct {
@@ -38,6 +38,8 @@ The controller can be told to check for updates right away by setting an annotat
 ```bash
 kubectl annotate --overwrite gitrepository/podinfo fluxcd.io/reconcileAt="$(date +%s)"
 ```
+
+The source objects reconciliation can be suspended by setting `spec.suspend` to `true`.
 
 ### Source status
 

--- a/docs/spec/v1beta1/gitrepositories.md
+++ b/docs/spec/v1beta1/gitrepositories.md
@@ -46,6 +46,10 @@ type GitRepositorySpec struct {
 	// consult the documentation for your version to find out what those are.
 	// +optional
 	Ignore *string `json:"ignore,omitempty"`
+
+	// This flag tells the controller to suspend the reconciliation of this source.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 ```
 

--- a/docs/spec/v1beta1/helmcharts.md
+++ b/docs/spec/v1beta1/helmcharts.md
@@ -32,6 +32,10 @@ type HelmChartSpec struct {
 	// relative path in the SourceRef. Ignored when omitted.
 	// +optional
 	ValuesFile string `json:"valuesFile,omitempty"`
+
+	// This flag tells the controller to suspend the reconciliation of this source.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 ```
 

--- a/docs/spec/v1beta1/helmrepositories.md
+++ b/docs/spec/v1beta1/helmrepositories.md
@@ -31,6 +31,10 @@ type HelmRepositorySpec struct {
 	// The timeout of index downloading, defaults to 60s.
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
+
+	// This flag tells the controller to suspend the reconciliation of this source.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 ```
 


### PR DESCRIPTION
This PR adds an optional field called `Suspend` to the source APIs and implements reconciliation suspension.

Ref: https://github.com/fluxcd/flux2/issues/507