### PR TITLE
Release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.20.0
+
+**Release date:** 2022-01-05
+
+This prerelease comes with an update to the Kubernetes and controller-runtime dependencies
+to align them with the Kubernetes 1.23 release, including an update of Helm to `v3.7.2`.
+
+In addition, the controller is now built with Go 1.17, and 
+`github.com/containerd/containerd` was updated to `v1.5.8` to please
+static security analysers and fix any warnings for GHSA-5j5w-g665-5m35.
+
+Improvements:
+- Update Go to v1.17
+  [#473](https://github.com/fluxcd/source-controller/pull/473)
+- Update build dependencies
+  [#520](https://github.com/fluxcd/source-controller/pull/520)
+- Update containerd to v1.5.8 (fix GHSA-5j5w-g665-5m35)
+  [#529](https://github.com/fluxcd/source-controller/pull/529)
+
 ## 0.19.2
 
 **Release date:** 2021-12-09

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 images:
 - name: fluxcd/source-controller
   newName: fluxcd/source-controller
-  newTag: v0.19.2
+  newTag: v0.20.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/fluxcd/pkg/ssh v0.2.0
 	github.com/fluxcd/pkg/untar v0.1.0
 	github.com/fluxcd/pkg/version v0.1.0
-	github.com/fluxcd/source-controller/api v0.19.2
+	github.com/fluxcd/source-controller/api v0.20.0
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v1.2.2


### PR DESCRIPTION
Starting with this version, contributors are required to use Go 1.17.