### PR TITLE
helm: remove temp file name from index cache err

### DIFF
--- a/internal/helm/repository/chart_repository.go
+++ b/internal/helm/repository/chart_repository.go
@@ -269,7 +269,7 @@ func (r *ChartRepository) CacheIndex() (string, error) {
 	if err = r.DownloadIndex(mw); err != nil {
 		f.Close()
 		os.RemoveAll(f.Name())
-		return "", fmt.Errorf("failed to cache index to '%s': %w", f.Name(), err)
+		return "", fmt.Errorf("failed to cache index to temporary file: %w", err)
 	}
 	if err = f.Close(); err != nil {
 		os.RemoveAll(f.Name())


### PR DESCRIPTION
Reported via Slack: https://cloud-native.slack.com/archives/CLAJ40HV3/p1642001937152300

![image](https://user-images.githubusercontent.com/10063039/149307457-8473e7e9-fdcf-4e9a-8db1-003da16f16fb.png)

---

Due to the temporary file having a random suffix, it would result in
the notification-controller not rate limiting the messages as they
are "unique".

For the close error (which also makes use of the name), we keep the
information as it might be of importance to figure out why the close
failed.