### PR TITLE
security: Drop capabilities, set userid and enable seccomp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,10 +90,6 @@ FROM debian:bookworm-slim as controller
 # Link repo to the GitHub Container Registry image
 LABEL org.opencontainers.image.source="https://github.com/fluxcd/source-controller"
 
-# Configure user
-RUN addgroup --gid 65532 controller && \
-	useradd -u 65532 -s /sbin/nologin -g controller controller
-
 ARG TARGETPLATFORM
 RUN apt update && apt install -y ca-certificates
 
@@ -102,5 +98,5 @@ COPY --from=build /workspace/source-controller /usr/local/bin/
 COPY --from=libgit2-bullseye /libgit2/built-on-glibc-version /
 COPY ATTRIBUTIONS.md /
 
-USER controller
+USER 65534:65534
 ENTRYPOINT [ "source-controller" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,8 +91,8 @@ FROM debian:bookworm-slim as controller
 LABEL org.opencontainers.image.source="https://github.com/fluxcd/source-controller"
 
 # Configure user
-RUN groupadd controller && \
-    useradd --gid controller --shell /bin/sh --create-home controller
+RUN addgroup --gid 65532 controller && \
+	useradd -u 65532 -s /sbin/nologin -g controller controller
 
 ARG TARGETPLATFORM
 RUN apt update && apt install -y ca-certificates

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -31,6 +31,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
           capabilities:
             drop: [ "ALL" ]
           seccompProfile:

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -20,9 +20,9 @@ spec:
         prometheus.io/port: "8080"
     spec:
       terminationGracePeriodSeconds: 10
-      # Required for AWS IAM Role bindings
-      # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html
       securityContext:
+        # Required for AWS IAM Role bindings
+        # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html
         fsGroup: 1337
       containers:
       - name: manager
@@ -31,6 +31,10 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ "ALL" ]
+          seccompProfile:
+            type: RuntimeDefault
         ports:
           - containerPort: 9090
             name: http


### PR DESCRIPTION
Further restricts the `SecurityContext` that the controller runs under, by enabling the default seccomp profile, dropping all linux capabilities. 

This was set at container-level to ensure backwards compatibility with use cases in which more privileged sidecars are injected into the `source-controller` pod without setting less restrictive settings.

Note that seccomp will only be enabled if the container runtime and operational system supports it, otherwise the container will run `unconfined` (aka fail-open), which is the same behaviour as not setting the `seccompProfile` in the first place.

Relates to https://github.com/fluxcd/flux2/issues/2014

Impacts https://github.com/weaveworks/flux2-openshift/issues/10

BREAKING CHANGE: 
- The use of new seccomp API requires Kubernetes 1.19.
- The controller container is now executed under `65534:65534` (userid:groupid). This change may break deployments that hard-coded the user name 'controller' in their `PodSecurityPolicy`.