### PR TITLE
Upgrade to `musl>=1.2.0` to be able to provide ARMv7 build

### DIFF
--- a/.github/actions/run-tests/Dockerfile
+++ b/.github/actions/run-tests/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.15-alpine
 
 # Add any build or testing essential system packages
 RUN apk add --no-cache build-base git pkgconf
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libgit2-dev~=1.1.0
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libgit2-dev~=1.1
 
 # Use the GitHub Actions uid:gid combination for proper fs permissions
 RUN addgroup -g 116 -S test && adduser -u 1001 -S -g test test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@
 FROM golang:1.15-alpine as builder
 
 RUN apk add gcc pkgconfig libc-dev
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libgit2-dev~=1.1.0
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main musl=1.2.2_pre5-r0
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libgit2-dev~=1.1
+# TODO: replace with non-edge musl 1.2.x when made available
+#  musl 1.2.x is a strict requirement of libgit2 due to time_t changes
+#  ref: https://musl.libc.org/time64.html
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main musl~=1.2
 
 WORKDIR /workspace
 
@@ -32,7 +35,7 @@ FROM alpine:3.12
 LABEL org.opencontainers.image.source="https://github.com/fluxcd/source-controller"
 
 RUN apk add --no-cache ca-certificates tini
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libgit2-dev~=1.1.0
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libgit2~=1.1
 
 COPY --from=builder /workspace/source-controller /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.15-alpine as builder
 
 RUN apk add gcc pkgconfig libc-dev
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libgit2-dev~=1.1.0
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main musl=1.2.2_pre5-r0
 
 WORKDIR /workspace
 


### PR DESCRIPTION
This PR changes the musl version used to the latest 1.2 version to be able to compile on 32 bit systems.