### PR TITLE
Set leader election deadline to 30s

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fluxcd/pkg/gitutil v0.0.1
 	github.com/fluxcd/pkg/helmtestserver v0.1.0
 	github.com/fluxcd/pkg/lockedfile v0.0.5
-	github.com/fluxcd/pkg/runtime v0.8.5
+	github.com/fluxcd/pkg/runtime v0.10.1
 	github.com/fluxcd/pkg/ssh v0.0.5
 	github.com/fluxcd/pkg/untar v0.0.5
 	github.com/fluxcd/pkg/version v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/fluxcd/pkg/helmtestserver v0.1.0 h1:RiVVxIHD6PJdKinW46feFIYf1LUj6xXSp
 github.com/fluxcd/pkg/helmtestserver v0.1.0/go.mod h1:3L+tbPn74PsHwHsyhbfk/kZAosrwMFTTA92XEFiwVAE=
 github.com/fluxcd/pkg/lockedfile v0.0.5 h1:C3T8wfdff1UY1bvplmCkGOLrdMWJHO8Q8+tdlEXJYzQ=
 github.com/fluxcd/pkg/lockedfile v0.0.5/go.mod h1:uAtPUBId6a2RqO84MTH5HKGX0SbM1kNW3Wr/FhYyDVA=
-github.com/fluxcd/pkg/runtime v0.8.5 h1:ynh8fszbLQ3QSisQBNOABEUTnvt+/QfCdaL6gOJQcoQ=
-github.com/fluxcd/pkg/runtime v0.8.5/go.mod h1:JD0eZIn5xkTeHHQUWXSqJPIh/ecO0d0qrUKbSVHnpnw=
+github.com/fluxcd/pkg/runtime v0.10.1 h1:NV0pe6lFzodKBIz0dT3xkoR0wJnTCicXwM/v/d5T0+Y=
+github.com/fluxcd/pkg/runtime v0.10.1/go.mod h1:JD0eZIn5xkTeHHQUWXSqJPIh/ecO0d0qrUKbSVHnpnw=
 github.com/fluxcd/pkg/ssh v0.0.5 h1:rnbFZ7voy2JBlUfMbfyqArX2FYaLNpDhccGFC3qW83A=
 github.com/fluxcd/pkg/ssh v0.0.5/go.mod h1:7jXPdXZpc0ttMNz2kD9QuMi3RNn/e0DOFbj0Tij/+Hs=
 github.com/fluxcd/pkg/testserver v0.0.2 h1:SoaMtO9cE5p/wl2zkGudzflnEHd9mk68CGjZOo7w0Uk=


### PR DESCRIPTION
This PR allows fine tuning the leader election with cmd args:

```
--enable-leader-election=true
--leader-election-release-on-cancel=true
--leader-election-lease-duration=35s
--leader-election-renew-deadline=30s
--leader-election-retry-period=5s
```

To make the leader election more tolerant to transient Kubernetes API outages, the renewal deadline was increased from 10s to 30s and the retry interval was bumped to 5 seconds.

Test image:

```
docker.io/stefanprodan/source-controller:ls-config-a034c5d
```

Part of: https://github.com/fluxcd/pkg/issues/94
Ref: https://github.com/fluxcd/source-controller/issues/317 