### PR TITLE
Split bucket item key by `/` to satisfy matcher

### DIFF
--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -236,7 +236,7 @@ func (r *BucketReconciler) reconcile(ctx context.Context, bucket sourcev1.Bucket
 			continue
 		}
 
-		if matcher.Match([]string{object.Key}, false) {
+		if matcher.Match(strings.Split(object.Key, "/"), false) {
 			continue
 		}
 


### PR DESCRIPTION
Image available for testing at `docker.io/hiddeco/source-controller:bucket-ignore`.

Needs additional test coverage before merge to ensure the issue doesn't arise again in the future.