### PR TITLE
storage: change Artifact checksum to SHA256

### DIFF
--- a/api/v1beta1/artifact_types.go
+++ b/api/v1beta1/artifact_types.go
@@ -39,7 +39,7 @@ type Artifact struct {
 	// +optional
 	Revision string `json:"revision"`
 
-	// Checksum is the SHA1 checksum of the artifact.
+	// Checksum is the SHA256 checksum of the artifact.
 	// +optional
 	Checksum string `json:"checksum"`
 

--- a/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
@@ -98,7 +98,7 @@ spec:
                 description: Artifact represents the output of the last successful Bucket sync.
                 properties:
                   checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
+                    description: Checksum is the SHA256 checksum of the artifact.
                     type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -155,7 +155,7 @@ spec:
                 description: Artifact represents the output of the last successful repository sync.
                 properties:
                   checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
+                    description: Checksum is the SHA256 checksum of the artifact.
                     type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
@@ -224,7 +224,7 @@ spec:
                   description: Artifact represents the output of a source synchronisation.
                   properties:
                     checksum:
-                      description: Checksum is the SHA1 checksum of the artifact.
+                      description: Checksum is the SHA256 checksum of the artifact.
                       type: string
                     lastUpdateTime:
                       description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -109,7 +109,7 @@ spec:
                 description: Artifact represents the output of the last successful chart sync.
                 properties:
                   checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
+                    description: Checksum is the SHA256 checksum of the artifact.
                     type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -83,7 +83,7 @@ spec:
                 description: Artifact represents the output of the last successful repository sync.
                 properties:
                   checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
+                    description: Checksum is the SHA256 checksum of the artifact.
                     type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.

--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -578,7 +578,7 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			},
 			afterFunc: func(t *WithT, obj *sourcev1.GitRepository, artifact sourcev1.Artifact) {
 				t.Expect(obj.GetArtifact()).ToNot(BeNil())
-				t.Expect(obj.GetArtifact().Checksum).To(Equal("b1fab897a1a0fb8094ce3ae0e9743a4b72bd7268"))
+				t.Expect(obj.GetArtifact().Checksum).To(Equal("ef9c34eab0584035ac8b8a4070876954ea46f270250d60648672feef3e943426"))
 				t.Expect(obj.Status.URL).ToNot(BeEmpty())
 			},
 			want: ctrl.Result{RequeueAfter: interval},
@@ -595,7 +595,7 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			},
 			afterFunc: func(t *WithT, obj *sourcev1.GitRepository, artifact sourcev1.Artifact) {
 				t.Expect(obj.GetArtifact()).ToNot(BeNil())
-				t.Expect(obj.GetArtifact().Checksum).To(Equal("b1fab897a1a0fb8094ce3ae0e9743a4b72bd7268"))
+				t.Expect(obj.GetArtifact().Checksum).To(Equal("ef9c34eab0584035ac8b8a4070876954ea46f270250d60648672feef3e943426"))
 				t.Expect(obj.Status.IncludedArtifacts).ToNot(BeEmpty())
 				t.Expect(obj.Status.URL).ToNot(BeEmpty())
 			},
@@ -630,7 +630,7 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			},
 			afterFunc: func(t *WithT, obj *sourcev1.GitRepository, artifact sourcev1.Artifact) {
 				t.Expect(obj.GetArtifact()).ToNot(BeNil())
-				t.Expect(obj.GetArtifact().Checksum).To(Equal("a71f8c076db814bc21c16cecc960c4fcaf970ac5"))
+				t.Expect(obj.GetArtifact().Checksum).To(Equal("dc95ae14c19d335b693bbba58ae2a562242b0cf33893baffd1b7605ba578e0d6"))
 			},
 			want: ctrl.Result{RequeueAfter: interval},
 			assertConditions: []metav1.Condition{
@@ -646,7 +646,7 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			},
 			afterFunc: func(t *WithT, obj *sourcev1.GitRepository, artifact sourcev1.Artifact) {
 				t.Expect(obj.GetArtifact()).ToNot(BeNil())
-				t.Expect(obj.GetArtifact().Checksum).To(Equal("b1fab897a1a0fb8094ce3ae0e9743a4b72bd7268"))
+				t.Expect(obj.GetArtifact().Checksum).To(Equal("ef9c34eab0584035ac8b8a4070876954ea46f270250d60648672feef3e943426"))
 				t.Expect(obj.Status.URL).ToNot(BeEmpty())
 			},
 			want: ctrl.Result{RequeueAfter: interval},
@@ -663,7 +663,7 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			},
 			afterFunc: func(t *WithT, obj *sourcev1.GitRepository, artifact sourcev1.Artifact) {
 				t.Expect(obj.GetArtifact()).ToNot(BeNil())
-				t.Expect(obj.GetArtifact().Checksum).To(Equal("b1fab897a1a0fb8094ce3ae0e9743a4b72bd7268"))
+				t.Expect(obj.GetArtifact().Checksum).To(Equal("ef9c34eab0584035ac8b8a4070876954ea46f270250d60648672feef3e943426"))
 				t.Expect(obj.Status.URL).ToNot(BeEmpty())
 			},
 			want: ctrl.Result{RequeueAfter: interval},

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -19,7 +19,7 @@ package controllers
 import (
 	"archive/tar"
 	"compress/gzip"
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"hash"
 	"io"
@@ -425,7 +425,7 @@ func (s *Storage) Symlink(artifact sourcev1.Artifact, linkName string) (string, 
 	return url, nil
 }
 
-// Checksum returns the SHA1 checksum for the data of the given io.Reader as a string.
+// Checksum returns the SHA256 checksum for the data of the given io.Reader as a string.
 func (s *Storage) Checksum(reader io.Reader) string {
 	h := newHash()
 	_, _ = io.Copy(h, reader)
@@ -451,7 +451,7 @@ func (s *Storage) LocalPath(artifact sourcev1.Artifact) string {
 	return path
 }
 
-// newHash returns a new SHA1 hash.
+// newHash returns a new SHA256 hash.
 func newHash() hash.Hash {
-	return sha1.New()
+	return sha256.New()
 }

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -839,7 +839,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Checksum is the SHA1 checksum of the artifact.</p>
+<p>Checksum is the SHA256 checksum of the artifact.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Addresses part of https://github.com/fluxcd/flux2/discussions/1707. Other usages of SHA1 (e.g. within the `BucketReconciler`) have been left untouched as they will be already addressed in e.g. #412.

:warning: target branch of the PR is `reconcilers-dev`.