### PR TITLE
libgit2: use provided host to validate public key

### DIFF
--- a/pkg/git/libgit2/transport_test.go
+++ b/pkg/git/libgit2/transport_test.go
@@ -73,8 +73,8 @@ func TestAuthSecretStrategyForURL(t *testing.T) {
 	}{
 		{"HTTP", "http://git.example.com/org/repo.git", &BasicAuth{}, false},
 		{"HTTPS", "https://git.example.com/org/repo.git", &BasicAuth{}, false},
-		{"SSH", "ssh://git.example.com:2222/org/repo.git", &PublicKeyAuth{}, false},
-		{"SSH with username", "ssh://example@git.example.com:2222/org/repo.git", &PublicKeyAuth{user: "example"}, false},
+		{"SSH", "ssh://git.example.com:2222/org/repo.git", &PublicKeyAuth{host: "git.example.com:2222"}, false},
+		{"SSH with username", "ssh://example@git.example.com:2222/org/repo.git", &PublicKeyAuth{user: "example", host: "git.example.com:2222"}, false},
 		{"unsupported", "protocol://example.com", nil, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
The callback from libgit2 only provides a hostname (without the port),
but the `known_hosts` file indexes the public keys based on the full
host (e.g. `[localhost]:123` for a host behind a specific port).

As a result, it was unable to find the correct public key for the
hostname when it was added to the `known_hosts` file with the port.

To work around this, we add the user provided host that includes the
port to the `PublicKeyAuth` strategy, and use this to find the right
entry in the `known_hosts` file, after having validated that the
hostname provided to the callback matches the hostname of the host
provided by the user.

Fixes: #287