### PR TITLE
pkg/git: Include commit message and URL in checkout error

### DIFF
--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -383,7 +383,7 @@ var _ = Describe("GitRepositoryReconciler", func() {
 				reference:         &sourcev1.GitRepositoryRef{Branch: "main"},
 				waitForReason:     sourcev1.GitOperationFailedReason,
 				expectStatus:      metav1.ConditionFalse,
-				expectMessage:     "unable to clone: user rejected certificate",
+				expectMessage:     "user rejected certificate",
 				gitImplementation: sourcev1.LibGit2Implementation,
 			}),
 			Entry("self signed libgit2 with CA", refTestCase{

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -93,6 +93,16 @@ func (c *Commit) Verify(keyRing ...string) (string, error) {
 	return "", fmt.Errorf("failed to verify commit with any of the given key rings")
 }
 
+// ShortMessage returns the first 50 characters of a commit subject.
+func (c *Commit) ShortMessage() string {
+	subject := strings.Split(c.Message, "\n")[0]
+	r := []rune(subject)
+	if len(r) > 50 {
+		return fmt.Sprintf("%s...", string(r[0:50]))
+	}
+	return subject
+}
+
 type CheckoutStrategy interface {
 	Checkout(ctx context.Context, path, url string, config *AuthOptions) (*Commit, error)
 }

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -218,3 +218,48 @@ func TestCommit_Verify(t *testing.T) {
 		})
 	}
 }
+
+func TestCommit_ShortMessage(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "short message",
+			input: "a short commit message",
+			want:  "a short commit message",
+		},
+		{
+			name:  "long message",
+			input: "hello world - a long commit message for testing long messages",
+			want:  "hello world - a long commit message for testing lo...",
+		},
+		{
+			name: "multi line commit message",
+			input: `title of the commit
+
+detailed description
+of the commit`,
+			want: "title of the commit",
+		},
+		{
+			name:  "message with unicodes",
+			input: "a message with unicode characters 你好世界 🏞️ 🏕️ ⛩️ 🌌",
+			want:  "a message with unicode characters 你好世界 🏞️ 🏕️ ⛩️ 🌌",
+		},
+		{
+			name:  "empty commit message",
+			input: "",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			c := Commit{Message: tt.input}
+			g.Expect(c.ShortMessage()).To(Equal(tt.want))
+		})
+	}
+}

--- a/pkg/git/gogit/checkout.go
+++ b/pkg/git/gogit/checkout.go
@@ -315,6 +315,7 @@ func buildCommitWithRef(c *object.Commit, ref plumbing.ReferenceName) (*git.Comm
 		Committer: buildSignature(c.Committer),
 		Signature: c.PGPSignature,
 		Encoded:   b,
+		Message:   c.Message,
 	}, nil
 }
 

--- a/pkg/git/libgit2/checkout.go
+++ b/pkg/git/libgit2/checkout.go
@@ -69,7 +69,7 @@ func (c *CheckoutBranch) Checkout(ctx context.Context, path, url string, opts *g
 		CheckoutBranch: c.Branch,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to clone: %w", gitutil.LibGit2Error(err))
+		return nil, fmt.Errorf("unable to clone '%s': %w", url, gitutil.LibGit2Error(err))
 	}
 	defer repo.Free()
 	head, err := repo.Head()


### PR DESCRIPTION
go-git: Include the commit message in the returned commit object.
libgit2: Set the URL in the checkout error.