### PR TITLE
gitrepo-reconciler: reconcileInclude test assertion fixes

### DIFF
--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -690,7 +690,7 @@ func TestGitRepositoryReconciler_reconcileInclude(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	storage, err := newTestStorage(server.HTTPServer)
 	g.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(testStorage.BasePath)
+	defer os.RemoveAll(storage.BasePath)
 
 	dependencyInterval := 5 * time.Second
 
@@ -735,8 +735,8 @@ func TestGitRepositoryReconciler_reconcileInclude(t *testing.T) {
 				},
 			},
 			includes: []include{
-				{name: "a", toPath: "a/"},
-				{name: "b", toPath: "b/"},
+				{name: "a", toPath: "a/", shouldExist: true},
+				{name: "b", toPath: "b/", shouldExist: true},
 			},
 			want: ctrl.Result{RequeueAfter: interval},
 			assertConditions: []metav1.Condition{
@@ -871,7 +871,7 @@ func TestGitRepositoryReconciler_reconcileInclude(t *testing.T) {
 			g.Expect(got).To(Equal(tt.want))
 			for _, i := range tt.includes {
 				if i.toPath != "" {
-					expect := g.Expect(filepath.Join(testStorage.BasePath, i.toPath))
+					expect := g.Expect(filepath.Join(tmpDir, i.toPath))
 					if i.shouldExist {
 						expect.To(BeADirectory())
 					} else {
@@ -879,9 +879,9 @@ func TestGitRepositoryReconciler_reconcileInclude(t *testing.T) {
 					}
 				}
 				if i.shouldExist {
-					g.Expect(filepath.Join(testStorage.BasePath, i.toPath)).Should(BeADirectory())
+					g.Expect(filepath.Join(tmpDir, i.toPath)).Should(BeADirectory())
 				} else {
-					g.Expect(filepath.Join(testStorage.BasePath, i.toPath)).ShouldNot(BeADirectory())
+					g.Expect(filepath.Join(tmpDir, i.toPath)).ShouldNot(BeADirectory())
 				}
 			}
 		})


### PR DESCRIPTION
Use the created artifact server test storage in `reconcileInclude`
test's GitRepositoryReconciler and cleanup the created storage.

Fix the test assertions to check the copied artifact directories in
the correct path, under `toPath`. Also, update the tests to expect artifacts in the
include `toPath` to exist.

:warning:  target branch of the PR is `reconcilers-dev`.