### PR TITLE
Add fsGroup to pod security context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY --from=builder /workspace/source-controller /usr/local/bin/
 # https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
-RUN addgroup -S controller && adduser -S -g controller controller
+RUN addgroup -S controller && adduser -S controller -G controller
 
 USER controller
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY internal/ internal/
 # build without specifing the arch
 RUN CGO_ENABLED=1 go build -o source-controller main.go
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 # link repo to the GitHub Container Registry image
 LABEL org.opencontainers.image.source="https://github.com/fluxcd/source-controller"

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         prometheus.io/port: "8080"
     spec:
       terminationGracePeriodSeconds: 10
+      # Required for AWS IAM Role bindings
+      # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html
+      securityContext:
+        fsGroup: 1337
       containers:
       - name: manager
         image: fluxcd/source-controller


### PR DESCRIPTION
Changes:
- add `fsGroup` to the pod security context (required for AWS IAM Role bindings)
- update Alpine to v3.13
- fix the controller group in Alpine

Fix: #284