### PR TITLE
controllers: store HelmChart Artifact with suffix

### DIFF
--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -626,11 +626,11 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, obj *source
 	}()
 
 	// Create artifact from build data
-	artifact := r.Storage.NewArtifactFor(obj.Kind, obj.GetObjectMeta(), b.Version, fmt.Sprintf("%s-%s.tgz", b.Name, b.Version))
+	artifact := r.Storage.NewArtifactFor(obj.Kind, obj.GetObjectMeta(), b.Version, fmt.Sprintf("%s-%s-%d.tgz", b.Name, b.Version, time.Now().Unix()))
 
 	// Return early if the build path equals the current artifact path
 	if curArtifact := obj.GetArtifact(); curArtifact != nil && r.Storage.LocalPath(*curArtifact) == b.Path {
-		ctrl.LoggerFrom(ctx).Info("artifact up-to-date", "revision", artifact.Revision)
+		ctrl.LoggerFrom(ctx).Info("artifact up-to-date", "revision", curArtifact.Revision)
 		return sreconcile.ResultSuccess, nil
 	}
 


### PR DESCRIPTION
This adds a Unix suffix to the HelmChart Artifact filename, to ensure
it is unique for sequential builds triggered due to e.g. a controller
restart.

The result of this is that consumers who _think_ they are fetching an
Artifact with a certain checksum run into a 404 when attempting to
download a previously advertised but now unavailable file, instead of
running into a checksum validation error (due to non-repetitive Helm
builds).

Potentially fixes #610 