### PR TITLE
Allow overwrite of advertised storage addr

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -41,6 +41,7 @@ spec:
           - --log-json
           - --enable-leader-election
           - --storage-path=/data
+          - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
         livenessProbe:
           httpGet:
             port: http


### PR DESCRIPTION
The added `--storage-adv-addr` flag allows overwriting the HTTP address
advertised in the status objects of the sources. This allows for finer
grain configuration in setups where a modified service is used, or where
the DNS resolution differs from the Kubernetes defaults.

When the flag is omitted, an attempt is made to determine the address
based on the configured `--storage-addr` and the `HOSTNAME`.

Fixes: #207
Offers a solution to: https://github.com/fluxcd/kustomize-controller/issues/196