### PR TITLE
Add well-known CI configs to exclusion list

### DIFF
--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -42,9 +42,11 @@ import (
 )
 
 const (
-	excludeFile = ".sourceignore"
-	excludeVCS  = ".git/,.gitignore,.gitmodules,.gitattributes"
-	excludeExt  = "*.jpg,*.jpeg,*.gif,*.png,*.wmv,*.flv,*.tar.gz,*.zip"
+	excludeFile  = ".sourceignore"
+	excludeVCS   = ".git/,.gitignore,.gitmodules,.gitattributes"
+	excludeExt   = "*.jpg,*.jpeg,*.gif,*.png,*.wmv,*.flv,*.tar.gz,*.zip"
+	excludeCI    = ".github/,.circleci/,.travis.yml,.gitlab-ci.yml,appveyor.yml,.drone.yml,cloudbuild.yaml,codeship-services.yml,codeship-steps.yml"
+	excludeExtra = "**/.goreleaser.yml,**/.sops.yaml,**/.flux.yaml"
 )
 
 // Storage manages artifacts
@@ -425,7 +427,8 @@ func loadExcludePatterns(dir string, ignore *string) ([]gitignore.Pattern, error
 	}
 
 	if ignore == nil {
-		for _, p := range strings.Split(excludeExt, ",") {
+		all := strings.Join([]string{excludeExt, excludeCI, excludeExtra}, ",")
+		for _, p := range strings.Split(all, ",") {
 			ps = append(ps, gitignore.ParsePattern(p, path))
 		}
 

--- a/controllers/storage_test.go
+++ b/controllers/storage_test.go
@@ -206,6 +206,8 @@ func TestArchiveIgnore(t *testing.T) {
 		"video.wmv",
 		"bar.png",
 		"foo.zip",
+		".drone.yml",
+		".flux.yaml",
 	}
 
 	// this is the table of ignored files and their values. true means that it's

--- a/docs/spec/v1beta1/buckets.md
+++ b/docs/spec/v1beta1/buckets.md
@@ -114,9 +114,13 @@ in a gzip compressed TAR archive (`<bucket checksum>.tar.gz`).
 
 ### Excluding files
 
-Git files (`.git/`, `.gitignore`, `.gitmodules`, and `.gitattributes`) are
-excluded from the archive by default, as well as some extensions (`.jpg, .jpeg,
-.gif, .png, .wmv, .flv, .tar.gz, .zip`)
+The following files and extensions are excluded from the archive by default:
+
+- Git files (`.git/ ,.gitignore, .gitmodules, .gitattributes`)
+- File extensions (`.jpg, .jpeg, .gif, .png, .wmv, .flv, .tar.gz, .zip`)
+- CI configs (`.github/, .circleci/, .travis.yml, .gitlab-ci.yml, appveyor.yml, .drone.yml, cloudbuild.yaml, codeship-services.yml, codeship-steps.yml`)
+- CLI configs (`.goreleaser.yml, .sops.yaml`)
+- Flux v1 config (`.flux.yaml`)
 
 Excluding additional files from the archive is possible by adding a
 `.sourceignore` file in the root of the bucket. The `.sourceignore` file

--- a/docs/spec/v1beta1/gitrepositories.md
+++ b/docs/spec/v1beta1/gitrepositories.md
@@ -149,9 +149,13 @@ gzip compressed TAR archive (`<commit hash>.tar.gz`).
 
 ### Excluding files
 
-Git files (`.git/`, `.gitignore`, `.gitmodules`, and `.gitattributes`) are
-excluded from the archive by default, as well as some extensions (`.jpg, .jpeg,
-.gif, .png, .wmv, .flv, .tar.gz, .zip`)
+The following files and extensions are excluded from the archive by default:
+
+- Git files (`.git/ ,.gitignore, .gitmodules, .gitattributes`)
+- File extensions (`.jpg, .jpeg, .gif, .png, .wmv, .flv, .tar.gz, .zip`)
+- CI configs (`.github/, .circleci/, .travis.yml, .gitlab-ci.yml, appveyor.yml, .drone.yml, cloudbuild.yaml, codeship-services.yml, codeship-steps.yml`)
+- CLI configs (`.goreleaser.yml, .sops.yaml`)  
+- Flux v1 config (`.flux.yaml`)
 
 Excluding additional files from the archive is possible by adding a
 `.sourceignore` file in the root of the repository. The `.sourceignore` file


### PR DESCRIPTION
This PR adds the following exclusions to the default list:
- CI configs (`.github/, .circleci/, .travis.yml, .gitlab-ci.yml, appveyor.yml, .drone.yml, cloudbuild.yaml, codeship-services.yml, codeship-steps.yml`)
- CLI configs (`.goreleaser.yml, .sops.yaml`)
- Flux v1 config (`.flux.yaml`)