### PR TITLE
Use patch instead of update when adding finalizers

### DIFF
--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -97,8 +97,9 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Add our finalizer if it does not exist
 	if !controllerutil.ContainsFinalizer(&bucket, sourcev1.SourceFinalizer) {
+		patch := client.MergeFrom(bucket.DeepCopy())
 		controllerutil.AddFinalizer(&bucket, sourcev1.SourceFinalizer)
-		if err := r.Update(ctx, &bucket); err != nil {
+		if err := r.Patch(ctx, &bucket, patch); err != nil {
 			log.Error(err, "unable to register finalizer")
 			return ctrl.Result{}, err
 		}

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -100,8 +100,9 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Add our finalizer if it does not exist
 	if !controllerutil.ContainsFinalizer(&repository, sourcev1.SourceFinalizer) {
+		patch := client.MergeFrom(repository.DeepCopy())
 		controllerutil.AddFinalizer(&repository, sourcev1.SourceFinalizer)
-		if err := r.Update(ctx, &repository); err != nil {
+		if err := r.Patch(ctx, &repository, patch); err != nil {
 			log.Error(err, "unable to register finalizer")
 			return ctrl.Result{}, err
 		}

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -126,8 +126,9 @@ func (r *HelmChartReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Add our finalizer if it does not exist
 	if !controllerutil.ContainsFinalizer(&chart, sourcev1.SourceFinalizer) {
+		patch := client.MergeFrom(chart.DeepCopy())
 		controllerutil.AddFinalizer(&chart, sourcev1.SourceFinalizer)
-		if err := r.Update(ctx, &chart); err != nil {
+		if err := r.Patch(ctx, &chart, patch); err != nil {
 			log.Error(err, "unable to register finalizer")
 			return ctrl.Result{}, err
 		}

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -93,8 +93,9 @@ func (r *HelmRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Add our finalizer if it does not exist
 	if !controllerutil.ContainsFinalizer(&repository, sourcev1.SourceFinalizer) {
+		patch := client.MergeFrom(repository.DeepCopy())
 		controllerutil.AddFinalizer(&repository, sourcev1.SourceFinalizer)
-		if err := r.Update(ctx, &repository); err != nil {
+		if err := r.Patch(ctx, &repository, patch); err != nil {
 			log.Error(err, "unable to register finalizer")
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
This is needed to prevent source-controller from managing all the fields under `.spec`.

Ref: https://github.com/fluxcd/flux2/issues/2286