### PR TITLE
controllers: Add more tests for reconcileArtifact

### DIFF
--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -402,7 +402,8 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context, obj *so
 		ctrl.LoggerFrom(ctx).Error(err, "failed to stat source path")
 		return ctrl.Result{}, err
 	} else if !f.IsDir() {
-		ctrl.LoggerFrom(ctx).Error(err, fmt.Sprintf("source path '%s' is not a directory", dir))
+		err := fmt.Errorf("source path '%s' is not a directory", dir)
+		ctrl.LoggerFrom(ctx).Error(err, "invalid target path")
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
Fixes error returned from target path validation check and adds more
test cases in `TestGitRepositoryReconciler_reconcileArtifact`.

:warning:  target branch of the PR is `gitrepository-reconciler`.

NOTE: Had a discussion with @hiddeco about adding more tests in
the rewrite target branch before working on it.