### PR TITLE
Add shortName to gitrepositories

### DIFF
--- a/api/v1beta1/gitrepository_types.go
+++ b/api/v1beta1/gitrepository_types.go
@@ -211,6 +211,7 @@ func (in *GitRepository) GetInterval() metav1.Duration {
 // +genclient
 // +genclient:Namespaced
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=gitrepo
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""

--- a/api/v1beta1/helmchart_types.go
+++ b/api/v1beta1/helmchart_types.go
@@ -171,6 +171,7 @@ func (in *HelmChart) GetInterval() metav1.Duration {
 // +genclient
 // +genclient:Namespaced
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=hc
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Chart",type=string,JSONPath=`.spec.chart`
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.version`

--- a/api/v1beta1/helmrepository_types.go
+++ b/api/v1beta1/helmrepository_types.go
@@ -150,6 +150,7 @@ func (in *HelmRepository) GetInterval() metav1.Duration {
 // +genclient
 // +genclient:Namespaced
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=helmrepo
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -13,6 +13,8 @@ spec:
     kind: GitRepository
     listKind: GitRepositoryList
     plural: gitrepositories
+    shortNames:
+    - gitrepo
     singular: gitrepository
   scope: Namespaced
   versions:

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -13,6 +13,8 @@ spec:
     kind: HelmChart
     listKind: HelmChartList
     plural: helmcharts
+    shortNames:
+    - hc
     singular: helmchart
   scope: Namespaced
   versions:

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -13,6 +13,8 @@ spec:
     kind: HelmRepository
     listKind: HelmRepositoryList
     plural: helmrepositories
+    shortNames:
+    - helmrepo
     singular: helmrepository
   scope: Namespaced
   versions:


### PR DESCRIPTION
Adding `gr` as a shortName, similar to how kustomizations has `ks`:
https://github.com/fluxcd/kustomize-controller/blob/2f2812636448cd27ddc5b4a8af1a333cbebf89ce/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml#L17

Not sure if this is the only change required for this, but would love to know if I am missing something. 