### PR TITLE
Update fluxcd/golang-with-libgit2 to 1.1.1-1

### DIFF
--- a/.github/actions/run-tests/Dockerfile
+++ b/.github/actions/run-tests/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.16.8
 ARG XX_VERSION=1.0.0-rc.2
 
 ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2
-ARG LIBGIT2_TAG=libgit2-1.1.1
+ARG LIBGIT2_TAG=libgit2-1.1.1-1
 
 FROM tonistiigi/xx:${XX_VERSION} AS xx
 FROM ${LIBGIT2_IMG}:${LIBGIT2_TAG} as libgit2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.16.8
 ARG XX_VERSION=1.0.0-rc.2
 
 ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2
-ARG LIBGIT2_TAG=libgit2-1.1.1
+ARG LIBGIT2_TAG=libgit2-1.1.1-1
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 FROM ${LIBGIT2_IMG}:${LIBGIT2_TAG} as libgit2

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG ?= latest
 
 # Base image used to build the Go binary
 LIBGIT2_IMG ?= ghcr.io/fluxcd/golang-with-libgit2
-LIBGIT2_TAG ?= libgit2-1.1.1
+LIBGIT2_TAG ?= libgit2-1.1.1-1
 
 # Allows for defining additional Docker buildx arguments,
 # e.g. '--push'.


### PR DESCRIPTION
This includes a tiny fix for Darwin to ensure the generated `.pc`
file includes the right paths.