### PR TITLE
Properly forward commit hash for go-git implementation

### DIFF
--- a/pkg/git/v1/commit.go
+++ b/pkg/git/v1/commit.go
@@ -28,7 +28,7 @@ type Commit struct {
 }
 
 func (c *Commit) Hash() string {
-	return ""
+	return c.commit.Hash.String()
 }
 
 // Verify returns an error if the PGP signature can't be verified


### PR DESCRIPTION
Regression bug introduced in #213 