### PR TITLE
Emit failure resolve event

### DIFF
--- a/api/v1beta2/condition_types.go
+++ b/api/v1beta2/condition_types.go
@@ -43,6 +43,10 @@ const (
 	// of a Source's Artifact.
 	// If True, the Source can be in an ArtifactOutdatedCondition.
 	BuildFailedCondition string = "BuildFailed"
+
+	// StorageOperationFailedCondition indicates a transient or persistent failure related to storage. If True, the
+	// reconciliation failed while performing some filesystem operation.
+	StorageOperationFailedCondition string = "StorageOperationFailed"
 )
 
 const (

--- a/api/v1beta2/condition_types.go
+++ b/api/v1beta2/condition_types.go
@@ -44,8 +44,9 @@ const (
 	// If True, the Source can be in an ArtifactOutdatedCondition.
 	BuildFailedCondition string = "BuildFailed"
 
-	// StorageOperationFailedCondition indicates a transient or persistent failure related to storage. If True, the
-	// reconciliation failed while performing some filesystem operation.
+	// StorageOperationFailedCondition indicates a transient or persistent
+	// failure related to storage. If True, the reconciliation failed while
+	// performing some filesystem operation.
 	StorageOperationFailedCondition string = "StorageOperationFailed"
 )
 
@@ -53,11 +54,34 @@ const (
 	// URLInvalidReason signals that a given Source has an invalid URL.
 	URLInvalidReason string = "URLInvalid"
 
-	// StorageOperationFailedReason signals a failure caused by a storage
-	// operation.
-	StorageOperationFailedReason string = "StorageOperationFailed"
-
 	// AuthenticationFailedReason signals that a Secret does not have the
 	// required fields, or the provided credentials do not match.
 	AuthenticationFailedReason string = "AuthenticationFailed"
+
+	// FileCreationFailedReason signals a failure caused by a file creation
+	// operation.
+	FileCreationFailedReason string = "FileCreationFailed"
+
+	// DirCreationFailedReason signals a failure caused by a directory creation
+	// operation.
+	DirCreationFailedReason string = "DirectoryCreationFailed"
+
+	// StatOperationFailedReason signals a failure caused by a stat operation on
+	// a path.
+	StatOperationFailedReason string = "StatOperationFailed"
+
+	// ReadOperationFailedReason signals a failure caused by a read operation.
+	ReadOperationFailedReason string = "ReadOperationFailed"
+
+	// AcquireLockFailedReason signals a failure in acquiring lock.
+	AcquireLockFailedReason string = "AcquireLockFailed"
+
+	// InvalidPathReason signals a failure caused by an invalid path.
+	InvalidPathReason string = "InvalidPath"
+
+	// ArchiveOperationFailedReason signals a failure in archive operation.
+	ArchiveOperationFailedReason string = "ArchiveOperationFailed"
+
+	// SymlinkUpdateFailedReason signals a failure in updating a symlink.
+	SymlinkUpdateFailedReason string = "SymlinkUpdateFailed"
 )

--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -45,7 +45,6 @@ import (
 	"github.com/fluxcd/pkg/runtime/conditions"
 	helper "github.com/fluxcd/pkg/runtime/controller"
 	"github.com/fluxcd/pkg/runtime/events"
-	"github.com/fluxcd/pkg/runtime/patch"
 	"github.com/fluxcd/pkg/runtime/predicates"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
@@ -252,12 +251,6 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 
 	oldObj := obj.DeepCopy()
 
-	// Initialize the patch helper with the current version of the object.
-	patchHelper, err := patch.NewHelper(obj, r.Client)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// recResult stores the abstracted reconcile result.
 	var recResult sreconcile.Result
 	// successEvent stores the notification event to be emitted on success.
@@ -266,7 +259,7 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	// Always attempt to patch the object and status after each reconciliation
 	// NOTE: The final runtime result and error are set in this block.
 	defer func() {
-		summarizeHelper := summarize.NewHelper(r.EventRecorder, patchHelper)
+		summarizeHelper := summarize.NewHelper(r.EventRecorder, r.Client, oldObj)
 		summarizeOpts := []summarize.Option{
 			summarize.WithConditions(bucketReadyCondition),
 			summarize.WithReconcileResult(recResult),

--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -328,8 +328,7 @@ func (r *BucketReconciler) reconcile(ctx context.Context, obj *sourcev1.Bucket, 
 			Err:    fmt.Errorf("failed to create temporary working directory: %w", err),
 			Reason: sourcev1.DirCreationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.DirCreationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 		return successEvent, sreconcile.ResultEmpty, e
 	}
 	defer func() {

--- a/controllers/bucket_controller_test.go
+++ b/controllers/bucket_controller_test.go
@@ -947,6 +947,9 @@ func TestBucketReconciler_reconcileArtifact(t *testing.T) {
 			},
 			want:    sreconcile.ResultEmpty,
 			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StorageOperationFailedReason, "failed to stat source path"),
+			},
 		},
 		{
 			name: "Dir path is not a directory",
@@ -963,6 +966,9 @@ func TestBucketReconciler_reconcileArtifact(t *testing.T) {
 			},
 			want:    sreconcile.ResultEmpty,
 			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StorageOperationFailedReason, "is not a directory"),
+			},
 		},
 	}
 

--- a/controllers/bucket_controller_test.go
+++ b/controllers/bucket_controller_test.go
@@ -948,7 +948,7 @@ func TestBucketReconciler_reconcileArtifact(t *testing.T) {
 			want:    sreconcile.ResultEmpty,
 			wantErr: true,
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StorageOperationFailedReason, "failed to stat source path"),
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StatOperationFailedReason, "failed to stat source path"),
 			},
 		},
 		{
@@ -967,7 +967,7 @@ func TestBucketReconciler_reconcileArtifact(t *testing.T) {
 			want:    sreconcile.ResultEmpty,
 			wantErr: true,
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StorageOperationFailedReason, "is not a directory"),
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.InvalidPathReason, "is not a directory"),
 			},
 		},
 	}

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -227,10 +227,10 @@ func (r *GitRepositoryReconciler) reconcile(ctx context.Context, obj *sourcev1.G
 	if err != nil {
 		e := &serror.Event{
 			Err:    fmt.Errorf("failed to create temporary working directory: %w", err),
-			Reason: sourcev1.StorageOperationFailedReason,
+			Reason: sourcev1.DirCreationFailedReason,
 		}
 		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.StorageOperationFailedReason, e.Err.Error())
+			sourcev1.DirCreationFailedReason, e.Err.Error())
 		return successEvent, sreconcile.ResultEmpty, e
 	}
 	defer func() {
@@ -455,19 +455,19 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context,
 	// Ensure target path exists and is a directory
 	if f, err := os.Stat(dir); err != nil {
 		e := &serror.Event{
-			Err:    fmt.Errorf("failed to stat target path: %w", err),
-			Reason: sourcev1.StorageOperationFailedReason,
+			Err:    fmt.Errorf("failed to stat target artifact path: %w", err),
+			Reason: sourcev1.StatOperationFailedReason,
 		}
 		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.StorageOperationFailedReason, e.Err.Error())
+			sourcev1.StatOperationFailedReason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	} else if !f.IsDir() {
 		e := &serror.Event{
 			Err:    fmt.Errorf("invalid target path: '%s' is not a directory", dir),
-			Reason: sourcev1.StorageOperationFailedReason,
+			Reason: sourcev1.InvalidPathReason,
 		}
 		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.StorageOperationFailedReason, e.Err.Error())
+			sourcev1.InvalidPathReason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -475,10 +475,10 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context,
 	if err := r.Storage.MkdirAll(artifact); err != nil {
 		e := &serror.Event{
 			Err:    fmt.Errorf("failed to create artifact directory: %w", err),
-			Reason: sourcev1.StorageOperationFailedReason,
+			Reason: sourcev1.DirCreationFailedReason,
 		}
 		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.StorageOperationFailedReason, e.Err.Error())
+			sourcev1.DirCreationFailedReason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 	unlock, err := r.Storage.Lock(artifact)
@@ -506,10 +506,10 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context,
 	if err := r.Storage.Archive(&artifact, dir, SourceIgnoreFilter(ps, nil)); err != nil {
 		e := &serror.Event{
 			Err:    fmt.Errorf("unable to archive artifact to storage: %w", err),
-			Reason: sourcev1.StorageOperationFailedReason,
+			Reason: sourcev1.ArchiveOperationFailedReason,
 		}
 		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.StorageOperationFailedReason, e.Err.Error())
+			sourcev1.ArchiveOperationFailedReason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -520,13 +520,8 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context,
 	// Update symlink on a "best effort" basis
 	url, err := r.Storage.Symlink(artifact, "latest.tar.gz")
 	if err != nil {
-		e := &serror.Event{
-			Err:    fmt.Errorf("failed to update status URL symlink: %s", err),
-			Reason: sourcev1.StorageOperationFailedReason,
-		}
-		r.eventLogf(ctx, obj, corev1.EventTypeWarning, sourcev1.StorageOperationFailedReason, e.Err.Error())
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.StorageOperationFailedReason, e.Err.Error())
+		r.eventLogf(ctx, obj, events.EventTypeTrace, sourcev1.SymlinkUpdateFailedReason,
+			"failed to update status URL symlink: %s", err)
 	}
 	if url != "" {
 		obj.Status.URL = url

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -229,8 +229,7 @@ func (r *GitRepositoryReconciler) reconcile(ctx context.Context, obj *sourcev1.G
 			Err:    fmt.Errorf("failed to create temporary working directory: %w", err),
 			Reason: sourcev1.DirCreationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.DirCreationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 		return successEvent, sreconcile.ResultEmpty, e
 	}
 	defer func() {
@@ -348,7 +347,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context,
 				Err:    fmt.Errorf("failed to get secret '%s': %w", name.String(), err),
 				Reason: sourcev1.AuthenticationFailedReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 			// Return error as the world as observed may change
 			return sreconcile.ResultEmpty, e
 		}
@@ -364,7 +363,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context,
 			Err:    fmt.Errorf("failed to configure auth strategy for Git implementation '%s': %w", obj.Spec.GitImplementation, err),
 			Reason: sourcev1.AuthenticationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 		// Return error as the contents of the secret may change
 		return sreconcile.ResultEmpty, e
 	}
@@ -384,7 +383,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context,
 			Err:    fmt.Errorf("failed to configure checkout strategy for Git implementation '%s': %w", obj.Spec.GitImplementation, err),
 			Reason: sourcev1.GitOperationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.GitOperationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 		// Do not return err as recovery without changes is impossible
 		return sreconcile.ResultEmpty, e
 	}
@@ -398,7 +397,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context,
 			Err:    fmt.Errorf("failed to checkout and determine revision: %w", err),
 			Reason: sourcev1.GitOperationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.GitOperationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 		// Coin flip on transient or persistent error, return error and hope for the best
 		return sreconcile.ResultEmpty, e
 	}
@@ -458,16 +457,14 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context,
 			Err:    fmt.Errorf("failed to stat target artifact path: %w", err),
 			Reason: sourcev1.StatOperationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.StatOperationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	} else if !f.IsDir() {
 		e := &serror.Event{
 			Err:    fmt.Errorf("invalid target path: '%s' is not a directory", dir),
 			Reason: sourcev1.InvalidPathReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.InvalidPathReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -477,8 +474,7 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context,
 			Err:    fmt.Errorf("failed to create artifact directory: %w", err),
 			Reason: sourcev1.DirCreationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.DirCreationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 	unlock, err := r.Storage.Lock(artifact)
@@ -508,8 +504,7 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context,
 			Err:    fmt.Errorf("unable to archive artifact to storage: %w", err),
 			Reason: sourcev1.ArchiveOperationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.ArchiveOperationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -41,7 +41,6 @@ import (
 	"github.com/fluxcd/pkg/runtime/conditions"
 	helper "github.com/fluxcd/pkg/runtime/controller"
 	"github.com/fluxcd/pkg/runtime/events"
-	"github.com/fluxcd/pkg/runtime/patch"
 	"github.com/fluxcd/pkg/runtime/predicates"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
@@ -149,12 +148,6 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	oldObj := obj.DeepCopy()
 
-	// Initialize the patch helper with the current version of the object.
-	patchHelper, err := patch.NewHelper(obj, r.Client)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// recResult stores the abstracted reconcile result.
 	var recResult sreconcile.Result
 	// successEvent stores the notification event to be emitted on success.
@@ -163,7 +156,7 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Always attempt to patch the object and status after each reconciliation
 	// NOTE: The final runtime result and error are set in this block.
 	defer func() {
-		summarizeHelper := summarize.NewHelper(r.EventRecorder, patchHelper)
+		summarizeHelper := summarize.NewHelper(r.EventRecorder, r.Client, oldObj)
 		summarizeOpts := []summarize.Option{
 			summarize.WithConditions(gitRepositoryReadyCondition),
 			summarize.WithReconcileResult(recResult),

--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -812,11 +812,17 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			name:    "Target path does not exists",
 			dir:     "testdata/git/foo",
 			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StorageOperationFailedReason, "failed to stat target path"),
+			},
 		},
 		{
 			name:    "Target path is not a directory",
 			dir:     "testdata/git/repository/foo.txt",
 			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StorageOperationFailedReason, "invalid target path"),
+			},
 		},
 	}
 	artifactSize := func(g *WithT, artifactURL string) *int64 {

--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -813,7 +813,7 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			dir:     "testdata/git/foo",
 			wantErr: true,
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StorageOperationFailedReason, "failed to stat target path"),
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StatOperationFailedReason, "failed to stat target artifact path"),
 			},
 		},
 		{
@@ -821,7 +821,7 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			dir:     "testdata/git/repository/foo.txt",
 			wantErr: true,
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StorageOperationFailedReason, "invalid target path"),
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.InvalidPathReason, "invalid target path"),
 			},
 		},
 	}

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -50,7 +50,6 @@ import (
 	"github.com/fluxcd/pkg/runtime/conditions"
 	helper "github.com/fluxcd/pkg/runtime/controller"
 	"github.com/fluxcd/pkg/runtime/events"
-	"github.com/fluxcd/pkg/runtime/patch"
 	"github.com/fluxcd/pkg/runtime/predicates"
 	"github.com/fluxcd/pkg/untar"
 
@@ -178,12 +177,6 @@ func (r *HelmChartReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	oldObj := obj.DeepCopy()
 
-	// Initialize the patch helper with the current version of the object.
-	patchHelper, err := patch.NewHelper(obj, r.Client)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// recResult stores the abstracted reconcile result.
 	var recResult sreconcile.Result
 	// successEvent stores the notification event to be emitted on success.
@@ -192,7 +185,7 @@ func (r *HelmChartReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Always attempt to patch the object after each reconciliation.
 	// NOTE: The final runtime result and error are set in this block.
 	defer func() {
-		summarizeHelper := summarize.NewHelper(r.EventRecorder, patchHelper)
+		summarizeHelper := summarize.NewHelper(r.EventRecorder, r.Client, oldObj)
 		summarizeOpts := []summarize.Option{
 			summarize.WithConditions(helmChartReadyCondition),
 			summarize.WithReconcileResult(recResult),

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -326,7 +326,7 @@ func (r *HelmChartReconciler) reconcileSource(ctx context.Context, obj *sourcev1
 			Err:    fmt.Errorf("failed to get source: %w", err),
 			Reason: "SourceUnavailable",
 		}
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, "SourceUnavailable", e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 
 		// Return Kubernetes client errors, but ignore others which can only be
 		// solved by a change in generation
@@ -416,7 +416,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 				Err:    fmt.Errorf("failed to get secret '%s': %w", repo.Spec.SecretRef.Name, err),
 				Reason: sourcev1.AuthenticationFailedReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 			// Return error as the world as observed may change
 			return sreconcile.ResultEmpty, e
 		}
@@ -428,7 +428,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 				Err:    fmt.Errorf("failed to configure Helm client with secret data: %w", err),
 				Reason: sourcev1.AuthenticationFailedReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 			// Requeue as content of secret might change
 			return sreconcile.ResultEmpty, e
 		}
@@ -440,7 +440,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 				Err:    fmt.Errorf("failed to create TLS client config with secret data: %w", err),
 				Reason: sourcev1.AuthenticationFailedReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 			// Requeue as content of secret might change
 			return sreconcile.ResultEmpty, e
 		}
@@ -457,14 +457,14 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 				Err:    fmt.Errorf("invalid Helm repository URL: %w", err),
 				Reason: sourcev1.URLInvalidReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.URLInvalidReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 			return sreconcile.ResultEmpty, e
 		default:
 			e := &serror.Stalling{
 				Err:    fmt.Errorf("failed to construct Helm client: %w", err),
 				Reason: meta.FailedReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, meta.FailedReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -509,7 +509,7 @@ func (r *HelmChartReconciler) buildFromTarballArtifact(ctx context.Context, obj 
 			Err:    fmt.Errorf("failed to create temporary working directory: %w", err),
 			Reason: sourcev1.DirCreationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.DirCreationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 	defer os.RemoveAll(tmpDir)
@@ -521,7 +521,7 @@ func (r *HelmChartReconciler) buildFromTarballArtifact(ctx context.Context, obj 
 			Err:    fmt.Errorf("failed to create directory to untar source into: %w", err),
 			Reason: sourcev1.DirCreationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.DirCreationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -532,7 +532,7 @@ func (r *HelmChartReconciler) buildFromTarballArtifact(ctx context.Context, obj 
 			Err:    fmt.Errorf("failed to open source artifact: %w", err),
 			Reason: sourcev1.ReadOperationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.ReadOperationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 	if _, err = untar.Untar(f, sourceDir); err != nil {
@@ -556,7 +556,7 @@ func (r *HelmChartReconciler) buildFromTarballArtifact(ctx context.Context, obj 
 			Err:    fmt.Errorf("path calculation for chart '%s' failed: %w", obj.Spec.Chart, err),
 			Reason: "IllegalPath",
 		}
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, "IllegalPath", e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 		// We are unable to recover from this change without a change in generation
 		return sreconcile.ResultEmpty, e
 	}
@@ -664,8 +664,7 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, obj *source
 			Err:    fmt.Errorf("failed to create artifact directory: %w", err),
 			Reason: sourcev1.DirCreationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.DirCreationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 	unlock, err := r.Storage.Lock(artifact)
@@ -674,8 +673,7 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, obj *source
 			Err:    fmt.Errorf("failed to acquire lock for artifact: %w", err),
 			Reason: sourcev1.AcquireLockFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.AcquireLockFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 	defer unlock()
@@ -686,8 +684,7 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, obj *source
 			Err:    fmt.Errorf("unable to copy Helm chart to storage: %w", err),
 			Reason: sourcev1.ArchiveOperationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.ArchiveOperationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 

--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -1453,7 +1453,7 @@ func TestHelmChartReconciler_reconcileSubRecs(t *testing.T) {
 				},
 			}
 
-			got, err := r.reconcile(context.TODO(), obj, tt.reconcileFuncs)
+			_, got, err := r.reconcile(context.TODO(), obj, tt.reconcileFuncs)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 			g.Expect(got).To(Equal(tt.wantResult))
 

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -242,8 +242,7 @@ func (r *HelmRepositoryReconciler) reconcile(ctx context.Context, obj *sourcev1.
 				Err:    fmt.Errorf("unable to read the artifact: %w", err),
 				Reason: sourcev1.ReadOperationFailedReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-				sourcev1.ReadOperationFailedReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 			return successEvent, sreconcile.ResultEmpty, e
 		}
 		size := units.HumanSize(float64(fi.Size()))
@@ -325,7 +324,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, obj *sou
 				Err:    fmt.Errorf("failed to get secret '%s': %w", name.String(), err),
 				Reason: sourcev1.AuthenticationFailedReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 			return sreconcile.ResultEmpty, e
 		}
 
@@ -336,7 +335,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, obj *sou
 				Err:    fmt.Errorf("failed to configure Helm client with secret data: %w", err),
 				Reason: sourcev1.AuthenticationFailedReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 			// Return err as the content of the secret may change.
 			return sreconcile.ResultEmpty, e
 		}
@@ -348,7 +347,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, obj *sou
 				Err:    fmt.Errorf("failed to create TLS client config with secret data: %w", err),
 				Reason: sourcev1.AuthenticationFailedReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 			// Requeue as content of secret might change
 			return sreconcile.ResultEmpty, e
 		}
@@ -363,14 +362,14 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, obj *sou
 				Err:    fmt.Errorf("invalid Helm repository URL: %w", err),
 				Reason: sourcev1.URLInvalidReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.URLInvalidReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 			return sreconcile.ResultEmpty, e
 		default:
 			e := &serror.Stalling{
 				Err:    fmt.Errorf("failed to construct Helm client: %w", err),
 				Reason: meta.FailedReason,
 			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, meta.FailedReason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -380,7 +379,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, obj *sou
 			Err:    fmt.Errorf("failed to fetch Helm repository index: %w", err),
 			Reason: meta.FailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, meta.FailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 		// Coin flip on transient or persistent error, return error and hope for the best
 		return sreconcile.ResultEmpty, e
 	}
@@ -390,9 +389,9 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, obj *sou
 	if err := chartRepo.LoadFromCache(); err != nil {
 		e := &serror.Event{
 			Err:    fmt.Errorf("failed to load Helm repository from cache: %w", err),
-			Reason: sourcev1.FetchFailedCondition,
+			Reason: sourcev1.IndexationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.IndexationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 	defer chartRepo.Unload()
@@ -449,8 +448,7 @@ func (r *HelmRepositoryReconciler) reconcileArtifact(ctx context.Context, obj *s
 			Err:    fmt.Errorf("failed to create artifact directory: %w", err),
 			Reason: sourcev1.DirCreationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.DirCreationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -470,8 +468,7 @@ func (r *HelmRepositoryReconciler) reconcileArtifact(ctx context.Context, obj *s
 			Err:    fmt.Errorf("unable to save artifact to storage: %w", err),
 			Reason: sourcev1.ArchiveOperationFailedReason,
 		}
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition,
-			sourcev1.ArchiveOperationFailedReason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
 		return sreconcile.ResultEmpty, e
 	}
 

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -41,7 +41,6 @@ import (
 	"github.com/fluxcd/pkg/runtime/conditions"
 	helper "github.com/fluxcd/pkg/runtime/controller"
 	"github.com/fluxcd/pkg/runtime/events"
-	"github.com/fluxcd/pkg/runtime/patch"
 	"github.com/fluxcd/pkg/runtime/predicates"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
@@ -139,12 +138,6 @@ func (r *HelmRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	oldObj := obj.DeepCopy()
 
-	// Initialize the patch helper with the current version of the object.
-	patchHelper, err := patch.NewHelper(obj, r.Client)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// recResult stores the abstracted reconcile result.
 	var recResult sreconcile.Result
 	// successEvent stores the notification event to be emitted on success.
@@ -153,7 +146,7 @@ func (r *HelmRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Always attempt to patch the object after each reconciliation.
 	// NOTE: The final runtime result and error are set in this block.
 	defer func() {
-		summarizeHelper := summarize.NewHelper(r.EventRecorder, patchHelper)
+		summarizeHelper := summarize.NewHelper(r.EventRecorder, r.Client, oldObj)
 		summarizeOpts := []summarize.Option{
 			summarize.WithConditions(helmRepositoryReadyCondition),
 			summarize.WithReconcileResult(recResult),

--- a/controllers/helmrepository_controller_test.go
+++ b/controllers/helmrepository_controller_test.go
@@ -736,7 +736,7 @@ func TestHelmRepositoryReconciler_reconcileSubRecs(t *testing.T) {
 
 			ctx := context.TODO()
 
-			gotRes, gotErr := r.reconcile(ctx, obj, tt.reconcileFuncs)
+			_, gotRes, gotErr := r.reconcile(ctx, obj, tt.reconcileFuncs)
 			g.Expect(gotErr != nil).To(Equal(tt.wantErr))
 			g.Expect(gotRes).To(Equal(tt.wantResult))
 

--- a/docs/spec/v1beta2/buckets.md
+++ b/docs/spec/v1beta2/buckets.md
@@ -903,17 +903,20 @@ without completing. This can occur due to some of the following factors:
   non-existing Secret.
 - The credentials in the referenced Secret are invalid.
 - The Bucket spec contains a generic misconfiguration.
+- A storage related failure when storing the artifact.
 
 When this happens, the controller sets the `Ready` Condition status to `False`,
 and adds a Condition with the following attributes to the Bucket's
 `.status.conditions`:
 
-- `type: FetchFailed`
+- `type: FetchFailed` | `type: StorageOperationFailed`
 - `status: "True"`
 - `reason: AuthenticationFailed` | `reason: BucketOperationFailed`
 
 This condition has a ["negative polarity"][typical-status-properties],
 and is only present on the Bucket while the status value is `"True"`.
+There may be more arbitrary values for the `reason` field to provide accurate
+reason for a condition.
 
 While the Bucket has this Condition, the controller will continue to attempt
 to produce an Artifact for the resource with an exponential backoff, until

--- a/docs/spec/v1beta2/gitrepositories.md
+++ b/docs/spec/v1beta2/gitrepositories.md
@@ -763,17 +763,20 @@ factors:
 - The verification of the Git commit signature failed.
 - The credentials in the referenced Secret are invalid.
 - The GitRepository spec contains a generic misconfiguration.
+- A storage related failure when storing the artifact.
 
 When this happens, the controller sets the `Ready` Condition status to `False`,
 and adds a Condition with the following attributes to the GitRepository's
 `.status.conditions`:
 
-- `type: FetchFailed` | `type: IncludeUnavailableCondition`
+- `type: FetchFailed` | `type: IncludeUnavailable` | `type: StorageOperationFailed`
 - `status: "True"`
-- `reason: AuthenticationFailed` | `reason: GitOperationFailed` | `reason: StorageOperationFailed`
+- `reason: AuthenticationFailed` | `reason: GitOperationFailed`
 
 This condition has a ["negative polarity"][typical-status-properties],
 and is only present on the GitRepository while the status value is `"True"`.
+There may be more arbitrary values for the `reason` field to provide accurate
+reason for a condition.
 
 In addition to the above Condition types, when the
 [verification of a Git commit signature](#verification) fails. A condition with

--- a/docs/spec/v1beta2/helmcharts.md
+++ b/docs/spec/v1beta2/helmcharts.md
@@ -532,17 +532,20 @@ factors:
 - The credentials in the [Source reference](#source-reference) Secret are
   invalid.
 - The HelmChart spec contains a generic misconfiguration.
+- A storage related failure when storing the artifact.
 
 When this happens, the controller sets the `Ready` Condition status to `False`,
 and adds a Condition with the following attributes to the HelmChart's
 `.status.conditions`:
 
-- `type: FetchFailed`
+- `type: FetchFailed` | `type: StorageOperationFailed`
 - `status: "True"`
 - `reason: AuthenticationFailed` | `reason: StorageOperationFailed` | `reason: URLInvalid` | `reason: IllegalPath` | `reason: Failed`
 
 This condition has a ["negative polarity"][typical-status-properties],
 and is only present on the HelmChart while the status value is `"True"`.
+There may be more arbitrary values for the `reason` field to provide accurate
+reason for a condition.
 
 While the HelmChart has this Condition, the controller will continue to
 attempt to produce an Artifact for the resource with an exponential backoff,

--- a/docs/spec/v1beta2/helmrepositories.md
+++ b/docs/spec/v1beta2/helmrepositories.md
@@ -475,17 +475,20 @@ factors:
   non-existing Secret.
 - The credentials in the referenced Secret are invalid.
 - The HelmRepository spec contains a generic misconfiguration.
+- A storage related failure when storing the artifact.
 
 When this happens, the controller sets the `Ready` Condition status to `False`,
 and adds a Condition with the following attributes to the HelmRepository's
 `.status.conditions`:
 
-- `type: FetchFailed`
+- `type: FetchFailed` | `type: StorageOperationFailed`
 - `status: "True"`
 - `reason: AuthenticationFailed` | `reason: IndexationFailed` | `reason: Failed`
 
 This condition has a ["negative polarity"][typical-status-properties],
 and is only present on the HelmRepository while the status value is `"True"`.
+There may be more arbitrary values for the `reason` field to provide accurate
+reason for a condition.
 
 While the HelmRepository has this Condition, the controller will continue to
 attempt to produce an Artifact for the resource with an exponential backoff,

--- a/internal/reconcile/summarize/summary.go
+++ b/internal/reconcile/summarize/summary.go
@@ -46,6 +46,26 @@ type Conditions struct {
 	NegativePolarity []string
 }
 
+// Notification contains information for constructing an event to be emitted. It
+// is used to define notifications from the SummarizeAndPatch helper.
+// Notification in itself doesn't have any type, like warning or normal, based
+// on the context, a notification can be used to construct different types of
+// events.
+type Notification struct {
+	Reason      string
+	Message     string
+	Annotations map[string]string
+}
+
+// IsZero evaluates if the Notification is empty based on the Reason and Message
+// values.
+func (n Notification) IsZero() bool {
+	if n.Reason == "" && n.Message == "" {
+		return true
+	}
+	return false
+}
+
 // Helper is SummarizeAndPatch helper.
 type Helper struct {
 	recorder    kuberecorder.EventRecorder


### PR DESCRIPTION
When source reconciliation failure happens, a warning event is emitted but
when resolved, there's no resolved event emitted, leaving the user uninformed
about the status of the operation.

This change checks the object status for failure conditions and
emits a normal event to notify that the failure is resolved on a
successful reconciliation. If a failure is resolved along with a new artifact,
"stored artifact" event is emitted, suppressing the failure resolve message.
New artifact event implies that the reconciliation was successful.

When using notification-controller, this appears as:

![git-repo-fail-final](https://user-images.githubusercontent.com/614105/157894234-2ea92e96-eda0-4e6b-bb2d-b633069580b6.png)

Console logs:

```console
{"level":"error","ts":"2022-03-07T13:57:00.950Z","logger":"controller.gitrepository","msg":"Reconciler error","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"podinfo","namespace":"flux-system","error":"failed to checkout and determine revision: unable to clone 'ssh://git@github.com/stefanprodan/podinfo': Failed to retrieve list of SSH authentication methods: Failed getting response"}
{"level":"info","ts":"2022-03-07T13:57:07.279Z","logger":"controller.gitrepository","msg":"resolved 'GitOperationFailed'","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"podinfo","namespace":"flux-system"}
```