### PR TITLE
Add support for Git submodules with go-git

### DIFF
--- a/api/v1beta1/gitrepository_types.go
+++ b/api/v1beta1/gitrepository_types.go
@@ -81,6 +81,12 @@ type GitRepositorySpec struct {
 	// +kubebuilder:default:=go-git
 	// +optional
 	GitImplementation string `json:"gitImplementation,omitempty"`
+
+	// When enabled, after the clone is created, initializes all submodules within,
+	// using their default settings.
+	// This option is available only when using the 'go-git' GitImplementation.
+	// +optional
+	RecurseSubmodules bool `json:"recurseSubmodules,omitempty"`
 }
 
 // GitRepositoryRef defines the Git ref used for pull and checkout operations.

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -66,6 +66,11 @@ spec:
               interval:
                 description: The interval at which to check for repository updates.
                 type: string
+              recurseSubmodules:
+                description: When enabled, after the clone is created, initializes
+                  all submodules within, using their default settings. This option
+                  is available only when using the 'go-git' GitImplementation.
+                type: boolean
               ref:
                 description: The Git reference to checkout and monitor for changes,
                   defaults to master branch.

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -183,7 +183,12 @@ func (r *GitRepositoryReconciler) reconcile(ctx context.Context, repository sour
 	// determine auth method
 	auth := &git.Auth{}
 	if repository.Spec.SecretRef != nil {
-		authStrategy, err := strategy.AuthSecretStrategyForURL(repository.Spec.URL, repository.Spec.GitImplementation)
+		authStrategy, err := strategy.AuthSecretStrategyForURL(
+			repository.Spec.URL,
+			git.CheckoutOptions{
+				GitImplementation: repository.Spec.GitImplementation,
+				RecurseSubmodules: repository.Spec.RecurseSubmodules,
+			})
 		if err != nil {
 			return sourcev1.GitRepositoryNotReady(repository, sourcev1.AuthenticationFailedReason, err.Error()), err
 		}
@@ -207,7 +212,12 @@ func (r *GitRepositoryReconciler) reconcile(ctx context.Context, repository sour
 		}
 	}
 
-	checkoutStrategy, err := strategy.CheckoutStrategyForRef(repository.Spec.Reference, repository.Spec.GitImplementation)
+	checkoutStrategy, err := strategy.CheckoutStrategyForRef(
+		repository.Spec.Reference,
+		git.CheckoutOptions{
+			GitImplementation: repository.Spec.GitImplementation,
+			RecurseSubmodules: repository.Spec.RecurseSubmodules,
+		})
 	if err != nil {
 		return sourcev1.GitRepositoryNotReady(repository, sourcev1.GitOperationFailedReason, err.Error()), err
 	}

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -400,6 +400,20 @@ string
 Defaults to go-git, valid values are (&lsquo;go-git&rsquo;, &lsquo;libgit2&rsquo;).</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>recurseSubmodules</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>When enabled, after the clone is created, initializes all submodules within,
+using their default settings.
+This option is available only when using the &lsquo;go-git&rsquo; GitImplementation.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -1244,6 +1258,20 @@ string
 <em>(Optional)</em>
 <p>Determines which git client library to use.
 Defaults to go-git, valid values are (&lsquo;go-git&rsquo;, &lsquo;libgit2&rsquo;).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>recurseSubmodules</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>When enabled, after the clone is created, initializes all submodules within,
+using their default settings.
+This option is available only when using the &lsquo;go-git&rsquo; GitImplementation.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/spec/v1beta1/gitrepositories.md
+++ b/docs/spec/v1beta1/gitrepositories.md
@@ -57,6 +57,11 @@ type GitRepositorySpec struct {
 	// +kubebuilder:default:=go-git
 	// +optional
 	GitImplementation string `json:"gitImplementation,omitempty"`
+	
+	// When enabled, after the clone is created, initializes all submodules within.
+	// This option is available only when using the 'go-git' GitImplementation.
+	// +optional
+	RecurseSubmodules bool `json:"recurseSubmodules,omitempty"`
 }
 ```
 
@@ -433,6 +438,42 @@ kubectl create secret generic pgp-public-keys \
     --from-file=author1.asc \
     --from-file=author2.asc
 ```
+
+### Git submodules
+
+With `spec.recurseSubmodules` you can configure the controller to
+clone a specific branch including its Git submodules:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: repo-with-submodules
+  namespace: default
+spec:
+  interval: 1m
+  url: https://github.com/<organization>/<repository>
+  secretRef:
+    name: https-credentials
+  ref:
+    branch: main
+  recurseSubmodules: true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: https-credentials
+  namespace: default
+type: Opaque
+data:
+  username: <GitHub Username>
+  password: <GitHub Token>
+```
+
+Note that deploy keys can't be used to pull submodules from private repositories
+as GitHub and GitLab doesn't allow a deploy key to be reused across repositories.
+You have to use either HTTPS token-based authentication, or an SSH key belonging
+to a user that has access to the main repository and all its submodules.
 
 ## Status examples
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -40,6 +40,11 @@ type CheckoutStrategy interface {
 	Checkout(ctx context.Context, path, url string, auth *Auth) (Commit, string, error)
 }
 
+type CheckoutOptions struct {
+	GitImplementation string
+	RecurseSubmodules bool
+}
+
 // TODO(hidde): candidate for refactoring, so that we do not directly
 //  depend on implementation specifics here.
 type Auth struct {

--- a/pkg/git/libgit2/checkout.go
+++ b/pkg/git/libgit2/checkout.go
@@ -29,7 +29,7 @@ import (
 	"github.com/fluxcd/source-controller/pkg/git"
 )
 
-func CheckoutStrategyForRef(ref *sourcev1.GitRepositoryRef) git.CheckoutStrategy {
+func CheckoutStrategyForRef(ref *sourcev1.GitRepositoryRef, opt git.CheckoutOptions) git.CheckoutStrategy {
 	switch {
 	case ref == nil:
 		return &CheckoutBranch{branch: git.DefaultBranch}

--- a/pkg/git/strategy/strategy.go
+++ b/pkg/git/strategy/strategy.go
@@ -25,24 +25,24 @@ import (
 	"github.com/fluxcd/source-controller/pkg/git/libgit2"
 )
 
-func CheckoutStrategyForRef(ref *sourcev1.GitRepositoryRef, gitImplementation string) (git.CheckoutStrategy, error) {
-	switch gitImplementation {
+func CheckoutStrategyForRef(ref *sourcev1.GitRepositoryRef, opt git.CheckoutOptions) (git.CheckoutStrategy, error) {
+	switch opt.GitImplementation {
 	case sourcev1.GoGitImplementation:
-		return gogit.CheckoutStrategyForRef(ref), nil
+		return gogit.CheckoutStrategyForRef(ref, opt), nil
 	case sourcev1.LibGit2Implementation:
-		return libgit2.CheckoutStrategyForRef(ref), nil
+		return libgit2.CheckoutStrategyForRef(ref, opt), nil
 	default:
-		return nil, fmt.Errorf("invalid git implementation %s", gitImplementation)
+		return nil, fmt.Errorf("invalid Git implementation %s", opt.GitImplementation)
 	}
 }
 
-func AuthSecretStrategyForURL(url string, gitImplementation string) (git.AuthSecretStrategy, error) {
-	switch gitImplementation {
+func AuthSecretStrategyForURL(url string, opt git.CheckoutOptions) (git.AuthSecretStrategy, error) {
+	switch opt.GitImplementation {
 	case sourcev1.GoGitImplementation:
 		return gogit.AuthSecretStrategyForURL(url)
 	case sourcev1.LibGit2Implementation:
 		return libgit2.AuthSecretStrategyForURL(url)
 	default:
-		return nil, fmt.Errorf("invalid git implementation %s", gitImplementation)
+		return nil, fmt.Errorf("invalid Git implementation %s", opt.GitImplementation)
 	}
 }


### PR DESCRIPTION
This PR adds an optional field `.spec.recurseSubmodules` to the GitRepository API. When enabled, after the clone is created, initializes all submodules within, using their default settings. This option is available only when using the `go-git` GitImplementation.

Fix: #169
Addresses: https://github.com/fluxcd/flux2/discussions/326