### PR TITLE
Use `binutils-gold` in builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # Docker buildkit multi-arch build requires golang alpine
 FROM golang:1.16-alpine as builder
 
-RUN apk add gcc pkgconfig libc-dev
-RUN apk add --no-cache musl~=1.2 libgit2-dev~=1.1
+RUN apk add --no-cache gcc pkgconfig libc-dev binutils-gold musl~=1.2 libgit2-dev~=1.1
 
 WORKDIR /workspace
 


### PR DESCRIPTION
There seems to have been a change in the dependencies that now causes
ARMv7 builds to fail:

```
    sigs.k8s.io/kustomize/kyaml/yaml/merge3=$WORK/b742/_pkg_.a
    sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/util/errors=$WORK/b678/_pkg_.a
    -importcfg $WORK/b001/importcfg.link -buildmode=exe
-buildid=YHfd11eGufJ7RVGSGz2z/H9JgY3lbjsdhQ8_r06Gz/HiYQEtSgCAIHJ7rrNYN6/YHfd11eGufJ7RVGSGz2z
-extld=gcc $WORK/b001/_pkg_.a
    exit status 1
    -c CGO_ENABLED=1 go build -x -o source-controller main.go]: exit
code: 2
```

After trying various things, including downgrading Go, using
packages from `edge`, using `gcc-go` to get a "grouped" version of
the dependencies, it seems that using `binutils-gold` solves the issue
and produces a working build for all our target architectures.

---

- Force-upgrading `kyaml` to see if this solves the issue was attempted in https://github.com/fluxcd/source-controller/runs/2776729515, but failed.
- "Nightly" build was run for the `1.13.2` release to confirm it is due to a change in dependencies: https://github.com/fluxcd/source-controller/runs/2777110279