### PR TITLE
Publish as single multi-arch Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,34 +40,17 @@ jobs:
         with:
           username: fluxcdbot
           password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
-      - name: Publish AMD64 image
+      - name: Publish multi-arch container image
         uses: docker/build-push-action@v2
         with:
           push: true
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
           tags: |
             ghcr.io/fluxcd/source-controller:${{ steps.prep.outputs.VERSION }}
             docker.io/fluxcd/source-controller:${{ steps.prep.outputs.VERSION }}
-          labels: |
-            org.opencontainers.image.title=${{ github.event.repository.name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.VERSION }}
-            org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}
-      - name: Publish ARM image
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          file: ./Dockerfile
-          platforms: linux/arm/v7,linux/arm64
-          tags: |
-            ghcr.io/fluxcd/source-controller-arm64:${{ steps.prep.outputs.VERSION }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -79,7 +62,6 @@ jobs:
         run: |
           docker buildx imagetools inspect docker.io/fluxcd/source-controller:${{ steps.prep.outputs.VERSION }}
           docker buildx imagetools inspect ghcr.io/fluxcd/source-controller:${{ steps.prep.outputs.VERSION }}
-          docker buildx imagetools inspect ghcr.io/fluxcd/source-controller-arm64:${{ steps.prep.outputs.VERSION }}
           docker pull docker.io/fluxcd/source-controller:${{ steps.prep.outputs.VERSION }}
           docker pull ghcr.io/fluxcd/source-controller:${{ steps.prep.outputs.VERSION }}
       - name: Generate release asset


### PR DESCRIPTION
This commit bundles the `source-controller:$VER-arm64` ARM image tag
range that was previously released separately with the
`source-controller:$VER` image, as GitHub now provides us insights into
image layer statistics.

Ref: https://github.com/fluxcd/flux2/issues/493#issuecomment-746156065