### PR TITLE
controllers: use short SHA in chart SemVer meta

### DIFF
--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -747,7 +747,7 @@ var _ = Describe("HelmChartReconciler", func() {
 						storage.ArtifactExist(*got.Status.Artifact)
 				}, timeout, interval).Should(BeTrue())
 				Expect(got.Status.Artifact.Revision).To(ContainSubstring(updated.Status.Artifact.Revision))
-				Expect(got.Status.Artifact.Revision).To(ContainSubstring(commit.String()))
+				Expect(got.Status.Artifact.Revision).To(ContainSubstring(commit.String()[0:12]))
 			})
 
 			When("Setting valid valuesFiles attribute", func() {


### PR DESCRIPTION
As the full version can be used as a label value, the full SHA from the
reference takes up too much space from the 63 characters available in
total.

```
* metadata.labels: Invalid value: "kube-prometheus-stack-20.0.1_a4303ff0f6fb560ea032f9981c6bd7c7f146d083.1": must be no more than 63 characters
```

To mitigate against this, we now take a "short" version of the first 12
characters, which was still unique for the Linux kernel in 2019 with
875.000 commits:
http://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#Short-SHA-1

This should be sufficient to safely detect all changes within the
context of operations.
