### PR TITLE
Allow HelmChart to use Source revision over version

### DIFF
--- a/api/v1beta1/helmchart_types.go
+++ b/api/v1beta1/helmchart_types.go
@@ -50,6 +50,13 @@ type HelmChartSpec struct {
 	// +optional
 	ValuesFile string `json:"valuesFile,omitempty"`
 
+	// Ignore the version of the chart, allowing reconciliation if the source has
+	// changed. Only applies to GitRepository and Bucket sources. Defaults to false
+	// when omitted.
+	// +kubebuilder:default:=false
+	// +optional
+	IgnoreVersion bool `json:"ignoreVersion,omitempty"`
+
 	// This flag tells the controller to suspend the reconciliation of this source.
 	// +optional
 	Suspend bool `json:"suspend,omitempty"`

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -62,6 +62,12 @@ spec:
                 description: The name or path the Helm chart is available at in the
                   SourceRef.
                 type: string
+              ignoreVersion:
+                default: false
+                description: Ignore the version of the chart, allowing reconciliation
+                  if the source has changed. Only applies to GitRepository and Bucket
+                  sources. Defaults to false when omitted.
+                type: boolean
               interval:
                 description: The interval at which to check the Source for updates.
                 type: string

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -541,6 +541,20 @@ relative path in the SourceRef. Ignored when omitted.</p>
 </tr>
 <tr>
 <td>
+<code>ignoreVersion</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Ignore the version of the chart, allowing reconciliation if the source has
+changed. Only applies to GitRepository and Bucket sources. Defaults to false
+when omitted.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>suspend</code><br>
 <em>
 bool
@@ -1462,6 +1476,20 @@ string
 <em>(Optional)</em>
 <p>Alternative values file to use as the default chart values, expected to be a
 relative path in the SourceRef. Ignored when omitted.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ignoreVersion</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Ignore the version of the chart, allowing reconciliation if the source has
+changed. Only applies to GitRepository and Bucket sources. Defaults to false
+when omitted.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Adds `IgnoreVersion` (working name) flag which allows the `HelmChart` CRD to use the Source revision (ex: `main/a96eff73a282d408a960086d978ca97a0a1fb2ef`) in place of the Chart.yaml version (`0.1.0`). `IgnoreVersion` is opt-in only and only changes the the HelmChart CRD.

This is only applicable to `GitRepository` and `Bucket` sources as `HelmRepository` has a clearly defined contract that Charts are (should be) immutable.

This change would allow Flux users to determine if they want to install/upgrade on each change to the source. A more detailed workflow and reasoning as to why is below:

<details>
<summary>Use Case</summary>

We manage a single repository which houses a single chart that manages all microservices. Beside the `./templates` lives `values-<environment>` for staging, test, dev, etc. Some developers keep their own `values-name.yaml` lying around elsewhere. We utilize Helm to its templating-fullest for production workloads and local develop (like bringing up databases in containers).

We chose not to package the Helm chart and ship it to a Helm repository. This would serve no purpose and just requires another step. We also chose to place the values files beside the `values.yaml` similar to how Bitnami once did. Currently, we use ArgoCD which uses a similar-to `GitRepository` source, templates on each change, and deploys when differences occur.

I feel like our use of Helm is optimal for GitOps:
1. We store the base (templates, `values.yaml`) in Git.
1. We store the overrides or patches beside the base (`values-production.yaml`) in the same Git repository.
1. We run CI on the base and overrides ensuring that the generated manifests comply with the Kubernetes API (against a KIND cluster).
1. We run CI to diff the local changed state against the remote state of the desired deployment target on pull-requests (similar to a `terraform plan`)
1. We update the chart many times a day mostly patching the `values-env.yaml` for changes to image tags.
1. By not versioning the Chart.yaml, changes to the base templates affect all environments immediately, meaning that all base changes must be backwards compatible.
1. We don't need to store the desired state (values) of our deployment in ConfigMaps, Secrets, Flux CRDs, ArgoCD CRDs, etc. It exists in a single place controlled, managed and audited by Git.

Without this change, Flux requires us to move values out of the Git repository and into other objects (mentioned above) or version the Chart.yaml with every change.
</details>

This has been tested in an environment with a patched helm-controller. Changes to the `HelmChart` CRD look like: 

```yaml
spec:
  chart:
    spec:
      chart: chart
      ignoreVersion: true
      sourceRef:
        kind: GitRepository
        name: flux-system
        namespace: flux-system
      valuesFile: chart/values-production.yaml
      version: '*'
  interval: 30s
  releaseName: prod
status:
  conditions:
  - lastTransitionTime: "2021-03-13T00:50:11Z"
    message: Release reconciliation succeeded
    reason: ReconciliationSucceeded
    status: "True"
    type: Ready
  - lastTransitionTime: "2021-03-13T00:50:11Z"
    message: Helm upgrade succeeded
    reason: UpgradeSucceeded
    status: "True"
    type: Released
  helmChart: flux-system/default-foko
  lastAppliedRevision: main/f0faacd5164a875ebdbd9e3fab778f49c5aadbbc
  lastAttemptedRevision: main/f0faacd5164a875ebdbd9e3fab778f49c5aadbbc
  lastAttemptedValuesChecksum: da39a3ee5e6b4b0d3255bfef95601890afd80709
  lastReleaseRevision: 4
  observedGeneration: 1
```