### PR TITLE
Check ignore matches before Bucket item downloads

### DIFF
--- a/.github/actions/run-tests/Dockerfile
+++ b/.github/actions/run-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine
+FROM golang:1.16-alpine
 
 # Add any build or testing essential system packages
 RUN apk add --no-cache build-base git pkgconf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Docker buildkit multi-arch build requires golang alpine
-FROM golang:1.15-alpine as builder
+FROM golang:1.16-alpine as builder
 
 RUN apk add gcc pkgconfig libc-dev
 RUN apk add --no-cache musl~=1.2 libgit2-dev~=1.1

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/source-controller/api
 
-go 1.15
+go 1.16
 
 require (
 	github.com/fluxcd/pkg/apis/meta v0.8.0

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -40,14 +40,6 @@ import (
 	"github.com/fluxcd/source-controller/pkg/sourceignore"
 )
 
-const (
-	excludeFile  = ".sourceignore"
-	excludeVCS   = ".git/,.gitignore,.gitmodules,.gitattributes"
-	excludeExt   = "*.jpg,*.jpeg,*.gif,*.png,*.wmv,*.flv,*.tar.gz,*.zip"
-	excludeCI    = ".github/,.circleci/,.travis.yml,.gitlab-ci.yml,appveyor.yml,.drone.yml,cloudbuild.yaml,codeship-services.yml,codeship-steps.yml"
-	excludeExtra = "**/.goreleaser.yml,**/.sops.yaml,**/.flux.yaml"
-)
-
 // Storage manages artifacts
 type Storage struct {
 	// BasePath is the local directory path where the source artifacts are stored.
@@ -150,19 +142,35 @@ func (s *Storage) ArtifactExist(artifact sourcev1.Artifact) bool {
 	return fi.Mode().IsRegular()
 }
 
-// Archive atomically archives the given directory as a tarball to the given v1beta1.Artifact
-// path, excluding any VCS specific files and directories, or any of the excludes defined in
-// the excludeFiles. If successful, it sets the checksum and last update time on the artifact.
-func (s *Storage) Archive(artifact *sourcev1.Artifact, dir string, ignore *string) (err error) {
+// ArchiveFileFilter must return true if a file should not be included
+// in the archive after inspecting the given path and/or os.FileInfo.
+type ArchiveFileFilter func(p string, fi os.FileInfo) bool
+
+// SourceIgnoreFilter returns an ArchiveFileFilter that filters out
+// files matching sourceignore.VCSPatterns and any of the provided
+// patterns. If an empty gitignore.Pattern slice is given, the matcher
+// is set to sourceignore.NewDefaultMatcher.
+func SourceIgnoreFilter(ps []gitignore.Pattern, domain []string) ArchiveFileFilter {
+	matcher := sourceignore.NewDefaultMatcher(ps, domain)
+	if len(ps) > 0 {
+		ps = append(sourceignore.VCSPatterns(domain), ps...)
+		matcher = sourceignore.NewMatcher(ps)
+	}
+	return func(p string, fi os.FileInfo) bool {
+		// The directory is always false as the archiver does already skip
+		// directories.
+		return matcher.Match(strings.Split(p, string(filepath.Separator)), false)
+	}
+}
+
+// Archive atomically archives the given directory as a tarball to the
+// given v1beta1.Artifact path, excluding directories and any
+// ArchiveFileFilter matches. If successful, it sets the checksum and
+// last update time on the artifact.
+func (s *Storage) Archive(artifact *sourcev1.Artifact, dir string, filter ArchiveFileFilter) (err error) {
 	if f, err := os.Stat(dir); os.IsNotExist(err) || !f.IsDir() {
 		return fmt.Errorf("invalid dir path: %s", dir)
 	}
-
-	ps, err := sourceignore.LoadExcludePatterns(dir, ignore)
-	if err != nil {
-		return err
-	}
-	matcher := sourceignore.NewMatcher(ps)
 
 	localPath := s.LocalPath(*artifact)
 	tf, err := ioutil.TempFile(filepath.Split(localPath))
@@ -181,7 +189,52 @@ func (s *Storage) Archive(artifact *sourcev1.Artifact, dir string, ignore *strin
 
 	gw := gzip.NewWriter(mw)
 	tw := tar.NewWriter(gw)
-	if err := writeToArchiveExcludeMatches(dir, matcher, tw); err != nil {
+	if err := filepath.Walk(dir, func(p string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Ignore anything that is not a file (directories, symlinks)
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
+
+		// Skip filtered files
+		if filter != nil && filter(p, fi) {
+			return nil
+		}
+
+		header, err := tar.FileInfoHeader(fi, p)
+		if err != nil {
+			return err
+		}
+		// The name needs to be modified to maintain directory structure
+		// as tar.FileInfoHeader only has access to the base name of the file.
+		// Ref: https://golang.org/src/archive/tar/common.go?#L626
+		relFilePath := p
+		if filepath.IsAbs(dir) {
+			relFilePath, err = filepath.Rel(dir, p)
+			if err != nil {
+				return err
+			}
+		}
+		header.Name = relFilePath
+
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		f, err := os.Open(p)
+		if err != nil {
+			f.Close()
+			return err
+		}
+		if _, err := io.Copy(tw, f); err != nil {
+			f.Close()
+			return err
+		}
+		return f.Close()
+	}); err != nil {
 		tw.Close()
 		gw.Close()
 		tf.Close()
@@ -212,58 +265,6 @@ func (s *Storage) Archive(artifact *sourcev1.Artifact, dir string, ignore *strin
 	artifact.Checksum = fmt.Sprintf("%x", h.Sum(nil))
 	artifact.LastUpdateTime = metav1.Now()
 	return nil
-}
-
-// writeToArchiveExcludeMatches walks over the given dir and writes any regular file that does
-// not match the given gitignore.Matcher.
-func writeToArchiveExcludeMatches(dir string, matcher gitignore.Matcher, writer *tar.Writer) error {
-	fn := func(p string, fi os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		// Ignore anything that is not a file (directories, symlinks)
-		if !fi.Mode().IsRegular() {
-			return nil
-		}
-
-		// Ignore excluded extensions and files
-		if matcher.Match(strings.Split(p, "/"), false) {
-			return nil
-		}
-
-		header, err := tar.FileInfoHeader(fi, p)
-		if err != nil {
-			return err
-		}
-		// The name needs to be modified to maintain directory structure
-		// as tar.FileInfoHeader only has access to the base name of the file.
-		// Ref: https://golang.org/src/archive/tar/common.go?#L626
-		relFilePath := p
-		if filepath.IsAbs(dir) {
-			relFilePath, err = filepath.Rel(dir, p)
-			if err != nil {
-				return err
-			}
-		}
-		header.Name = relFilePath
-
-		if err := writer.WriteHeader(header); err != nil {
-			return err
-		}
-
-		f, err := os.Open(p)
-		if err != nil {
-			f.Close()
-			return err
-		}
-		if _, err := io.Copy(writer, f); err != nil {
-			f.Close()
-			return err
-		}
-		return f.Close()
-	}
-	return filepath.Walk(dir, fn)
 }
 
 // AtomicWriteFile atomically writes the io.Reader contents to the v1beta1.Artifact path.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/source-controller
 
-go 1.15
+go 1.16
 
 replace github.com/fluxcd/source-controller/api => ./api
 

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+	gotest.tools v2.2.0+incompatible
 	helm.sh/helm/v3 v3.5.3
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2

--- a/pkg/sourceignore/sourceignore.go
+++ b/pkg/sourceignore/sourceignore.go
@@ -18,8 +18,8 @@ package sourceignore
 
 import (
 	"bufio"
-	"bytes"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	ExcludeFile  = ".sourceignore"
+	IgnoreFile   = ".sourceignore"
 	ExcludeVCS   = ".git/,.gitignore,.gitmodules,.gitattributes"
 	ExcludeExt   = "*.jpg,*.jpeg,*.gif,*.png,*.wmv,*.flv,*.tar.gz,*.zip"
 	ExcludeCI    = ".github/,.circleci/,.travis.yml,.gitlab-ci.yml,appveyor.yml,.drone.yml,cloudbuild.yaml,codeship-services.yml,codeship-steps.yml"
@@ -41,47 +41,85 @@ func NewMatcher(ps []gitignore.Pattern) gitignore.Matcher {
 	return gitignore.NewMatcher(ps)
 }
 
-// GetPatterns collects ignore patterns from the given reader and
-// returns them as a gitignore.Pattern slice.
-func GetPatterns(reader io.Reader, path []string) []gitignore.Pattern {
+// NewDefaultMatcher returns a gitignore.Matcher with the DefaultPatterns
+// as lowest priority patterns.
+func NewDefaultMatcher(ps []gitignore.Pattern, domain []string) gitignore.Matcher {
+	var defaultPs []gitignore.Pattern
+	defaultPs = append(defaultPs, VCSPatterns(domain)...)
+	defaultPs = append(defaultPs, DefaultPatterns(domain)...)
+	ps = append(defaultPs, ps...)
+	return gitignore.NewMatcher(ps)
+}
+
+// VCSPatterns returns a gitignore.Pattern slice with ExcludeVCS
+// patterns.
+func VCSPatterns(domain []string) []gitignore.Pattern {
 	var ps []gitignore.Pattern
-	scanner := bufio.NewScanner(reader)
-
-	for scanner.Scan() {
-		s := scanner.Text()
-		if !strings.HasPrefix(s, "#") && len(strings.TrimSpace(s)) > 0 {
-			ps = append(ps, gitignore.ParsePattern(s, path))
-		}
+	for _, p := range strings.Split(ExcludeVCS, ",") {
+		ps = append(ps, gitignore.ParsePattern(p, domain))
 	}
-
 	return ps
 }
 
-// LoadExcludePatterns loads the excluded patterns from .sourceignore or other
-// sources and returns the gitignore.Pattern slice.
-func LoadExcludePatterns(dir string, ignore *string) ([]gitignore.Pattern, error) {
-	path := strings.Split(dir, "/")
-
+// DefaultPatterns returns a gitignore.Pattern slice with the default
+// ExcludeExt, ExcludeCI, ExcludeExtra patterns.
+func DefaultPatterns(domain []string) []gitignore.Pattern {
+	all := strings.Join([]string{ExcludeExt, ExcludeCI, ExcludeExtra}, ",")
 	var ps []gitignore.Pattern
-	for _, p := range strings.Split(ExcludeVCS, ",") {
-		ps = append(ps, gitignore.ParsePattern(p, path))
+	for _, p := range strings.Split(all, ",") {
+		ps = append(ps, gitignore.ParsePattern(p, domain))
 	}
+	return ps
+}
 
-	if ignore == nil {
-		all := strings.Join([]string{ExcludeExt, ExcludeCI, ExcludeExtra}, ",")
-		for _, p := range strings.Split(all, ",") {
-			ps = append(ps, gitignore.ParsePattern(p, path))
+// ReadPatterns collects ignore patterns from the given reader and
+// returns them as a gitignore.Pattern slice.
+// If a domain is supplied, this is used as the scope of the read
+// patterns.
+func ReadPatterns(reader io.Reader, domain []string) []gitignore.Pattern {
+	var ps []gitignore.Pattern
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		s := scanner.Text()
+		if !strings.HasPrefix(s, "#") && len(strings.TrimSpace(s)) > 0 {
+			ps = append(ps, gitignore.ParsePattern(s, domain))
 		}
-
-		if f, err := os.Open(filepath.Join(dir, ExcludeFile)); err == nil {
-			defer f.Close()
-			ps = append(ps, GetPatterns(f, path)...)
-		} else if !os.IsNotExist(err) {
-			return nil, err
-		}
-	} else {
-		ps = append(ps, GetPatterns(bytes.NewBufferString(*ignore), path)...)
 	}
+	return ps
+}
 
+// ReadIgnoreFile attempts to read the file at the given path and
+// returns the read patterns.
+func ReadIgnoreFile(path string, domain []string) ([]gitignore.Pattern, error) {
+	var ps []gitignore.Pattern
+	if f, err := os.Open(path); err == nil {
+		defer f.Close()
+		ps = append(ps, ReadPatterns(f, domain)...)
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	return ps, nil
+}
+
+// LoadIgnorePatterns recursively loads the the IgnoreFile patterns found
+// in the directory.
+func LoadIgnorePatterns(dir string, domain []string) ([]gitignore.Pattern, error) {
+	ps, err := ReadIgnoreFile(filepath.Join(dir, IgnoreFile), domain)
+	if err != nil {
+		return nil, err
+	}
+	fis, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, fi := range fis {
+		if fi.IsDir() && fi.Name() != ".git" {
+			var subps []gitignore.Pattern
+			subps, err = LoadIgnorePatterns(filepath.Join(dir, fi.Name()), append(domain, fi.Name()))
+			if len(subps) > 0 {
+				ps = append(ps, subps...)
+			}
+		}
+	}
 	return ps, nil
 }

--- a/pkg/sourceignore/sourceignore.go
+++ b/pkg/sourceignore/sourceignore.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sourceignore
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+)
+
+const (
+	ExcludeFile  = ".sourceignore"
+	ExcludeVCS   = ".git/,.gitignore,.gitmodules,.gitattributes"
+	ExcludeExt   = "*.jpg,*.jpeg,*.gif,*.png,*.wmv,*.flv,*.tar.gz,*.zip"
+	ExcludeCI    = ".github/,.circleci/,.travis.yml,.gitlab-ci.yml,appveyor.yml,.drone.yml,cloudbuild.yaml,codeship-services.yml,codeship-steps.yml"
+	ExcludeExtra = "**/.goreleaser.yml,**/.sops.yaml,**/.flux.yaml"
+)
+
+// NewMatcher returns a gitignore.Matcher for the given gitignore.Pattern
+// slice. It mainly exists to compliment the API.
+func NewMatcher(ps []gitignore.Pattern) gitignore.Matcher {
+	return gitignore.NewMatcher(ps)
+}
+
+// GetPatterns collects ignore patterns from the given reader and
+// returns them as a gitignore.Pattern slice.
+func GetPatterns(reader io.Reader, path []string) []gitignore.Pattern {
+	var ps []gitignore.Pattern
+	scanner := bufio.NewScanner(reader)
+
+	for scanner.Scan() {
+		s := scanner.Text()
+		if !strings.HasPrefix(s, "#") && len(strings.TrimSpace(s)) > 0 {
+			ps = append(ps, gitignore.ParsePattern(s, path))
+		}
+	}
+
+	return ps
+}
+
+// LoadExcludePatterns loads the excluded patterns from .sourceignore or other
+// sources and returns the gitignore.Pattern slice.
+func LoadExcludePatterns(dir string, ignore *string) ([]gitignore.Pattern, error) {
+	path := strings.Split(dir, "/")
+
+	var ps []gitignore.Pattern
+	for _, p := range strings.Split(ExcludeVCS, ",") {
+		ps = append(ps, gitignore.ParsePattern(p, path))
+	}
+
+	if ignore == nil {
+		all := strings.Join([]string{ExcludeExt, ExcludeCI, ExcludeExtra}, ",")
+		for _, p := range strings.Split(all, ",") {
+			ps = append(ps, gitignore.ParsePattern(p, path))
+		}
+
+		if f, err := os.Open(filepath.Join(dir, ExcludeFile)); err == nil {
+			defer f.Close()
+			ps = append(ps, GetPatterns(f, path)...)
+		} else if !os.IsNotExist(err) {
+			return nil, err
+		}
+	} else {
+		ps = append(ps, GetPatterns(bytes.NewBufferString(*ignore), path)...)
+	}
+
+	return ps, nil
+}

--- a/pkg/sourceignore/sourceignore_test.go
+++ b/pkg/sourceignore/sourceignore_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sourceignore
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+	"gotest.tools/assert"
+)
+
+func TestReadPatterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		ignore     string
+		domain     []string
+		matches    []string
+		mismatches []string
+	}{
+		{
+			name: "simple",
+			ignore: `ignore-dir/*
+!ignore-dir/include
+`,
+			matches:    []string{"ignore-dir/file.yaml"},
+			mismatches: []string{"file.yaml", "ignore-dir/include"},
+		},
+		{
+			name: "with comments",
+			ignore: `ignore-dir/*
+# !ignore-dir/include`,
+			matches: []string{"ignore-dir/file.yaml", "ignore-dir/include"},
+		},
+		{
+			name:       "domain scoped",
+			domain:     []string{"domain", "scoped"},
+			ignore:     "ignore-dir/*",
+			matches:    []string{"domain/scoped/ignore-dir/file.yaml"},
+			mismatches: []string{"ignore-dir/file.yaml"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := strings.NewReader(tt.ignore)
+			ps := ReadPatterns(reader, tt.domain)
+			matcher := NewMatcher(ps)
+			for _, m := range tt.matches {
+				assert.Equal(t, matcher.Match(strings.Split(m, "/"), false), true, "expected %s to match", m)
+			}
+			for _, m := range tt.mismatches {
+				assert.Equal(t, matcher.Match(strings.Split(m, "/"), false), false, "expected %s to not match", m)
+			}
+		})
+	}
+}
+
+func TestReadIgnoreFile(t *testing.T) {
+	f, err := ioutil.TempFile("", IgnoreFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err = f.Write([]byte(`# .sourceignore
+ignore-this.txt`)); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	tests := []struct {
+		name   string
+		path   string
+		domain []string
+		want   []gitignore.Pattern
+	}{
+		{
+			name: IgnoreFile,
+			path: f.Name(),
+			want: []gitignore.Pattern{
+				gitignore.ParsePattern("ignore-this.txt", nil),
+			},
+		},
+		{
+			name:   "with domain",
+			path:   f.Name(),
+			domain: strings.Split(filepath.Dir(f.Name()), string(filepath.Separator)),
+			want: []gitignore.Pattern{
+				gitignore.ParsePattern("ignore-this.txt", strings.Split(filepath.Dir(f.Name()), string(filepath.Separator))),
+			},
+		},
+		{
+			name: "non existing",
+			path: "",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReadIgnoreFile(tt.path, tt.domain)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReadIgnoreFile() got = %d, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVCSPatterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		domain     []string
+		patterns   []gitignore.Pattern
+		matches    []string
+		mismatches []string
+	}{
+		{
+			name:       "simple matches",
+			matches:    []string{".git/config", ".gitignore"},
+			mismatches: []string{"workload.yaml", "workload.yml", "simple.txt"},
+		},
+		{
+			name:       "domain scoped matches",
+			domain:     []string{"directory"},
+			matches:    []string{"directory/.git/config", "directory/.gitignore"},
+			mismatches: []string{"other/.git/config"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := NewDefaultMatcher(tt.patterns, tt.domain)
+			for _, m := range tt.matches {
+				assert.Equal(t, matcher.Match(strings.Split(m, "/"), false), true, "expected %s to match", m)
+			}
+			for _, m := range tt.mismatches {
+				assert.Equal(t, matcher.Match(strings.Split(m, "/"), false), false, "expected %s to not match", m)
+			}
+		})
+	}
+}
+
+func TestDefaultPatterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		domain     []string
+		patterns   []gitignore.Pattern
+		matches    []string
+		mismatches []string
+	}{
+		{
+			name:       "simple matches",
+			matches:    []string{"image.jpg", "archive.tar.gz", ".github/workflows/workflow.yaml", "subdir/.flux.yaml", "subdir2/.sops.yaml"},
+			mismatches: []string{"workload.yaml", "workload.yml", "simple.txt"},
+		},
+		{
+			name:       "domain scoped matches",
+			domain:     []string{"directory"},
+			matches:    []string{"directory/image.jpg", "directory/archive.tar.gz"},
+			mismatches: []string{"other/image.jpg", "other/archive.tar.gz"},
+		},
+		{
+			name:       "patterns",
+			patterns:   []gitignore.Pattern{gitignore.ParsePattern("!*.jpg", nil)},
+			mismatches: []string{"image.jpg"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := NewDefaultMatcher(tt.patterns, tt.domain)
+			for _, m := range tt.matches {
+				assert.Equal(t, matcher.Match(strings.Split(m, "/"), false), true, "expected %s to match", m)
+			}
+			for _, m := range tt.mismatches {
+				assert.Equal(t, matcher.Match(strings.Split(m, "/"), false), false, "expected %s to not match", m)
+			}
+		})
+	}
+}
+
+func TestLoadExcludePatterns(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "sourceignore-load-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	files := map[string]string{
+		".sourceignore":     "root.txt",
+		"d/.gitignore":      "ignored",
+		"z/.sourceignore":   "last.txt",
+		"a/b/.sourceignore": "subdir.txt",
+	}
+	for n, c := range files {
+		if err = os.MkdirAll(filepath.Join(tmpDir, filepath.Dir(n)), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err = os.WriteFile(filepath.Join(tmpDir, n), []byte(c), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tests := []struct {
+		name   string
+		dir    string
+		domain []string
+		want   []gitignore.Pattern
+	}{
+		{
+			name: "traverse loads",
+			dir:  tmpDir,
+			want: []gitignore.Pattern{
+				gitignore.ParsePattern("root.txt", nil),
+				gitignore.ParsePattern("subdir.txt", []string{"a", "b"}),
+				gitignore.ParsePattern("last.txt", []string{"z"}),
+			},
+		},
+		{
+			name:   "domain",
+			dir:    tmpDir,
+			domain: strings.Split(tmpDir, string(filepath.Separator)),
+			want: []gitignore.Pattern{
+				gitignore.ParsePattern("root.txt", strings.Split(tmpDir, string(filepath.Separator))),
+				gitignore.ParsePattern("subdir.txt", append(strings.Split(tmpDir, string(filepath.Separator)), "a", "b")),
+				gitignore.ParsePattern("last.txt", append(strings.Split(tmpDir, string(filepath.Separator)), "z")),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LoadIgnorePatterns(tt.dir, tt.domain)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("LoadIgnorePatterns() got = %#v, want %#v", got, tt.want)
+				for _, v := range got {
+					t.Error(v)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #333 

This PR makes the `BucketReconciler` more efficient by looking for
exclusions while downloading files, instead of during the archiving of
the downloaded contents.

It also makes the filtering applied during the archiving
configurable by introducing an optional `ArchiveFileFilter`
callback argument and a `SourceIgnoreFilter` implementation.

`SourceIgnoreFilter` filters out files matching
sourceignore.VCSPatterns and any of the provided patterns.
If an empty gitignore.Pattern slice is given, the matcher is set to
sourceignore.NewDefaultMatcher.

The `GitRepositoryReconciler` now loads the ignore patterns
before archiving the repository contents by calling
`sourceignore.LoadIgnorePatterns` and other helpers. The loading
behavior is **breaking** as `.sourceignore` files in the (subdirectories of the)
repository are now still taken into account if `spec.ignore` for a resource
is defined, overwriting is still possible by creating an overwriting rule 
in the `spec.ignore` of the resource.