### PR TITLE
Fix makefile envtest and controller-gen usage

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,10 +31,6 @@ jobs:
           image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
       - name: Setup Kustomize
         uses: fluxcd/pkg/actions/kustomize@main
-      - name: Setup envtest
-        uses: fluxcd/pkg/actions/envtest@main
-        with:
-          version: "1.19.2"
       - name: Setup Helm
         uses: fluxcd/pkg/actions/helm@main
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 bin/
+testbin/
 config/release/
 
 # Exclude all libgit2 related files


### PR DESCRIPTION
Refactor logic to install helper tools into one function in the
Makefile. Add support for envtest to help install tools like kubectl,
etcd which helps users run tests more conveniently.

Signed-off-by: Sanskar Jaiswal <sanskar.jaiswal@weave.works>

Ref: https://github.com/fluxcd/flux2/issues/2273