### PR TITLE
pkg/git: AuthOptions.Validate() test improvements

### DIFF
--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -106,7 +106,7 @@ Oomb3gD/TRf/nAdVED+k81GdLzciYdUGtI71/qI47G0nMBluLRE=
 
 	keyRingFingerprintFixture = "3299AEB0E4085BAF"
 
-	malformedKeyRing = `
+	malformedKeyRingFixture = `
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQSuBF9+HgMRDADKT8UBcSzpTi4JXt/ohhVW3x81AGFPrQvs6MYrcnNJfIkPTJD8
@@ -189,7 +189,7 @@ func TestCommit_Verify(t *testing.T) {
 				Encoded:   []byte(encodedCommitFixture),
 				Signature: signatureCommitFixture,
 			},
-			keyRings: []string{malformedKeyRing},
+			keyRings: []string{malformedKeyRingFixture},
 			wantErr:  "failed to read armored key ring: unexpected EOF",
 		},
 		{

--- a/pkg/git/options.go
+++ b/pkg/git/options.go
@@ -96,6 +96,8 @@ func (o AuthOptions) Validate() error {
 		}
 	case "":
 		return fmt.Errorf("no transport type set")
+	default:
+		return fmt.Errorf("unknown transport '%s'", o.Transport)
 	}
 	return nil
 }

--- a/pkg/git/options_test.go
+++ b/pkg/git/options_test.go
@@ -77,12 +77,34 @@ func TestAuthOptions_Validate(t *testing.T) {
 			wantErr: "invalid 'http' auth option: 'password' requires 'username' to be set",
 		},
 		{
+			name: "Valid HTTP transport",
+			opts: AuthOptions{
+				Transport: HTTP,
+				Username:  "example",
+				Password:  "foo",
+			},
+		},
+		{
 			name: "HTTPS transport with password requires user",
 			opts: AuthOptions{
 				Transport: HTTPS,
 				Password:  "foo",
 			},
 			wantErr: "invalid 'https' auth option: 'password' requires 'username' to be set",
+		},
+		{
+			name: "Valid HTTPS transport",
+			opts: AuthOptions{
+				Transport: HTTPS,
+				Username:  "example",
+				Password:  "foo",
+			},
+		},
+		{
+			name: "Valid HTTPS without any config",
+			opts: AuthOptions{
+				Transport: HTTPS,
+			},
 		},
 		{
 			name: "SSH transport requires identity",
@@ -120,6 +142,27 @@ func TestAuthOptions_Validate(t *testing.T) {
 			name:    "Requires transport",
 			opts:    AuthOptions{},
 			wantErr: "no transport type set",
+		},
+		{
+			name: "Valid SSH transport",
+			opts: AuthOptions{
+				Transport:  SSH,
+				Identity:   []byte(privateKeyPassphraseFixture),
+				Password:   "foobar",
+				KnownHosts: []byte(knownHostsFixture),
+			},
+		},
+		{
+			name:    "No transport",
+			opts:    AuthOptions{},
+			wantErr: "no transport type set",
+		},
+		{
+			name: "Unknown transport",
+			opts: AuthOptions{
+				Transport: "foo",
+			},
+			wantErr: "unknown transport 'foo'",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
- Adds more test cases for Validate() and an error for unknown transport.
- Add `Fixture` suffix to a test constant `malformedKeyRing`.

:warning: target branch of the PR is `git-auth-opts`.

Adds to #462 .