### PR TITLE
Use Recreate strategy for controller deployment

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app: source-controller
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
- Prevents a deadlock in active-passive HA setups with multiple
  replicas and during upgrades that previously occurred. As the
  leader election would be held hostage by the previous replica
  set due to the rolling update strategy.
- Ensures backing persistent (RW) volumes can safely be used, as
  they can not be shared and will not become available to the next
  pod without recreating all.

Regression introduced in #273, with some sparkles of history that stateful deployments should always use a recreate strategy.