### PR TITLE
Fix GitRepository include for nested paths

### DIFF
--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -756,6 +756,12 @@ var _ = Describe("GitRepositoryReconciler", func() {
 				createFiles: []string{"dir1", "dir2"},
 				checkFiles:  []string{"sub/dir1", "sub/dir2"},
 			}),
+			Entry("to nested path", includeTestCase{
+				fromPath:    "",
+				toPath:      "sub/nested",
+				createFiles: []string{"dir1", "dir2"},
+				checkFiles:  []string{"sub/nested/dir1", "sub/nested/dir2"},
+			}),
 			Entry("from and to path", includeTestCase{
 				fromPath:    "nested",
 				toPath:      "sub",

--- a/docs/spec/v1beta1/gitrepositories.md
+++ b/docs/spec/v1beta1/gitrepositories.md
@@ -62,6 +62,9 @@ type GitRepositorySpec struct {
 	// This option is available only when using the 'go-git' GitImplementation.
 	// +optional
 	RecurseSubmodules bool `json:"recurseSubmodules,omitempty"`
+
+	// Extra git repositories to map into the repository
+	Include []GitRepositoryInclude `json:"include,omitempty"`
 }
 ```
 
@@ -529,8 +532,8 @@ spec:
   include:
     - repository:
         name: app-repo
-      from: deploy/kubernetes
-      to: base/app
+      fromPath: deploy/kubernetes
+      toPath: base/app
 ---
 apiVersion: v1
 kind: Secret
@@ -543,9 +546,9 @@ data:
   password: <GitHub Token>
 ```
 
-The `from` and `to` parameters allows you to limit the files included and where they will be
-copied to in the main repository. If you do not specify a value for `from` all files in the
-repository will be included. The `to` value will default to the name of the repository.
+The `fromPath` and `toPath` parameters allows you to limit the files included and where they will be
+copied to in the main repository. If you do not specify a value for `fromPath` all files in the
+repository will be included. The `toPath` value will default to the name of the repository.
 
 ## Status examples
 


### PR DESCRIPTION
Bug fixes:
- when setting `toPath` to a nested one, it errors out with `no such file or directory`, fixed by creating the parent dir
- docs were not in sync with the actual API, replaced `to/from` with `toPath/fromPath`