### PR TITLE
Fix chart with custom valuesFile (0bytes tgz)

### DIFF
--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -403,13 +403,8 @@ func (r *HelmChartReconciler) reconcileFromHelmRepository(ctx context.Context,
 		if changed, err := helm.OverwriteChartDefaultValues(helmChart, valuesData); err != nil {
 			return sourcev1.HelmChartNotReady(chart, sourcev1.ChartPackageFailedReason, err.Error()), err
 		} else if !changed {
-			// No changes, write original package to storage
-			if err := r.Storage.AtomicWriteFile(&newArtifact, res, 0644); err != nil {
-				err = fmt.Errorf("unable to write chart file: %w", err)
-				return sourcev1.HelmChartNotReady(chart, sourcev1.StorageOperationFailedReason, err.Error()), err
-			}
-
-			break
+			// No changes, skip to write original package to storage
+			goto skipToDefault
 		}
 
 		// Create temporary working directory
@@ -435,6 +430,9 @@ func (r *HelmChartReconciler) reconcileFromHelmRepository(ctx context.Context,
 
 		readyMessage = fmt.Sprintf("Fetched and packaged revision: %s", newArtifact.Revision)
 		readyReason = sourcev1.ChartPackageSucceededReason
+		break
+	skipToDefault:
+		fallthrough
 	default:
 		// Write artifact to storage
 		if err := r.Storage.AtomicWriteFile(&newArtifact, res, 0644); err != nil {


### PR DESCRIPTION
Creating a HelmRelease/Chart with a `valuesFile` declaration ends with a 0bytes tgz on the storage path.

```
$ ls -l /tmp/storage/helmchart/flux-system/podinfo
total 0
-rw-r--r--  1 raffis  wheel   0 Feb  9 09:48 podinfo-5.1.4.tgz
-rw-r--r--  1 raffis  wheel   0 Feb  9 09:48 podinfo-5.1.4.tgz.lock
lrwxr-xr-x  1 raffis  wheel  60 Feb  9 09:48 podinfo-latest.tgz -> /tmp/storage/helmchart/flux-system/podinfo/podinfo-5.1.4.tgz
```

Reproducing manifests:
```yaml
apiVersion: source.toolkit.fluxcd.io/v1beta1
kind: HelmRepository
metadata:
  name: podinfo
  namespace: flux-system
spec:
  interval: 5m
  url: https://stefanprodan.github.io/podinfo
---
apiVersion: source.toolkit.fluxcd.io/v1beta1
kind: HelmChart
metadata:
  name: podinfo
  namespace: flux-system
spec:
  interval: 1m
  sourceRef:
    kind: HelmRepository
    name: podinfo
  chart: podinfo
  valuesFile: values-prod.yaml
```

The problem is that the it falls through to default as well and executes the atomicwrite as well.
This pr fixes that behavior.

Two other hints:
* Might need to add a test to validate the written tgz
* The `Copy()` method in the storage package is quite the same as `AtomicWriteFile()`, only difference is the chmod, might merge these two as in either case the mode can be set I reckon.