### PR TITLE
Validate provided name for charts from HelmRepos

### DIFF
--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/fluxcd/pkg/apis/meta"
@@ -938,3 +939,26 @@ var _ = Describe("HelmChartReconciler", func() {
 		})
 	})
 })
+
+func Test_validHelmChartName(t *testing.T) {
+	tests := []struct {
+		name      string
+		chart     string
+		expectErr bool
+	}{
+		{"valid", "drupal", false},
+		{"valid dash", "nginx-lego", false},
+		{"valid dashes", "aws-cluster-autoscaler", false},
+		{"valid alphanum", "ng1nx-leg0", false},
+		{"invalid slash", "artifactory/invalid", true},
+		{"invalid dot", "in.valid", true},
+		{"invalid uppercase", "inValid", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validHelmChartName(tt.chart); (err != nil) != tt.expectErr {
+				t.Errorf("validHelmChartName() error = %v, expectErr %v", err, tt.expectErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Following the rules described in
https://helm.sh/docs/chart_best_practices/conventions/#chart-names.

This guards against people following the wrong guidance of Artifactory,
that supports and promotes repository indexes with e.g. '/' in the
chart names.

In a future version this should be moved to a validation webhook, but
there are still discussions ongoing around the TLS certificates for
this.

Ref: #226 