### PR TITLE
Fix values file override

### DIFF
--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -504,19 +504,12 @@ func (r *HelmChartReconciler) reconcileFromTarballArtifact(ctx context.Context,
 			err = fmt.Errorf("invalid values file path: %s", chart.Spec.ValuesFile)
 			return sourcev1.HelmChartNotReady(chart, sourcev1.StorageOperationFailedReason, err.Error()), err
 		}
-		src, err := os.Open(srcPath)
-		if err != nil {
-			err = fmt.Errorf("failed to open values file '%s': %w", chart.Spec.ValuesFile, err)
-			return sourcev1.HelmChartNotReady(chart, sourcev1.StorageOperationFailedReason, err.Error()), err
-		}
-		defer src.Close()
 
-		var valuesData []byte
-		if _, err := src.Read(valuesData); err != nil {
+		valuesData, err := ioutil.ReadFile(srcPath)
+		if err != nil {
 			err = fmt.Errorf("failed to read from values file '%s': %w", chart.Spec.ValuesFile, err)
 			return sourcev1.HelmChartNotReady(chart, sourcev1.StorageOperationFailedReason, err.Error()), err
 		}
-
 		isValuesFileOverriden, err = helm.OverwriteChartDefaultValues(helmChart, valuesData)
 		if err != nil {
 			return sourcev1.HelmChartNotReady(chart, sourcev1.ChartPackageFailedReason, err.Error()), err


### PR DESCRIPTION
`io.Read` was used incorrectly to read from the override file provided
by the user.
This is now replaced with `ioutil.ReadFile` for better handling and
error reporting.

Fixes #263