### PR TITLE
Drop deprecated `io/ioutil`

### DIFF
--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -184,7 +183,7 @@ func (r *BucketReconciler) reconcile(ctx context.Context, bucket sourcev1.Bucket
 	}
 
 	// create tmp dir
-	tempDir, err := ioutil.TempDir("", bucket.Name)
+	tempDir, err := os.MkdirTemp("", bucket.Name)
 	if err != nil {
 		err = fmt.Errorf("tmp dir error: %w", err)
 		return sourcev1.BucketNotReady(bucket, sourcev1.StorageOperationFailedReason, err.Error()), err
@@ -368,7 +367,7 @@ func (r *BucketReconciler) checksum(root string) (string, error) {
 		if !info.Mode().IsRegular() {
 			return nil
 		}
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/controllers/bucket_controller_test.go
+++ b/controllers/bucket_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,7 +50,7 @@ func TestBucketReconciler_checksum(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			root, err := ioutil.TempDir("", "bucket-checksum-")
+			root, err := os.MkdirTemp("", "bucket-checksum-")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -76,7 +75,7 @@ func mockFile(root, path, content string) error {
 	if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
 		panic(err)
 	}
-	if err := ioutil.WriteFile(filePath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
 		panic(err)
 	}
 	return nil

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -223,7 +222,7 @@ func (r *GitRepositoryReconciler) checkDependencies(repository sourcev1.GitRepos
 
 func (r *GitRepositoryReconciler) reconcile(ctx context.Context, repository sourcev1.GitRepository) (sourcev1.GitRepository, error) {
 	// create tmp dir for the Git clone
-	tmpGit, err := ioutil.TempDir("", repository.Name)
+	tmpGit, err := os.MkdirTemp("", repository.Name)
 	if err != nil {
 		err = fmt.Errorf("tmp dir error: %w", err)
 		return sourcev1.GitRepositoryNotReady(repository, sourcev1.StorageOperationFailedReason, err.Error()), err

--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -459,7 +458,7 @@ var _ = Describe("GitRepositoryReconciler", func() {
 
 				// this one is linked to a real directory, so that I can
 				// exec `git submodule add` later
-				tmp, err := ioutil.TempDir("", "flux-test")
+				tmp, err := os.MkdirTemp("", "flux-test")
 				Expect(err).NotTo(HaveOccurred())
 				defer os.RemoveAll(tmp)
 
@@ -697,7 +696,7 @@ var _ = Describe("GitRepositoryReconciler", func() {
 			res, err := http.Get(got.Status.URL)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res.StatusCode).To(Equal(http.StatusOK))
-			tmp, err := ioutil.TempDir("", "flux-test")
+			tmp, err := os.MkdirTemp("", "flux-test")
 			Expect(err).NotTo(HaveOccurred())
 			defer os.RemoveAll(tmp)
 			_, err = untar.Untar(res.Body, filepath.Join(tmp, "tar"))
@@ -743,7 +742,7 @@ var _ = Describe("GitRepositoryReconciler", func() {
 			res, err = http.Get(got.Status.URL)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res.StatusCode).To(Equal(http.StatusOK))
-			tmp, err = ioutil.TempDir("", "flux-test")
+			tmp, err = os.MkdirTemp("", "flux-test")
 			Expect(err).NotTo(HaveOccurred())
 			defer os.RemoveAll(tmp)
 			_, err = untar.Untar(res.Body, filepath.Join(tmp, "tar"))

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -331,7 +330,7 @@ func (r *HelmChartReconciler) reconcileFromHelmRepository(ctx context.Context,
 	if err != nil {
 		return sourcev1.HelmChartNotReady(chart, sourcev1.StorageOperationFailedReason, err.Error()), err
 	}
-	b, err := ioutil.ReadAll(indexFile)
+	b, err := io.ReadAll(indexFile)
 	if err != nil {
 		return sourcev1.HelmChartNotReady(chart, sourcev1.ChartPullFailedReason, err.Error()), err
 	}
@@ -376,7 +375,7 @@ func (r *HelmChartReconciler) reconcileFromHelmRepository(ctx context.Context,
 	if err != nil {
 		return sourcev1.HelmChartNotReady(chart, sourcev1.ChartPullFailedReason, err.Error()), err
 	}
-	tmpFile, err := ioutil.TempFile("", fmt.Sprintf("%s-%s-", chart.Namespace, chart.Name))
+	tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s-%s-", chart.Namespace, chart.Name))
 	if err != nil {
 		return sourcev1.HelmChartNotReady(chart, sourcev1.ChartPullFailedReason, err.Error()), err
 	}
@@ -448,7 +447,7 @@ func (r *HelmChartReconciler) reconcileFromHelmRepository(ctx context.Context,
 		}
 
 		// Create temporary working directory
-		tmpDir, err := ioutil.TempDir("", fmt.Sprintf("%s-%s-", chart.Namespace, chart.Name))
+		tmpDir, err := os.MkdirTemp("", fmt.Sprintf("%s-%s-", chart.Namespace, chart.Name))
 		if err != nil {
 			err = fmt.Errorf("tmp dir error: %w", err)
 			return sourcev1.HelmChartNotReady(chart, sourcev1.StorageOperationFailedReason, err.Error()), err
@@ -491,7 +490,7 @@ func (r *HelmChartReconciler) reconcileFromHelmRepository(ctx context.Context,
 func (r *HelmChartReconciler) reconcileFromTarballArtifact(ctx context.Context,
 	artifact sourcev1.Artifact, chart sourcev1.HelmChart, force bool) (sourcev1.HelmChart, error) {
 	// Create temporary working directory
-	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("%s-%s-", chart.Namespace, chart.Name))
+	tmpDir, err := os.MkdirTemp("", fmt.Sprintf("%s-%s-", chart.Namespace, chart.Name))
 	if err != nil {
 		err = fmt.Errorf("tmp dir error: %w", err)
 		return sourcev1.HelmChartNotReady(chart, sourcev1.StorageOperationFailedReason, err.Error()), err
@@ -554,7 +553,7 @@ func (r *HelmChartReconciler) reconcileFromTarballArtifact(ctx context.Context,
 				return sourcev1.HelmChartNotReady(chart, sourcev1.StorageOperationFailedReason, err.Error()), err
 			}
 
-			valuesData, err := ioutil.ReadFile(srcPath)
+			valuesData, err := os.ReadFile(srcPath)
 			if err != nil {
 				err = fmt.Errorf("failed to read from values file '%s': %w", v, err)
 				return sourcev1.HelmChartNotReady(chart, sourcev1.StorageOperationFailedReason, err.Error()), err
@@ -659,7 +658,7 @@ func (r *HelmChartReconciler) reconcileFromTarballArtifact(ctx context.Context,
 				if err != nil {
 					return sourcev1.HelmChartNotReady(chart, sourcev1.StorageOperationFailedReason, err.Error()), err
 				}
-				b, err := ioutil.ReadAll(indexFile)
+				b, err := io.ReadAll(indexFile)
 				if err != nil {
 					return sourcev1.HelmChartNotReady(chart, sourcev1.ChartPullFailedReason, err.Error()), err
 				}

--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -612,7 +611,7 @@ var _ = Describe("HelmChartReconciler", func() {
 					return nil
 				}
 
-				b, err := ioutil.ReadFile(p)
+				b, err := os.ReadFile(p)
 				if err != nil {
 					return err
 				}
@@ -872,14 +871,14 @@ var _ = Describe("HelmChartReconciler", func() {
 			helmChart, err := loader.LoadDir(chartDir)
 			Expect(err).NotTo(HaveOccurred())
 
-			chartPackagePath, err := ioutil.TempDir("", fmt.Sprintf("chartpackage-%s-%s", helmChart.Name(), randStringRunes(5)))
+			chartPackagePath, err := os.MkdirTemp("", fmt.Sprintf("chartpackage-%s-%s", helmChart.Name(), randStringRunes(5)))
 			Expect(err).NotTo(HaveOccurred())
 			defer os.RemoveAll(chartPackagePath)
 
 			pkg, err := chartutil.Save(helmChart, chartPackagePath)
 			Expect(err).NotTo(HaveOccurred())
 
-			b, err := ioutil.ReadFile(pkg)
+			b, err := os.ReadFile(pkg)
 			Expect(err).NotTo(HaveOccurred())
 
 			tgz := filepath.Base(pkg)
@@ -1078,7 +1077,7 @@ var _ = Describe("HelmChartReconciler", func() {
 					return nil
 				}
 
-				b, err := ioutil.ReadFile(p)
+				b, err := os.ReadFile(p)
 				if err != nil {
 					return err
 				}

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -174,7 +173,7 @@ func (s *Storage) Archive(artifact *sourcev1.Artifact, dir string, filter Archiv
 	}
 
 	localPath := s.LocalPath(*artifact)
-	tf, err := ioutil.TempFile(filepath.Split(localPath))
+	tf, err := os.CreateTemp(filepath.Split(localPath))
 	if err != nil {
 		return err
 	}
@@ -272,7 +271,7 @@ func (s *Storage) Archive(artifact *sourcev1.Artifact, dir string, filter Archiv
 // If successful, it sets the checksum and last update time on the artifact.
 func (s *Storage) AtomicWriteFile(artifact *sourcev1.Artifact, reader io.Reader, mode os.FileMode) (err error) {
 	localPath := s.LocalPath(*artifact)
-	tf, err := ioutil.TempFile(filepath.Split(localPath))
+	tf, err := os.CreateTemp(filepath.Split(localPath))
 	if err != nil {
 		return err
 	}
@@ -311,7 +310,7 @@ func (s *Storage) AtomicWriteFile(artifact *sourcev1.Artifact, reader io.Reader,
 // If successful, it sets the checksum and last update time on the artifact.
 func (s *Storage) Copy(artifact *sourcev1.Artifact, reader io.Reader) (err error) {
 	localPath := s.LocalPath(*artifact)
-	tf, err := ioutil.TempFile(filepath.Split(localPath))
+	tf, err := os.CreateTemp(filepath.Split(localPath))
 	if err != nil {
 		return err
 	}
@@ -357,7 +356,7 @@ func (s *Storage) CopyFromPath(artifact *sourcev1.Artifact, path string) (err er
 // CopyToPath copies the contents of the given artifact to the path.
 func (s *Storage) CopyToPath(artifact *sourcev1.Artifact, subPath, toPath string) error {
 	// create a tmp directory to store artifact
-	tmp, err := ioutil.TempDir("", "flux-include")
+	tmp, err := os.MkdirTemp("", "flux-include")
 	if err != nil {
 		return err
 	}

--- a/controllers/storage_test.go
+++ b/controllers/storage_test.go
@@ -21,7 +21,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -34,7 +33,7 @@ import (
 )
 
 func createStoragePath() (string, error) {
-	return ioutil.TempDir("", "")
+	return os.MkdirTemp("", "")
 }
 
 func cleanupStoragePath(dir string) func() {
@@ -52,7 +51,7 @@ func TestStorageConstructor(t *testing.T) {
 		t.Fatal("nonexistent path was allowable in storage constructor")
 	}
 
-	f, err := ioutil.TempFile(dir, "")
+	f, err := os.CreateTemp(dir, "")
 	if err != nil {
 		t.Fatalf("while creating temporary file: %v", err)
 	}
@@ -124,7 +123,7 @@ func TestStorage_Archive(t *testing.T) {
 				os.RemoveAll(dir)
 			}
 		}()
-		dir, err = ioutil.TempDir("", "archive-test-files-")
+		dir, err = os.MkdirTemp("", "archive-test-files-")
 		if err != nil {
 			return
 		}
@@ -244,7 +243,7 @@ func TestStorage_Archive(t *testing.T) {
 
 func TestStorageRemoveAllButCurrent(t *testing.T) {
 	t.Run("bad directory in archive", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "")
+		dir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -97,7 +96,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	Expect(loadExampleKeys()).To(Succeed())
 
-	tmpStoragePath, err := ioutil.TempDir("", "source-controller-storage-")
+	tmpStoragePath, err := os.MkdirTemp("", "source-controller-storage-")
 	Expect(err).NotTo(HaveOccurred(), "failed to create tmp storage dir")
 
 	storage, err = NewStorage(tmpStoragePath, "localhost:5050", time.Second*30)
@@ -167,15 +166,15 @@ func init() {
 }
 
 func loadExampleKeys() (err error) {
-	examplePublicKey, err = ioutil.ReadFile("testdata/certs/server.pem")
+	examplePublicKey, err = os.ReadFile("testdata/certs/server.pem")
 	if err != nil {
 		return err
 	}
-	examplePrivateKey, err = ioutil.ReadFile("testdata/certs/server-key.pem")
+	examplePrivateKey, err = os.ReadFile("testdata/certs/server-key.pem")
 	if err != nil {
 		return err
 	}
-	exampleCA, err = ioutil.ReadFile("testdata/certs/ca.pem")
+	exampleCA, err = os.ReadFile("testdata/certs/ca.pem")
 	return err
 }
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -92,7 +91,7 @@ func CopyDir(src, dst string) error {
 		return fmt.Errorf("cannot mkdir %s: %w", dst, err)
 	}
 
-	entries, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	if err != nil {
 		return fmt.Errorf("cannot read directory %s: %w", dst, err)
 	}

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -6,7 +6,6 @@ package fs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,7 +19,7 @@ var (
 )
 
 func TestRenameWithFallback(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +57,7 @@ func TestRenameWithFallback(t *testing.T) {
 }
 
 func TestCopyDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +118,7 @@ func TestCopyDir(t *testing.T) {
 			t.Fatalf("expected %s to be a directory", dn)
 		}
 
-		got, err := ioutil.ReadFile(fn)
+		got, err := os.ReadFile(fn)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -156,7 +155,7 @@ func TestCopyDirFail_SrcInaccessible(t *testing.T) {
 	})
 	defer cleanup()
 
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +177,7 @@ func TestCopyDirFail_DstInaccessible(t *testing.T) {
 
 	var srcdir, dstdir string
 
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +202,7 @@ func TestCopyDirFail_DstInaccessible(t *testing.T) {
 func TestCopyDirFail_SrcIsNotDir(t *testing.T) {
 	var srcdir, dstdir string
 
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +228,7 @@ func TestCopyDirFail_SrcIsNotDir(t *testing.T) {
 func TestCopyDirFail_DstExists(t *testing.T) {
 	var srcdir, dstdir string
 
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +266,7 @@ func TestCopyDirFailOpen(t *testing.T) {
 
 	var srcdir, dstdir string
 
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,7 +297,7 @@ func TestCopyDirFailOpen(t *testing.T) {
 }
 
 func TestCopyFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +319,7 @@ func TestCopyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := ioutil.ReadFile(destf)
+	got, err := os.ReadFile(destf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -345,7 +344,7 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestCopyFileSymlink(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -370,11 +369,11 @@ func TestCopyFileSymlink(t *testing.T) {
 				// Creating symlinks on Windows require an additional permission
 				// regular users aren't granted usually. So we copy the file
 				// content as a fall back instead of creating a real symlink.
-				srcb, err := ioutil.ReadFile(symlink)
+				srcb, err := os.ReadFile(symlink)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
-				dstb, err := ioutil.ReadFile(dst)
+				dstb, err := os.ReadFile(dst)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
@@ -407,7 +406,7 @@ func TestCopyFileLongFilePath(t *testing.T) {
 		t.Skip("skipping on non-windows")
 	}
 
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,7 +423,7 @@ func TestCopyFileLongFilePath(t *testing.T) {
 		t.Fatalf("%+v", fmt.Errorf("unable to create temp directory: %s", fullPath))
 	}
 
-	err = ioutil.WriteFile(fullPath+"src", []byte(nil), 0644)
+	err = os.WriteFile(fullPath+"src", []byte(nil), 0644)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -445,7 +444,7 @@ func TestCopyFileFail(t *testing.T) {
 		t.Skip("skipping on windows")
 	}
 
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -485,7 +484,7 @@ func TestCopyFileFail(t *testing.T) {
 // files this function creates. It is the caller's responsibility to call
 // this function before the test is done running, whether there's an error or not.
 func setupInaccessibleDir(t *testing.T, op func(dir string) error) func() {
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 		return nil // keep compiler happy
@@ -569,7 +568,7 @@ func TestIsDir(t *testing.T) {
 }
 
 func TestIsSymlink(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dep")
+	dir, err := os.MkdirTemp("", "dep")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/helm/dependency_manager_test.go
+++ b/internal/helm/dependency_manager_test.go
@@ -19,7 +19,7 @@ package helm
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -170,7 +170,7 @@ func TestBuild_WithLocalChart(t *testing.T) {
 
 func TestBuild_WithRemoteChart(t *testing.T) {
 	chart := chartFixture
-	b, err := ioutil.ReadFile(helmPackageFile)
+	b, err := os.ReadFile(helmPackageFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/helm/getter.go
+++ b/internal/helm/getter.go
@@ -18,7 +18,6 @@ package helm
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -80,7 +79,7 @@ func TLSClientConfigFromSecret(secret corev1.Secret) (getter.Option, func(), err
 	}
 
 	// create tmp dir for TLS files
-	tmp, err := ioutil.TempDir("", "helm-tls-"+secret.Name)
+	tmp, err := os.MkdirTemp("", "helm-tls-"+secret.Name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -90,12 +89,12 @@ func TLSClientConfigFromSecret(secret corev1.Secret) (getter.Option, func(), err
 
 	if len(certBytes) > 0 && len(keyBytes) > 0 {
 		certFile = filepath.Join(tmp, "cert.crt")
-		if err := ioutil.WriteFile(certFile, certBytes, 0644); err != nil {
+		if err := os.WriteFile(certFile, certBytes, 0644); err != nil {
 			cleanup()
 			return nil, nil, err
 		}
 		keyFile = filepath.Join(tmp, "key.crt")
-		if err := ioutil.WriteFile(keyFile, keyBytes, 0644); err != nil {
+		if err := os.WriteFile(keyFile, keyBytes, 0644); err != nil {
 			cleanup()
 			return nil, nil, err
 		}
@@ -103,7 +102,7 @@ func TLSClientConfigFromSecret(secret corev1.Secret) (getter.Option, func(), err
 
 	if len(caBytes) > 0 {
 		caFile = filepath.Join(tmp, "ca.pem")
-		if err := ioutil.WriteFile(caFile, caBytes, 0644); err != nil {
+		if err := os.WriteFile(caFile, caBytes, 0644); err != nil {
 			cleanup()
 			return nil, nil, err
 		}

--- a/internal/helm/repository.go
+++ b/internal/helm/repository.go
@@ -19,7 +19,7 @@ package helm
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"path"
 	"sort"
@@ -209,7 +209,7 @@ func (r *ChartRepository) DownloadIndex() error {
 	if err != nil {
 		return err
 	}
-	b, err := ioutil.ReadAll(res)
+	b, err := io.ReadAll(res)
 	if err != nil {
 		return err
 	}

--- a/internal/helm/repository_test.go
+++ b/internal/helm/repository_test.go
@@ -18,8 +18,8 @@ package helm
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -231,7 +231,7 @@ func TestChartRepository_DownloadChart(t *testing.T) {
 }
 
 func TestChartRepository_DownloadIndex(t *testing.T) {
-	b, err := ioutil.ReadFile(chartmuseumtestfile)
+	b, err := os.ReadFile(chartmuseumtestfile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +270,7 @@ func TestChartRepository_LoadIndex(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			b, err := ioutil.ReadFile(tt.filename)
+			b, err := os.ReadFile(tt.filename)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -292,7 +292,7 @@ func TestChartRepository_LoadIndex_Duplicates(t *testing.T) {
 }
 
 func TestChartRepository_LoadIndex_Unordered(t *testing.T) {
-	b, err := ioutil.ReadFile(unorderedtestfile)
+	b, err := os.ReadFile(unorderedtestfile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/git/gogit/checkout_test.go
+++ b/pkg/git/gogit/checkout_test.go
@@ -18,7 +18,6 @@ package gogit
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -30,7 +29,7 @@ func TestCheckoutTagSemVer_Checkout(t *testing.T) {
 	tag := CheckoutTag{
 		tag: "v1.7.0",
 	}
-	tmpDir, _ := ioutil.TempDir("", "test")
+	tmpDir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(tmpDir)
 
 	cTag, _, err := tag.Checkout(context.TODO(), tmpDir, "https://github.com/projectcontour/contour", auth)
@@ -41,7 +40,7 @@ func TestCheckoutTagSemVer_Checkout(t *testing.T) {
 	semVer := CheckoutSemVer{
 		semVer: ">=1.0.0 <=1.7.0",
 	}
-	tmpDir2, _ := ioutil.TempDir("", "test")
+	tmpDir2, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(tmpDir2)
 
 	cSemVer, _, err := semVer.Checkout(context.TODO(), tmpDir2, "https://github.com/projectcontour/contour", auth)

--- a/pkg/git/libgit2/checkout_test.go
+++ b/pkg/git/libgit2/checkout_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -40,7 +39,7 @@ func TestCheckoutTagSemVer_Checkout(t *testing.T) {
 	tag := CheckoutTag{
 		tag: "v1.7.0",
 	}
-	tmpDir, _ := ioutil.TempDir("", "test")
+	tmpDir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(tmpDir)
 
 	cTag, _, err := tag.Checkout(context.TODO(), tmpDir, "https://github.com/projectcontour/contour", auth)
@@ -66,7 +65,7 @@ func TestCheckoutTagSemVer_Checkout(t *testing.T) {
 	semVer := CheckoutSemVer{
 		semVer: ">=1.0.0 <=1.7.0",
 	}
-	tmpDir2, _ := ioutil.TempDir("", "test")
+	tmpDir2, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(tmpDir2)
 
 	cSemVer, _, err := semVer.Checkout(context.TODO(), tmpDir2, "https://github.com/projectcontour/contour", auth)

--- a/pkg/sourceignore/sourceignore.go
+++ b/pkg/sourceignore/sourceignore.go
@@ -19,7 +19,6 @@ package sourceignore
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,7 +107,7 @@ func LoadIgnorePatterns(dir string, domain []string) ([]gitignore.Pattern, error
 	if err != nil {
 		return nil, err
 	}
-	fis, err := ioutil.ReadDir(dir)
+	fis, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sourceignore/sourceignore_test.go
+++ b/pkg/sourceignore/sourceignore_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sourceignore
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -74,7 +73,7 @@ func TestReadPatterns(t *testing.T) {
 }
 
 func TestReadIgnoreFile(t *testing.T) {
-	f, err := ioutil.TempFile("", IgnoreFile)
+	f, err := os.CreateTemp("", IgnoreFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +197,7 @@ func TestDefaultPatterns(t *testing.T) {
 }
 
 func TestLoadExcludePatterns(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "sourceignore-load-")
+	tmpDir, err := os.MkdirTemp("", "sourceignore-load-")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The package has been deprecated since Go 1.16, see:
https://golang.org/doc/go1.16#ioutil

Ref: https://github.com/fluxcd/flux2/issues/1658