### PR TITLE
Fix pointer error during public key import

### DIFF
--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -298,7 +298,7 @@ func (r *GitRepositoryReconciler) reconcile(ctx context.Context, repository sour
 			Namespace: repository.Namespace,
 			Name:      repository.Spec.Verification.SecretRef.Name,
 		}
-		var secret *corev1.Secret
+		secret := &corev1.Secret{}
 		if err := r.Client.Get(ctx, publicKeySecret, secret); err != nil {
 			err = fmt.Errorf("PGP public keys secret error: %w", err)
 			return sourcev1.GitRepositoryNotReady(repository, sourcev1.VerificationFailedReason, err.Error()), err


### PR DESCRIPTION
When testing the signed commit verification feature that is documented, we noticed this code errors out on line 303:

```
PGP public keys secret error: expected pointer, but got nil
```

Looks like the pointer was not initialized with a concrete instance of the Secret struct, so this code fails.

I have manually verified this change enables commit verification, and that unsigned commits (or missing pgp keys) fail in expected ways now:

```
flux-system           	False	PGP public keys secret error: Secret "pgp-public-keys" not found
```
or
```
flux-system           	False	commit does not have a PGP signature                                          	main/27187bea606c0da16ff1555394a0ff9d68a33595
```
(both of these are expected failures)

We suspect that changes in controller-runtime are the culprit, this must have worked at the time it was added. (Might be good to cover it with a test, if it turns out we don't have one!)

Thanks to @CitadelCore for bringing this to my attention!