### PR TITLE
crds: set default observedGeneration to -1

### DIFF
--- a/api/v1beta1/bucket_types.go
+++ b/api/v1beta1/bucket_types.go
@@ -188,7 +188,8 @@ type Bucket struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   BucketSpec   `json:"spec,omitempty"`
+	Spec BucketSpec `json:"spec,omitempty"`
+	// +kubebuilder:default={"observedGeneration":-1}
 	Status BucketStatus `json:"status,omitempty"`
 }
 

--- a/api/v1beta1/gitrepository_types.go
+++ b/api/v1beta1/gitrepository_types.go
@@ -261,7 +261,8 @@ type GitRepository struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   GitRepositorySpec   `json:"spec,omitempty"`
+	Spec GitRepositorySpec `json:"spec,omitempty"`
+	// +kubebuilder:default={"observedGeneration":-1}
 	Status GitRepositoryStatus `json:"status,omitempty"`
 }
 

--- a/api/v1beta1/helmchart_types.go
+++ b/api/v1beta1/helmchart_types.go
@@ -230,7 +230,8 @@ type HelmChart struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   HelmChartSpec   `json:"spec,omitempty"`
+	Spec HelmChartSpec `json:"spec,omitempty"`
+	// +kubebuilder:default={"observedGeneration":-1}
 	Status HelmChartStatus `json:"status,omitempty"`
 }
 

--- a/api/v1beta1/helmrepository_types.go
+++ b/api/v1beta1/helmrepository_types.go
@@ -177,7 +177,8 @@ type HelmRepository struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   HelmRepositorySpec   `json:"spec,omitempty"`
+	Spec HelmRepositorySpec `json:"spec,omitempty"`
+	// +kubebuilder:default={"observedGeneration":-1}
 	Status HelmRepositoryStatus `json:"status,omitempty"`
 }
 

--- a/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
@@ -111,6 +111,8 @@ spec:
             - interval
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: BucketStatus defines the observed state of a bucket
             properties:
               artifact:

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -166,6 +166,8 @@ spec:
             - url
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: GitRepositoryStatus defines the observed state of a Git repository.
             properties:
               artifact:

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -128,6 +128,8 @@ spec:
             - sourceRef
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: HelmChartStatus defines the observed state of the HelmChart.
             properties:
               artifact:

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -95,6 +95,8 @@ spec:
             - url
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: HelmRepositoryStatus defines the observed state of the HelmRepository.
             properties:
               artifact:


### PR DESCRIPTION
Set default `status.observedGeneration` to `-1` for the following CRDs

- HelmRepository
- HelmChart
- GitRepository
- Bucket

Fix: #516

Signed-off-by: York Chen <ychen@d2iq.com>