### PR TITLE
Tidy git clone errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/fluxcd/pkg/apis/meta v0.8.0
 	github.com/fluxcd/pkg/gittestserver v0.1.0
+	github.com/fluxcd/pkg/gitutil v0.0.1
 	github.com/fluxcd/pkg/helmtestserver v0.1.0
 	github.com/fluxcd/pkg/lockedfile v0.0.5
 	github.com/fluxcd/pkg/runtime v0.8.3

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,8 @@ github.com/fluxcd/pkg/apis/meta v0.8.0 h1:wqWpUsxhKHB1ZztcvOz+vnyhdKW9cWmjFp8Vci
 github.com/fluxcd/pkg/apis/meta v0.8.0/go.mod h1:yHuY8kyGHYz22I0jQzqMMGCcHViuzC/WPdo9Gisk8Po=
 github.com/fluxcd/pkg/gittestserver v0.1.0 h1:BvIG+bBhgbmqhtpSS2qUpOXRIL1P1Ow2jauloH8X86U=
 github.com/fluxcd/pkg/gittestserver v0.1.0/go.mod h1:HWZaoib03fQeSsauCAN2iAFdr6bnjKQ+CFxMFD2mwDY=
+github.com/fluxcd/pkg/gitutil v0.0.1 h1:uCEa2hDUS3y5OJ2jQ/2XNziotZTvZ4s56njMkxEfbZg=
+github.com/fluxcd/pkg/gitutil v0.0.1/go.mod h1:6WkZyuVXODa6PR2UppepCGQyKuQ9eOsL3dd+89hE24s=
 github.com/fluxcd/pkg/helmtestserver v0.1.0 h1:RiVVxIHD6PJdKinW46feFIYf1LUj6xXSpgARk+m9U7U=
 github.com/fluxcd/pkg/helmtestserver v0.1.0/go.mod h1:3L+tbPn74PsHwHsyhbfk/kZAosrwMFTTA92XEFiwVAE=
 github.com/fluxcd/pkg/lockedfile v0.0.5 h1:C3T8wfdff1UY1bvplmCkGOLrdMWJHO8Q8+tdlEXJYzQ=

--- a/pkg/git/gogit/checkout.go
+++ b/pkg/git/gogit/checkout.go
@@ -26,6 +26,7 @@ import (
 	extgogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 
+	"github.com/fluxcd/pkg/gitutil"
 	"github.com/fluxcd/pkg/version"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
@@ -71,7 +72,7 @@ func (c *CheckoutBranch) Checkout(ctx context.Context, path, url string, auth *g
 		Tags:              extgogit.NoTags,
 	})
 	if err != nil {
-		return nil, "", fmt.Errorf("unable to clone '%s', error: %w", url, err)
+		return nil, "", fmt.Errorf("unable to clone '%s', error: %w", url, gitutil.GoGitError(err))
 	}
 	head, err := repo.Head()
 	if err != nil {

--- a/pkg/git/libgit2/checkout.go
+++ b/pkg/git/libgit2/checkout.go
@@ -23,6 +23,8 @@ import (
 	"github.com/blang/semver/v4"
 	git2go "github.com/libgit2/git2go/v31"
 
+	"github.com/fluxcd/pkg/gitutil"
+
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 	"github.com/fluxcd/source-controller/pkg/git"
 )
@@ -64,7 +66,7 @@ func (c *CheckoutBranch) Checkout(ctx context.Context, path, url string, auth *g
 		CheckoutBranch: c.branch,
 	})
 	if err != nil {
-		return nil, "", fmt.Errorf("unable to clone '%s', error: %w", url, err)
+		return nil, "", fmt.Errorf("unable to clone '%s', error: %w", url, gitutil.LibGit2Error(err))
 	}
 	head, err := repo.Head()
 	if err != nil {


### PR DESCRIPTION
In some circumstances (that are rather hard to reproduce), cloning from a GitLab repo gets a multiline response as described in https://github.com/fluxcd/image-automation-controller/pull/115.

This uses the same remedy as in that PR, by calling the funcs provided by fluxcd/pkg/gitutil on any error returned by libgit2 or gogit clone operations.

This should not change any errors that are _not_ multiline, i.e., everything should look the same in other-than-GitLab circumstances.

I allege that this fixes https://github.com/fluxcd/source-controller/issues/120