### PR TITLE
Fix generation of API documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 
 # API (doc) generation utilities
 CONTROLLER_GEN_VERSION ?= v0.5.0
-GEN_API_REF_DOCS_VERSION ?= 0.3.0
+GEN_API_REF_DOCS_VERSION ?= v0.3.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -562,9 +562,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Determines what enables reconciliation. Valid values are (&lsquo;ChartVersion&rsquo;,
-&lsquo;Revision&rsquo;). See the documentation of the values for an explanation on their
-behavior.
+<p>Determines what enables the creation of a new artifact. Valid values are
+(&lsquo;ChartVersion&rsquo;, &lsquo;Revision&rsquo;).
+See the documentation of the values for an explanation on their behavior.
 Defaults to ChartVersion when omitted.</p>
 </td>
 </tr>
@@ -1635,9 +1635,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Determines what enables reconciliation. Valid values are (&lsquo;ChartVersion&rsquo;,
-&lsquo;Revision&rsquo;). See the documentation of the values for an explanation on their
-behavior.
+<p>Determines what enables the creation of a new artifact. Valid values are
+(&lsquo;ChartVersion&rsquo;, &lsquo;Revision&rsquo;).
+See the documentation of the values for an explanation on their behavior.
 Defaults to ChartVersion when omitted.</p>
 </td>
 </tr>


### PR DESCRIPTION
The version was accidentally set to an invalid version, causing the API documentation generation to fail.
