### PR TITLE
e2e: Set timeout to fix intermittent errors

### DIFF
--- a/config/testdata/git/large-repo.yaml
+++ b/config/testdata/git/large-repo.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   gitImplementation: go-git
   interval: 10m
+  timeout: 2m
   url: https://github.com/hashgraph/hedera-mirror-node.git
   ref:
     branch: main
@@ -19,6 +20,7 @@ metadata:
 spec:
   gitImplementation: libgit2
   interval: 10m
+  timeout: 2m
   url: https://github.com/hashgraph/hedera-mirror-node.git
   ref:
     branch: main

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -137,5 +137,5 @@ kubectl -n source-system wait helmchart/helmchart-bucket --for=condition=ready -
 
 echo "Run large Git repo tests"
 kubectl -n source-system apply -f "${ROOT_DIR}/config/testdata/git/large-repo.yaml"
-kubectl -n source-system wait gitrepository/large-repo-go-git --for=condition=ready --timeout=2m
-kubectl -n source-system wait gitrepository/large-repo-libgit2 --for=condition=ready --timeout=2m
+kubectl -n source-system wait gitrepository/large-repo-go-git --for=condition=ready --timeout=2m15s
+kubectl -n source-system wait gitrepository/large-repo-libgit2 --for=condition=ready --timeout=2m15s


### PR DESCRIPTION
Example of intermittent error based on timeout:
https://github.com/fluxcd/source-controller/runs/4872716543?check_suite_focus=true