### PR TITLE
Add setup-envtest in Makefile

### DIFF
--- a/.github/actions/run-tests/Dockerfile
+++ b/.github/actions/run-tests/Dockerfile
@@ -17,6 +17,9 @@ RUN set -eux; \
 RUN groupadd -g 116 test && \
     useradd -u 1001 --gid test --shell /bin/sh --create-home test
 
+# Set path to envtest binaries.
+ENV PATH="/github/workspace/envtest:${PATH}"
+
 # Run as test user
 USER test
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,15 +26,16 @@ jobs:
           image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
       - name: Setup Kustomize
         uses: fluxcd/pkg/actions/kustomize@main
-      - name: Setup Kubebuilder
-        uses: fluxcd/pkg/actions/kubebuilder@main
+      - name: Setup envtest
+        uses: fluxcd/pkg/actions/envtest@main
+        with:
+          version: "1.19.2"
       - name: Setup Helm
         uses: fluxcd/pkg/actions/helm@main
       - name: Run tests
         uses: ./.github/actions/run-tests
         env:
           GOPATH: /github/home/go
-          KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin
       - name: Check if working tree is dirty
         run: |
           if [[ $(git diff --stat) != '' ]]; then
@@ -44,14 +45,10 @@ jobs:
           fi
       - name: Build container image
         run: make docker-build IMG=test/source-controller:latest
-        env:
-          KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin
       - name: Load test image
         run: kind load docker-image test/source-controller:latest
       - name: Deploy controller
         run: make dev-deploy IMG=test/source-controller:latest
-        env:
-          KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin
       - name: Run smoke tests
         run: |
           kubectl -n source-system apply -f ./config/samples

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ IMG ?= fluxcd/source-controller:latest
 # Produce CRDs that work back to Kubernetes 1.16
 CRD_OPTIONS ?= crd:crdVersions=v1
 
+ENVTEST_BIN_VERSION?=1.19.2
+KUBEBUILDER_ASSETS?=$(shell $(SETUP_ENVTEST) use -i $(ENVTEST_BIN_VERSION) -p path)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -13,8 +16,8 @@ endif
 all: manager
 
 # Run tests
-test: generate fmt vet manifests api-docs
-	go test ./... -coverprofile cover.out
+test: generate fmt vet manifests api-docs setup-envtest
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./... -coverprofile cover.out
 	cd api; go test ./... -coverprofile cover.out
 
 # Build manager binary
@@ -111,4 +114,20 @@ ifeq (, $(shell which gen-crd-api-reference-docs))
 API_REF_GEN=$(GOBIN)/gen-crd-api-reference-docs
 else
 API_REF_GEN=$(shell which gen-crd-api-reference-docs)
+endif
+
+# Find or download setup-envtest
+setup-envtest:
+ifeq (, $(shell which setup-envtest))
+	@{ \
+	set -e ;\
+	SETUP_ENVTEST_TMP_DIR=$$(mktemp -d) ;\
+	cd $$SETUP_ENVTEST_TMP_DIR ;\
+	go mod init tmp ;\
+	go get sigs.k8s.io/controller-runtime/tools/setup-envtest@latest ;\
+	rm -rf $$SETUP_ENVTEST_TMP_DIR ;\
+	}
+SETUP_ENVTEST=$(GOBIN)/setup-envtest
+else
+SETUP_ENVTEST=$(shell which setup-envtest)
 endif


### PR DESCRIPTION
Use setup-envtest for installing the binaries required for using
envtest.
The latest envtest binaries for k8s v1.21.2 are not compatible with
kubebuilder < v3, which results in envtest suite test tear down
failure. envtest fails to stop the kube-apiserver.

```
timeout waiting for process kube-apiserver to stop
```

Pin to k8s v1.19.2 envtest binaries that work with kubebuilder v2.