### PR TITLE
git/libgit2: set CheckoutForce on branch strategy

### DIFF
--- a/pkg/git/gogit/checkout_test.go
+++ b/pkg/git/gogit/checkout_test.go
@@ -58,17 +58,20 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 	tests := []struct {
 		name           string
 		branch         string
+		filesCreated   map[string]string
 		expectedCommit string
 		expectedErr    string
 	}{
 		{
 			name:           "Default branch",
 			branch:         "master",
+			filesCreated:   map[string]string{"branch": "init"},
 			expectedCommit: firstCommit.String(),
 		},
 		{
 			name:           "Other branch",
 			branch:         "test",
+			filesCreated:   map[string]string{"branch": "second"},
 			expectedCommit: secondCommit.String(),
 		},
 		{
@@ -90,12 +93,18 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 
 			cc, err := branch.Checkout(context.TODO(), tmpDir, path, nil)
 			if tt.expectedErr != "" {
+				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tt.expectedErr))
 				g.Expect(cc).To(BeNil())
 				return
 			}
-			g.Expect(err).To(BeNil())
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(cc.String()).To(Equal(tt.branch + "/" + tt.expectedCommit))
+
+			for k, v := range tt.filesCreated {
+				g.Expect(filepath.Join(tmpDir, k)).To(BeARegularFile())
+				g.Expect(os.ReadFile(filepath.Join(tmpDir, k))).To(BeEquivalentTo(v))
+			}
 		})
 	}
 }

--- a/pkg/git/libgit2/checkout.go
+++ b/pkg/git/libgit2/checkout.go
@@ -66,6 +66,9 @@ func (c *CheckoutBranch) Checkout(ctx context.Context, path, url string, opts *g
 			RemoteCallbacks: RemoteCallbacks(ctx, opts),
 			ProxyOptions:    git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
 		},
+		CheckoutOptions: git2go.CheckoutOptions{
+			Strategy: git2go.CheckoutForce,
+		},
 		CheckoutBranch: c.Branch,
 	})
 	if err != nil {
@@ -79,7 +82,7 @@ func (c *CheckoutBranch) Checkout(ctx context.Context, path, url string, opts *g
 	defer head.Free()
 	cc, err := repo.LookupCommit(head.Target())
 	if err != nil {
-		return nil, fmt.Errorf("could not find commit '%s' in branch '%s': %w", head.Target(), c.Branch, err)
+		return nil, fmt.Errorf("failed to lookup HEAD commit '%s' for branch '%s': %w", head.Target(), c.Branch, err)
 	}
 	defer cc.Free()
 	return buildCommit(cc, "refs/heads/"+c.Branch), nil

--- a/pkg/git/libgit2/checkout_test.go
+++ b/pkg/git/libgit2/checkout_test.go
@@ -73,17 +73,20 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 	tests := []struct {
 		name           string
 		branch         string
+		filesCreated   map[string]string
 		expectedCommit string
 		expectedErr    string
 	}{
 		{
 			name:           "Default branch",
 			branch:         defaultBranch,
+			filesCreated:   map[string]string{"branch": "second"},
 			expectedCommit: secondCommit.String(),
 		},
 		{
 			name:           "Other branch",
 			branch:         "test",
+			filesCreated:   map[string]string{"branch": "init"},
 			expectedCommit: firstCommit.String(),
 		},
 		{
@@ -112,6 +115,11 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(cc.String()).To(Equal(tt.branch + "/" + tt.expectedCommit))
+
+			for k, v := range tt.filesCreated {
+				g.Expect(filepath.Join(tmpDir, k)).To(BeARegularFile())
+				g.Expect(os.ReadFile(filepath.Join(tmpDir, k))).To(BeEquivalentTo(v))
+			}
 		})
 	}
 }

--- a/pkg/git/libgit2/checkout_test.go
+++ b/pkg/git/libgit2/checkout_test.go
@@ -51,8 +51,8 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 
 	// ignores the error here because it can be defaulted
 	// https://github.blog/2020-07-27-highlights-from-git-2-28/#introducing-init-defaultbranch
-	defaultBranch := "main"
-	if v, err := cfg.LookupString("init.defaultBranch"); err != nil {
+	defaultBranch := "master"
+	if v, err := cfg.LookupString("init.defaultBranch"); err != nil && v != "" {
 		defaultBranch = v
 	}
 
@@ -61,10 +61,12 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Branch off on first commit
 	if err = createBranch(repo, "test", nil); err != nil {
 		t.Fatal(err)
 	}
 
+	// Create second commit on default branch
 	secondCommit, err := commitFile(repo, "branch", "second", time.Now())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
In the recent update from libgit2 1.1.x to 1.3.x, something seems to
have changed upstream. Resulting in the clone of a branch ending up
with a semi-bare file system state (in other words: without any files
present in the directory).

This commit patches the clone behavior to set the `CheckoutForce`
strategy as `CheckoutOption`, which mitigates the issue.

In addition, test cases have been added to ensure we do not run into
this again by asserting the state of the branch after cloning.

Fixes: https://github.com/fluxcd/source-controller/issues/588