### PR TITLE
Download libgit2 libraries for fuzzing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-hack/libgit2/
+build/libgit2/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.17
 ARG XX_VERSION=1.1.0
 
 ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2
-ARG LIBGIT2_TAG=libgit2-1.1.1-6
+ARG LIBGIT2_TAG=libgit2-1.1.1-7
 
 FROM ${LIBGIT2_IMG}:${LIBGIT2_TAG} AS libgit2-libs
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG ?= latest
 
 # Base image used to build the Go binary
 LIBGIT2_IMG ?= ghcr.io/fluxcd/golang-with-libgit2
-LIBGIT2_TAG ?= libgit2-1.1.1-6
+LIBGIT2_TAG ?= libgit2-1.1.1-7
 
 # Allows for defining additional Docker buildx arguments,
 # e.g. '--push'.
@@ -234,13 +234,11 @@ fuzz-build: $(LIBGIT2)
 	rm -rf $(shell pwd)/build/fuzz/
 	mkdir -p $(shell pwd)/build/fuzz/out/
 
-# TODO: remove mapping of current libgit2 dir and pull binaries from release or build dependency chain on demand.
 	docker build . --tag local-fuzzing:latest -f tests/fuzz/Dockerfile.builder
 	docker run --rm \
 		-e FUZZING_LANGUAGE=go -e SANITIZER=address \
 		-e CIFUZZ_DEBUG='True' -e OSS_FUZZ_PROJECT_NAME=fluxcd \
 		-v "$(shell pwd)/build/fuzz/out":/out \
-		-v "$(shell pwd)/build/libgit2":"/root/go/src/github.com/fluxcd/source-controller/build/libgit2" \
 		local-fuzzing:latest
 
 fuzz-smoketest: fuzz-build

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -16,7 +16,7 @@
 
 set -euxo pipefail
 
-LIBGIT2_TAG="${LIBGIT2_TAG:-libgit2-1.1.1-6}"
+LIBGIT2_TAG="${LIBGIT2_TAG:-libgit2-1.1.1-7}"
 GOPATH="${GOPATH:-/root/go}"
 GO_SRC="${GOPATH}/src"
 PROJECT_PATH="github.com/fluxcd/source-controller"
@@ -25,9 +25,31 @@ cd "${GO_SRC}"
 
 pushd "${PROJECT_PATH}"
 
+export TARGET_DIR="$(/bin/pwd)/build/libgit2/${LIBGIT2_TAG}"
+
+# For most cases, libgit2 will already be present. 
+# The exception being at the oss-fuzz integration.
+if [ ! -d "${TARGET_DIR}" ]; then
+    curl -o output.tar.gz -LO "https://github.com/fluxcd/golang-with-libgit2/releases/download/${LIBGIT2_TAG}/linux-$(uname -m)-libs.tar.gz"
+    
+    DIR=libgit2-linux
+    NEW_DIR="$(/bin/pwd)/build/libgit2/${LIBGIT2_TAG}"
+    INSTALLED_DIR="/home/runner/work/golang-with-libgit2/golang-with-libgit2/build/${DIR}"
+
+    mkdir -p ./build/libgit2
+
+    tar -xf output.tar.gz
+    rm output.tar.gz
+    mv "${DIR}" "${LIBGIT2_TAG}"
+    mv "${LIBGIT2_TAG}/" "./build/libgit2"
+
+    # Update the prefix paths included in the .pc files.
+    # This will make it easier to update to the location in which they will be used.
+    find "${NEW_DIR}" -type f -name "*.pc" | xargs -I {} sed -i "s;${INSTALLED_DIR};${NEW_DIR};g" {}
+fi
+
 apt-get update && apt-get install -y pkg-config
 
-export TARGET_DIR="$(/bin/pwd)/build/libgit2/${LIBGIT2_TAG}"
 export CGO_ENABLED=1
 export LIBRARY_PATH="${TARGET_DIR}/lib:${TARGET_DIR}/lib64"
 export PKG_CONFIG_PATH="${TARGET_DIR}/lib/pkgconfig:${TARGET_DIR}/lib64/pkgconfig"


### PR DESCRIPTION
Fixes the integration with `oss-fuzz`. The entry point of the integration is `tests/fuzz/oss_fuzz_build.sh` which must be completely self-sufficient.