### PR TITLE
Use libgit2 from "unstable" / "sid"

### DIFF
--- a/.github/actions/run-tests/Dockerfile
+++ b/.github/actions/run-tests/Dockerfile
@@ -1,13 +1,23 @@
-FROM golang:1.16-alpine
+FROM golang:1.16-buster as builder
 
-# Add any build or testing essential system packages
-RUN apk add --no-cache build-base git pkgconf
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libgit2-dev~=1.1
+# Up-to-date libgit2 dependencies are only available in
+# unstable, as libssh2 in testing/bullseye has been linked
+# against gcrypt which causes issues with PKCS* formats.
+# Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=668271
+RUN echo "deb http://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
+    && echo "deb-src http://deb.debian.org/debian unstable main" >> /etc/apt/sources.list
+RUN set -eux; \
+    apt-get update \
+    && apt-get install -y libgit2-dev/unstable \
+    && apt-get clean \
+    && apt-get autoremove --purge -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Use the GitHub Actions uid:gid combination for proper fs permissions
-RUN addgroup -g 116 -S test && adduser -u 1001 -S -g test test
+RUN groupadd -g 116 test && \
+    useradd -u 1001 --gid test --shell /bin/sh --create-home test
 
 # Run as test user
 USER test
 
-ENTRYPOINT ["/bin/sh", "-c"]
+ENTRYPOINT [ "/bin/sh", "-c" ]

--- a/config/testdata/git/large-repo.yaml
+++ b/config/testdata/git/large-repo.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 10m
   url: https://github.com/hashgraph/hedera-mirror-node.git
   ref:
-    branch: master
+    branch: main
   ignore: |
     /*
     !/charts
@@ -21,7 +21,7 @@ spec:
   interval: 10m
   url: https://github.com/hashgraph/hedera-mirror-node.git
   ref:
-    branch: master
+    branch: main
   ignore: |
     /*
     !/charts


### PR DESCRIPTION
We received reports from users no longer being able to clone Git
repositories using libgit2 because of errors during the cloning
attempt: `error: Failed to authenticate SSH session: Unable to extract
public key from private key.`

After an extensive scavenger hunt I was able to pinpoint the issue to
`libssh2` being linked against `libgcrypt` instead of `openssl`. The
problem with this is that the libgcrypt backend in libssh2 contains
a hand written slimmed down ASN.1 parser to read out keys, while the
OpenSSL backend in libssh2 uses OpenSSL, which supports a lot more
formats (and more specifically, most PKCS* formats).

As Debian's bullseye/testing repository has been frozen, and a
backport has not been made available yet, fetching the dependency from
"unstable" seems to be the best option for now, as this has `libssh2`
available including OpenSSL.

Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=668271
Ref: https://github.com/fluxcd/flux2/issues/1543