### PR TITLE
storage: change Artifact checksum to SHA256

### DIFF
--- a/api/v1beta1/artifact_types.go
+++ b/api/v1beta1/artifact_types.go
@@ -39,7 +39,7 @@ type Artifact struct {
 	// +optional
 	Revision string `json:"revision"`
 
-	// Checksum is the SHA1 checksum of the artifact.
+	// Checksum is the SHA256 checksum of the artifact.
 	// +optional
 	Checksum string `json:"checksum"`
 

--- a/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
@@ -99,7 +99,7 @@ spec:
                 description: Artifact represents the output of the last successful Bucket sync.
                 properties:
                   checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
+                    description: Checksum is the SHA256 checksum of the artifact.
                     type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -154,7 +154,7 @@ spec:
                 description: Artifact represents the output of the last successful repository sync.
                 properties:
                   checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
+                    description: Checksum is the SHA256 checksum of the artifact.
                     type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
@@ -223,7 +223,7 @@ spec:
                   description: Artifact represents the output of a source synchronisation.
                   properties:
                     checksum:
-                      description: Checksum is the SHA1 checksum of the artifact.
+                      description: Checksum is the SHA256 checksum of the artifact.
                       type: string
                     lastUpdateTime:
                       description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -116,7 +116,7 @@ spec:
                 description: Artifact represents the output of the last successful chart sync.
                 properties:
                   checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
+                    description: Checksum is the SHA256 checksum of the artifact.
                     type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -83,7 +83,7 @@ spec:
                 description: Artifact represents the output of the last successful repository sync.
                 properties:
                   checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
+                    description: Checksum is the SHA256 checksum of the artifact.
                     type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -19,7 +19,7 @@ package controllers
 import (
 	"archive/tar"
 	"compress/gzip"
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"hash"
 	"io"
@@ -421,7 +421,7 @@ func (s *Storage) Symlink(artifact sourcev1.Artifact, linkName string) (string, 
 	return url, nil
 }
 
-// Checksum returns the SHA1 checksum for the data of the given io.Reader as a string.
+// Checksum returns the SHA256 checksum for the data of the given io.Reader as a string.
 func (s *Storage) Checksum(reader io.Reader) string {
 	h := newHash()
 	_, _ = io.Copy(h, reader)
@@ -447,7 +447,7 @@ func (s *Storage) LocalPath(artifact sourcev1.Artifact) string {
 	return path
 }
 
-// newHash returns a new SHA1 hash.
+// newHash returns a new SHA256 hash.
 func newHash() hash.Hash {
-	return sha1.New()
+	return sha256.New()
 }

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -856,7 +856,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Checksum is the SHA1 checksum of the artifact.</p>
+<p>Checksum is the SHA256 checksum of the artifact.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
This changes the format of the Artifact checksum from SHA1 to SHA256 to
mitigate chosen-prefix and length extension attacks, and ensures it can
be used to secure content against malicious modifications.

Source consumers (including our own {kustomize,helm}-controllers)
should ensure the SHA256 of a downloaded artifact matches the
advertised checksum before making use of it.

Cherry-picked from `reconcilers-dev`.

Fixes #467.