### PR TITLE
feat: add helm chart for source-controller

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+char_set = utf-8
+insert_final_newline = true
+
+[*.{ts,js,json}]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.sh]
+indent_style = tab

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,6 +9,11 @@ on:
 jobs:
   kind:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        deployments:
+          - dev-deploy
+          - chart-deploy
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -46,7 +51,7 @@ jobs:
       - name: Load test image
         run: kind load docker-image test/source-controller:latest
       - name: Deploy controller
-        run: make dev-deploy IMG=test/source-controller:latest
+        run: make ${{ matrix.deployment }} IMG=test/source-controller:latest
         env:
           KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin
       - name: Run smoke tests

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+type: application
+name: source-controller
+description: |
+  A Helm chart for deploying the source-controller, which is a component of the Flux GitOps Toolkit. The
+  source-controller is a Kubernetes operator specialised in artifacts acquisition from external sources such as Git,
+  Helm repositories, and Cloud Platform Provider buckets, including AWS S3, GCP GCS, and Azure Blob Storage.
+keywords:
+- helm
+- fluxcd
+- gitops
+- source-controller
+annotations:
+  app: fluxcd
+  component: source-controller
+home: https://toolkit.fluxcd.io/components/source/controller
+sources:
+- https://github.com/fluxcd/source-controller
+- https://github.com/fluxcd/flux2
+
+maintainers:
+- name: Flux Authors and Contributors
+  url: https://github.com/fluxcd/source-controller/graphs/contributors
+- name: Deavon M. McCaffery
+  url: https://github.com/dmccaffery
+
+version: 0.1.0
+appVersion: "v0.9.1"

--- a/chart/crds/source.toolkit.fluxcd.io_buckets.yaml
+++ b/chart/crds/source.toolkit.fluxcd.io_buckets.yaml
@@ -1,0 +1,227 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: buckets.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: Bucket
+    listKind: BucketList
+    plural: buckets
+    singular: bucket
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Bucket is the Schema for the buckets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BucketSpec defines the desired state of an S3 compatible
+              bucket
+            properties:
+              bucketName:
+                description: The bucket name.
+                type: string
+              endpoint:
+                description: The bucket endpoint address.
+                type: string
+              ignore:
+                description: Ignore overrides the set of excluded patterns in the
+                  .sourceignore format (which is the same as .gitignore). If not provided,
+                  a default will be used, consult the documentation for your version
+                  to find out what those are.
+                type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS S3 HTTP endpoint.
+                type: boolean
+              interval:
+                description: The interval at which to check for bucket updates.
+                type: string
+              provider:
+                default: generic
+                description: The S3 compatible storage provider name, default ('generic').
+                enum:
+                - generic
+                - aws
+                type: string
+              region:
+                description: The bucket region.
+                type: string
+              secretRef:
+                description: The name of the secret containing authentication credentials
+                  for the Bucket.
+                properties:
+                  name:
+                    description: Name of the referent
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 20s
+                description: The timeout for download operations, defaults to 20s.
+                type: string
+            required:
+            - bucketName
+            - endpoint
+            - interval
+            type: object
+          status:
+            description: BucketStatus defines the observed state of a bucket
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  Bucket sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA1 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of this artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: Revision is a human readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm index timestamp, a Helm chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the Bucket.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the artifact output of the
+                  last Bucket sync.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/crds/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/chart/crds/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -1,0 +1,264 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: gitrepositories.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: GitRepository
+    listKind: GitRepositoryList
+    plural: gitrepositories
+    singular: gitrepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitRepositorySpec defines the desired state of a Git repository.
+            properties:
+              gitImplementation:
+                default: go-git
+                description: Determines which git client library to use. Defaults
+                  to go-git, valid values are ('go-git', 'libgit2').
+                enum:
+                - go-git
+                - libgit2
+                type: string
+              ignore:
+                description: Ignore overrides the set of excluded patterns in the
+                  .sourceignore format (which is the same as .gitignore). If not provided,
+                  a default will be used, consult the documentation for your version
+                  to find out what those are.
+                type: string
+              interval:
+                description: The interval at which to check for repository updates.
+                type: string
+              ref:
+                description: The Git reference to checkout and monitor for changes,
+                  defaults to master branch.
+                properties:
+                  branch:
+                    default: master
+                    description: The Git branch to checkout, defaults to master.
+                    type: string
+                  commit:
+                    description: The Git commit SHA to checkout, if specified Tag
+                      filters will be ignored.
+                    type: string
+                  semver:
+                    description: The Git tag semver expression, takes precedence over
+                      Tag.
+                    type: string
+                  tag:
+                    description: The Git tag to checkout, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: The secret name containing the Git credentials. For HTTPS
+                  repositories the secret must contain username and password fields.
+                  For SSH repositories the secret must contain identity, identity.pub
+                  and known_hosts fields.
+                properties:
+                  name:
+                    description: Name of the referent
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 20s
+                description: The timeout for remote Git operations like cloning, defaults
+                  to 20s.
+                type: string
+              url:
+                description: The repository URL, can be a HTTP/S or SSH address.
+                pattern: ^(http|https|ssh)://
+                type: string
+              verify:
+                description: Verify OpenPGP signature for the Git commit HEAD points
+                  to.
+                properties:
+                  mode:
+                    description: Mode describes what git object should be verified,
+                      currently ('head').
+                    enum:
+                    - head
+                    type: string
+                  secretRef:
+                    description: The secret name containing the public keys of all
+                      trusted Git authors.
+                    properties:
+                      name:
+                        description: Name of the referent
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - mode
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            description: GitRepositoryStatus defines the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  repository sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA1 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of this artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: Revision is a human readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm index timestamp, a Helm chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the artifact output of the
+                  last repository sync.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/crds/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/chart/crds/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -1,0 +1,229 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: helmcharts.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: HelmChart
+    listKind: HelmChartList
+    plural: helmcharts
+    singular: helmchart
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.chart
+      name: Chart
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.sourceRef.kind
+      name: Source Kind
+      type: string
+    - jsonPath: .spec.sourceRef.name
+      name: Source Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HelmChart is the Schema for the helmcharts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmChartSpec defines the desired state of a Helm chart.
+            properties:
+              chart:
+                description: The name or path the Helm chart is available at in the
+                  SourceRef.
+                type: string
+              interval:
+                description: The interval at which to check the Source for updates.
+                type: string
+              sourceRef:
+                description: The reference to the Source the chart is available at.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent, valid values are ('HelmRepository',
+                      'GitRepository', 'Bucket').
+                    enum:
+                    - HelmRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              valuesFile:
+                description: Alternative values file to use as the default chart values,
+                  expected to be a relative path in the SourceRef. Ignored when omitted.
+                type: string
+              version:
+                default: '*'
+                description: The chart version semver expression, ignored for charts
+                  from GitRepository and Bucket sources. Defaults to latest when omitted.
+                type: string
+            required:
+            - chart
+            - interval
+            - sourceRef
+            type: object
+          status:
+            description: HelmChartStatus defines the observed state of the HelmChart.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  chart sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA1 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of this artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: Revision is a human readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm index timestamp, a Helm chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmChart.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the last chart pulled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/crds/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/chart/crds/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -1,0 +1,205 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: helmrepositories.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: HelmRepository
+    listKind: HelmRepositoryList
+    plural: helmrepositories
+    singular: helmrepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HelmRepository is the Schema for the helmrepositories API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmRepositorySpec defines the reference to a Helm repository.
+            properties:
+              interval:
+                description: The interval at which to check the upstream for updates.
+                type: string
+              secretRef:
+                description: The name of the secret containing authentication credentials
+                  for the Helm repository. For HTTP/S basic auth the secret must contain
+                  username and password fields. For TLS the secret must contain a
+                  certFile and keyFile, and/or caCert fields.
+                properties:
+                  name:
+                    description: Name of the referent
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout of index downloading, defaults to 60s.
+                type: string
+              url:
+                description: The Helm repository URL, a valid URL contains at least
+                  a protocol and host.
+                type: string
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            description: HelmRepositoryStatus defines the observed state of the HelmRepository.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  repository sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA1 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of this artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: Revision is a human readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm index timestamp, a Helm chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the last index fetched.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,6 @@
+1. Get the application URL by running these commands:
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "source-controller.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,90 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "source-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "source-controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "source-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "source-controller.rbac.fullname" -}}
+{{- (include "source-controller.fullname" .) | replace "-" ":" }}
+{{- end }}
+
+{{/*
+Create common labels to all resources.
+*/}}
+{{- define "source-controller.labels" -}}
+helm.sh/chart: {{ include "source-controller.chart" . }}
+{{ include "source-controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: fluxcd
+app.kubernetes.io/component: source-controller
+control-plane: controller
+{{- end }}
+
+{{/*
+Create selector labels.
+*/}}
+{{- define "source-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "source-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "source-controller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "source-controller.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the appropriate apiVersion for deployments.
+*/}}
+{{- define "source-controller.deployment.apiVersion" -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+
+{{/*
+Create the appropriate apiVersion for rbac.
+*/}}
+{{- define "source-controller.rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/bucket_editor_clusterrole.yaml
+++ b/chart/templates/bucket_editor_clusterrole.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.rbac.create .Values.watchAllNamespaces -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:bucket-editor
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/bucket_editor_role.yaml
+++ b/chart/templates/bucket_editor_role.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.rbac.create (not .Values.watchAllNamespaces) -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:bucket-editor
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/bucket_viewer_clusterrole.yaml
+++ b/chart/templates/bucket_viewer_clusterrole.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create .Values.watchAllNamespaces -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:bucket-viewer
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/bucket_viewer_role.yaml
+++ b/chart/templates/bucket_viewer_role.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create (not .Values.watchAllNamespaces) -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:bucket-viewer
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -1,0 +1,144 @@
+{{- if and .Values.rbac.create .Values.watchAllNamespaces -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:manager
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories/status
+    verbs:
+      - get
+      - patch
+      - update
+{{- end }}

--- a/chart/templates/clusterrolebinding.yaml
+++ b/chart/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rbac.create .Values.watchAllNamespaces -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "source-controller.fullname" . }}-manager
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "source-controller.rbac.fullname" . }}:manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "source-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: {{ include "source-controller.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "source-controller.fullname" . }}
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "source-controller.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "source-controller.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "source-controller.serviceAccountName" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - --watch-all-namespaces={{ default .Values.watchAllNamespaces true }}
+        - --concurrent={{ default .Values.reconcilers 2 }}
+        - --log-level={{ default .Values.logLevel "info" }}
+        - --log-encoding={{ default .Values.logEncoding "json" }}
+        - --enable-leader-election
+        - --storage-path=/data
+        - --storage-adv-addr={{ include "source-controller.fullname" . }}.$(RUNTIME_NAMESPACE).svc.cluster.local.
+        env:
+        - name: RUNTIME_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - name: http
+          containerPort: 9090
+        - name: prometheus
+          containerPort: 8080
+        - name: healthz
+          containerPort: 9440
+        readinessProbe:
+          httpGet:
+              path: /healthz
+              port: healthz
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /data
+          name: data
+        - mountPath: /tmp
+          name: tmp
+      securityContext:
+        fsGroup: 1337
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - emptyDir: {}
+        name: data
+      - emptyDir: {}
+        name: tmp
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/templates/gitrepository_editor_clusterrole.yaml
+++ b/chart/templates/gitrepository_editor_clusterrole.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.rbac.create .Values.watchAllNamespaces -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:gitrepository-editor
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/gitrepository_editor_role.yaml
+++ b/chart/templates/gitrepository_editor_role.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.rbac.create (not .Values.watchAllNamespaces) -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:gitrepository-editor
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/gitrepository_viewer_clusterrole.yaml
+++ b/chart/templates/gitrepository_viewer_clusterrole.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create .Values.watchAllNamespaces -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:gitrepository-viewer
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/gitrepository_viewer_role.yaml
+++ b/chart/templates/gitrepository_viewer_role.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create (not .Values.watchAllNamespaces) -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:gitrepository-viewer
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/helmchart_editor_clusterrole.yaml
+++ b/chart/templates/helmchart_editor_clusterrole.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.rbac.create .Values.watchAllNamespaces -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:helmchart-editor
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/helmchart_editor_role.yaml
+++ b/chart/templates/helmchart_editor_role.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.rbac.create (not .Values.watchAllNamespaces) -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:helmchart-editor
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/helmchart_viewer_clusterrole.yaml
+++ b/chart/templates/helmchart_viewer_clusterrole.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create .Values.watchAllNamespaces -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:helmchart-viewer
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/helmchart_viewer_role.yaml
+++ b/chart/templates/helmchart_viewer_role.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create (not .Values.watchAllNamespaces) -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:helmchart-viewer
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/helmrepository_editor_clusterrole.yaml
+++ b/chart/templates/helmrepository_editor_clusterrole.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.rbac.create .Values.watchAllNamespaces -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:helmrepository-editor
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/helmrepository_editor_role.yaml
+++ b/chart/templates/helmrepository_editor_role.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.rbac.create (not .Values.watchAllNamespaces) -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:helmrepository-editor
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/helmrepository_viewer_clusterrole.yaml
+++ b/chart/templates/helmrepository_viewer_clusterrole.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create .Values.watchAllNamespaces -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:helmrepository-viewer
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/helmrepository_viewer_role.yaml
+++ b/chart/templates/helmrepository_viewer_role.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create (not .Values.watchAllNamespaces) -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:helmrepository-viewer
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories/status
+    verbs:
+      - get
+{{- end }}

--- a/chart/templates/leader_election_role.yaml
+++ b/chart/templates/leader_election_role.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.rbac.create -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:leader-election
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+{{- end }}

--- a/chart/templates/leader_election_rolebinding.yaml
+++ b/chart/templates/leader_election_rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "source-controller.fullname" . }}-leader-election
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "source-controller.rbac.fullname" . }}:leader-election
+subjects:
+- kind: ServiceAccount
+  name: {{ include "source-controller.serviceAccountName" . }}
+{{- end }}

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -1,0 +1,144 @@
+{{- if and .Values.rbac.create (not .Values.watchAllNamespaces) -}}
+apiVersion: {{ include "source-controller.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "source-controller.rbac.fullname" . }}:manager
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories/status
+    verbs:
+      - get
+      - patch
+      - update
+{{- end }}

--- a/chart/templates/rolebinding.yaml
+++ b/chart/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.rbac.create (not .Values.watchAllNamespaces) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "source-controller.fullname" . }}-manager
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "source-controller.rbac.fullname" . }}:manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "source-controller.serviceAccountName" . }}
+{{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "source-controller.fullname" . }}
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "source-controller.selectorLabels" . | nindent 4 }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "source-controller.serviceAccountName" . }}
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/tests/test-service.yaml
+++ b/chart/templates/tests/test-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "source-controller.fullname" . }}-test-service"
+  labels:
+    {{- include "source-controller.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+  - name: service
+    image: busybox
+    command:
+    - wget
+    args:
+    - --tries=5
+    - --timeout=5
+    - --quiet
+    - '{{ include "source-controller.fullname" . }}:{{ .Values.service.port }}'
+  restartPolicy: Never

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,56 @@
+# set the number of replicas; the controller supports leader-election
+replicas: 1
+
+image:
+  repository: fluxcd/source-controller
+  pullPolicy: IfNotPresent
+  # override the image tag, which is the application version by default
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# a value indicating whether or not to watch all namespaces
+watchAllNamespaces: true
+
+# the number of reconcilers per controller type
+reconcilers: 2
+
+# log level and encoding options
+logLevel: info # debug, info, error
+logEncoding: json # json, console
+
+rbac:
+  # a value indicating whether or not to create rbac roles
+  create: true
+
+serviceAccount:
+  # a value indicating whether or not to create a service account
+  create: true
+
+  # additional annotations to add to the service account
+  annotations: {}
+
+  # the name to use for the service account, which is auto-generated if not set
+  name: ""
+
+podAnnotations: {}
+  # prometheus.io/port: "8080"
+  # prometheus.io/scrape: "true"
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}
+  # limits:
+  #   cpu: 1000m
+  #   memory: 1Gi
+  # requests:
+  #   cpu: 50m
+  #   memory: 64Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/hack/sync-chart.sh
+++ b/hack/sync-chart.sh
@@ -1,0 +1,93 @@
+#! /usr/bin/env sh
+
+# Copyright 2020, 2021 The Flux authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+__print_header() {
+    printf 'apiVersion: {{ include "source-controller.rbac.apiVersion" . }}\n'
+    printf 'kind: %s\n' "$1"
+    printf 'metadata:\n'
+    printf '  name: {{ include "source-controller.rbac.fullname" . }}:%s\n' "$2"
+    printf '  labels:\n'
+    printf '    {{- include "source-controller.labels" . | nindent 4 }}\n'
+}
+
+__sync_crds() {
+    # remove existing crds
+    rm -rf chart/crds
+
+    # copy crds from config
+    cp -R config/crd/bases chart/crds
+}
+
+__sync_clusterroles() {
+    # remove existing roles
+    rm -f chart/templates/*_clusterrole.yaml chart/templates/clusterrole.yaml
+    role="./config/rbac/role.yaml"
+
+    find config/rbac -type f -name '*_role.yaml' -or -name 'role.yaml' | while IFS= read -r role; do
+        kind=$(yq e '.kind' "$role" | tr '[:upper:]' '[:lower:]')
+
+        if test "${kind:-'role'}" = "role"; then
+            continue
+        fi
+
+        basename=$(basename "$role")
+        filename=${basename##*.yaml}
+        filename=${basename%role*}
+        filename=${filename}clusterrole.yaml
+
+        name=$(yq e '.metadata.name' "$role")
+        name=${name%-role*}
+
+        {
+            printf '{{- if and .Values.rbac.create .Values.watchAllNamespaces -}}\n'
+            __print_header "ClusterRole" "$name"
+            yq e '.rules | { "rules": . }' "$role"
+            printf '{{- end }}\n'
+        } > "chart/templates/${filename}"
+    done
+}
+
+__sync_roles() {
+    # remove existing roles
+    rm -f chart/templates/*_role.yaml chart/templates/role.yaml
+
+    find config/rbac -type f -name '*_role.yaml' -or -name 'role.yaml' | while IFS= read -r role; do
+        basename=$(basename "$role")
+        filename=${basename##*.yaml}
+        filename=${basename%role*}
+        filename=${filename}role.yaml
+
+        name=$(yq e '.metadata.name' "$role")
+        name=${name%-role*}
+
+        {
+            if test "$name" = "leader-election"; then
+                printf '{{- if and .Values.rbac.create -}}\n'
+            else
+                printf '{{- if and .Values.rbac.create (not .Values.watchAllNamespaces) -}}\n'
+            fi
+            __print_header "Role" "$name"
+            yq e '.rules | { "rules": . }' "$role"
+            printf '{{- end }}\n'
+        } > "chart/templates/${filename}"
+    done
+}
+
+__sync_crds
+__sync_clusterroles
+__sync_roles


### PR DESCRIPTION
* add helm chart for standard deployment
* add hack script to synchronise crds and rbac policies from kustomizations
  - support rbac cluster roles and namespaced roles depending on all namespaces are watched
  - support non-default service account
* update makefile to include support for helm deployments
* update e2e workflow to test both deployment strategies
* add editorconfig to ensure the current spacing is followed in editors

Closes: #313 