### PR TITLE
Respect configured user in SSH Git repository URL

### DIFF
--- a/pkg/git/transport_test.go
+++ b/pkg/git/transport_test.go
@@ -66,19 +66,25 @@ var (
 
 func TestAuthSecretStrategyForURL(t *testing.T) {
 	tests := []struct {
-		name string
-		url  string
-		want AuthSecretStrategy
+		name    string
+		url     string
+		want    AuthSecretStrategy
+		wantErr bool
 	}{
-		{"HTTP", "http://git.example.com/org/repo.git", &BasicAuth{}},
-		{"HTTPS", "https://git.example.com/org/repo.git", &BasicAuth{}},
-		{"SSH", "ssh://git.example.com:2222/org/repo.git", &PublicKeyAuth{}},
-		{"unsupported", "protocol://example.com", nil},
+		{"HTTP", "http://git.example.com/org/repo.git", &BasicAuth{}, false},
+		{"HTTPS", "https://git.example.com/org/repo.git", &BasicAuth{}, false},
+		{"SSH", "ssh://git.example.com:2222/org/repo.git", &PublicKeyAuth{}, false},
+		{"SSH with username", "ssh://example@git.example.com:2222/org/repo.git", &PublicKeyAuth{user: "example"}, false},
+		{"unsupported", "protocol://example.com", nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := AuthSecretStrategyForURL(tt.url)
-			if reflect.TypeOf(got) != reflect.TypeOf(tt.want) {
+			got, err := AuthSecretStrategyForURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AuthSecretStrategyForURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("AuthSecretStrategyForURL() got = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
We had a hardcoded assumption that the SSH user for a Git repository is
always "git". This is however not true in all scenarios, for example
when one is making use of Gerrit for team code collaboration, as users
there have their own username for (SSH) Git operations.

This commit changes the logic of the auth strategy helpers to:

1. Select the auth strategy based on the protocol of the parsed URL,
   instead of a simple rely on a correct prefix.
2. Use the user information from the parsed URL to configure the user
   for the public key authentication strategy, with a fallback to `git`
   if none is defined.