### PR TITLE
Assume local dependency without Helm repository

### DIFF
--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -537,7 +537,7 @@ func (r *HelmChartReconciler) reconcileFromTarballArtifact(ctx context.Context,
 			}
 
 			// Continue loop if file scheme detected
-			if strings.HasPrefix(dep.Repository, "file://") {
+			if dep.Repository == "" || strings.HasPrefix(dep.Repository, "file://") {
 				dwr = append(dwr, &helm.DependencyWithRepository{
 					Dependency: dep,
 					Repository: nil,

--- a/internal/helm/dependency_manager.go
+++ b/internal/helm/dependency_manager.go
@@ -156,7 +156,7 @@ func (dm *DependencyManager) secureLocalChartPath(dep *DependencyWithRepository)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse alleged local chart reference: %w", err)
 	}
-	if localUrl.Scheme != "file" {
+	if localUrl.Scheme != "" && localUrl.Scheme != "file" {
 		return "", fmt.Errorf("'%s' is not a local chart reference", dep.Dependency.Repository)
 	}
 	return securejoin.SecureJoin(dm.WorkingDir, filepath.Join(dm.ChartPath, localUrl.Host, localUrl.Path))


### PR DESCRIPTION
This commit fixes a bug where local chart dependencies would not be
detected correctly due to the absence of a repository URL.

Fixes #194 