### PR TITLE
Update go-git to v5.4.2

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -97,6 +97,11 @@ jobs:
           kubectl -n source-system apply -f ./config/testdata/helmchart-from-bucket/source.yaml
           kubectl -n source-system wait bucket/charts --for=condition=ready --timeout=1m
           kubectl -n source-system wait helmchart/helmchart-bucket --for=condition=ready --timeout=1m
+      - name: Run large Git repo tests
+        run: |
+          kubectl -n source-system apply -f ./config/testdata/git/large-repo.yaml
+          kubectl -n source-system wait gitrepository/large-repo-go-git --for=condition=ready --timeout=2m
+          kubectl -n source-system wait gitrepository/large-repo-libgit2 --for=condition=ready --timeout=2m
       - name: Logs
         run: |
           kubectl -n source-system logs deploy/source-controller

--- a/config/testdata/git/large-repo.yaml
+++ b/config/testdata/git/large-repo.yaml
@@ -1,0 +1,27 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: large-repo-go-git
+spec:
+  gitImplementation: go-git
+  interval: 10m
+  url: https://github.com/hashgraph/hedera-mirror-node.git
+  ref:
+    branch: master
+  ignore: |
+    /*
+    !/charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: large-repo-libgit2
+spec:
+  gitImplementation: libgit2
+  interval: 10m
+  url: https://github.com/hashgraph/hedera-mirror-node.git
+  ref:
+    branch: master
+  ignore: |
+    /*
+    !/charts

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/fluxcd/pkg/version v0.0.1
 	github.com/fluxcd/source-controller/api v0.13.1
 	github.com/go-git/go-billy/v5 v5.3.1
-	github.com/go-git/go-git/v5 v5.4.1
+	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v0.4.0
 	github.com/libgit2/git2go/v31 v31.4.14
 	github.com/minio/minio-go/v7 v7.0.10

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/go-git/go-billy/v5 v5.3.1 h1:CPiOUAzKtMRvolEKw+bG1PLRpT7D3LIs3/3ey4Ai
 github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-git-fixtures/v4 v4.2.1 h1:n9gGL1Ct/yIw+nfsfr8s4+sbhT+Ncu2SubfXjIWgci8=
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
-github.com/go-git/go-git/v5 v5.4.1 h1:2RJXJuTMac944e419pJJJ3mOJBcr3A3M6SN6wQKZ/Gs=
-github.com/go-git/go-git/v5 v5.4.1/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
+github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
+github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=


### PR DESCRIPTION
This should resolve `object not found` and
`empty git-upload-pack given` errors that were thrown for Git
repositories that used to work fine before the `v0.13.0` release.

Fixes #369 