### PR TITLE
Add new condition StorageOperationFailedCondition

### DIFF
--- a/api/v1beta2/condition_types.go
+++ b/api/v1beta2/condition_types.go
@@ -43,17 +43,41 @@ const (
 	// of a Source's Artifact.
 	// If True, the Source can be in an ArtifactOutdatedCondition.
 	BuildFailedCondition string = "BuildFailed"
+
+	// StorageOperationFailedCondition indicates a transient or persistent
+	// failure related to storage. If True, the reconciliation failed while
+	// performing some filesystem operation.
+	StorageOperationFailedCondition string = "StorageOperationFailed"
 )
 
 const (
 	// URLInvalidReason signals that a given Source has an invalid URL.
 	URLInvalidReason string = "URLInvalid"
 
-	// StorageOperationFailedReason signals a failure caused by a storage
-	// operation.
-	StorageOperationFailedReason string = "StorageOperationFailed"
-
 	// AuthenticationFailedReason signals that a Secret does not have the
 	// required fields, or the provided credentials do not match.
 	AuthenticationFailedReason string = "AuthenticationFailed"
+
+	// DirCreationFailedReason signals a failure caused by a directory creation
+	// operation.
+	DirCreationFailedReason string = "DirectoryCreationFailed"
+
+	// StatOperationFailedReason signals a failure caused by a stat operation on
+	// a path.
+	StatOperationFailedReason string = "StatOperationFailed"
+
+	// ReadOperationFailedReason signals a failure caused by a read operation.
+	ReadOperationFailedReason string = "ReadOperationFailed"
+
+	// AcquireLockFailedReason signals a failure in acquiring lock.
+	AcquireLockFailedReason string = "AcquireLockFailed"
+
+	// InvalidPathReason signals a failure caused by an invalid path.
+	InvalidPathReason string = "InvalidPath"
+
+	// ArchiveOperationFailedReason signals a failure in archive operation.
+	ArchiveOperationFailedReason string = "ArchiveOperationFailed"
+
+	// SymlinkUpdateFailedReason signals a failure in updating a symlink.
+	SymlinkUpdateFailedReason string = "SymlinkUpdateFailed"
 )

--- a/controllers/bucket_controller_test.go
+++ b/controllers/bucket_controller_test.go
@@ -947,6 +947,9 @@ func TestBucketReconciler_reconcileArtifact(t *testing.T) {
 			},
 			want:    sreconcile.ResultEmpty,
 			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StatOperationFailedReason, "failed to stat source path"),
+			},
 		},
 		{
 			name: "Dir path is not a directory",
@@ -963,6 +966,9 @@ func TestBucketReconciler_reconcileArtifact(t *testing.T) {
 			},
 			want:    sreconcile.ResultEmpty,
 			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.InvalidPathReason, "is not a directory"),
+			},
 		},
 	}
 

--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -812,11 +812,17 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			name:    "Target path does not exists",
 			dir:     "testdata/git/foo",
 			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.StatOperationFailedReason, "failed to stat target artifact path"),
+			},
 		},
 		{
 			name:    "Target path is not a directory",
 			dir:     "testdata/git/repository/foo.txt",
 			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, sourcev1.InvalidPathReason, "invalid target path"),
+			},
 		},
 	}
 	artifactSize := func(g *WithT, artifactURL string) *int64 {
@@ -1172,7 +1178,7 @@ func TestGitRepositoryReconciler_verifyCommitSignature(t *testing.T) {
 			},
 			wantErr: true,
 			assertConditions: []metav1.Condition{
-				*conditions.FalseCondition(sourcev1.SourceVerifiedCondition, meta.FailedReason, "signature verification of commit 'shasum' failed: failed to verify commit with any of the given key rings"),
+				*conditions.FalseCondition(sourcev1.SourceVerifiedCondition, "InvalidCommitSignature", "signature verification of commit 'shasum' failed: failed to verify commit with any of the given key rings"),
 			},
 		},
 		{
@@ -1188,7 +1194,7 @@ func TestGitRepositoryReconciler_verifyCommitSignature(t *testing.T) {
 			},
 			wantErr: true,
 			assertConditions: []metav1.Condition{
-				*conditions.FalseCondition(sourcev1.SourceVerifiedCondition, meta.FailedReason, "PGP public keys secret error: secrets \"none-existing\" not found"),
+				*conditions.FalseCondition(sourcev1.SourceVerifiedCondition, "VerificationError", "PGP public keys secret error: secrets \"none-existing\" not found"),
 			},
 		},
 		{

--- a/docs/spec/v1beta2/buckets.md
+++ b/docs/spec/v1beta2/buckets.md
@@ -903,17 +903,20 @@ without completing. This can occur due to some of the following factors:
   non-existing Secret.
 - The credentials in the referenced Secret are invalid.
 - The Bucket spec contains a generic misconfiguration.
+- A storage related failure when storing the artifact.
 
 When this happens, the controller sets the `Ready` Condition status to `False`,
 and adds a Condition with the following attributes to the Bucket's
 `.status.conditions`:
 
-- `type: FetchFailed`
+- `type: FetchFailed` | `type: StorageOperationFailed`
 - `status: "True"`
 - `reason: AuthenticationFailed` | `reason: BucketOperationFailed`
 
 This condition has a ["negative polarity"][typical-status-properties],
 and is only present on the Bucket while the status value is `"True"`.
+There may be more arbitrary values for the `reason` field to provide accurate
+reason for a condition.
 
 While the Bucket has this Condition, the controller will continue to attempt
 to produce an Artifact for the resource with an exponential backoff, until

--- a/docs/spec/v1beta2/gitrepositories.md
+++ b/docs/spec/v1beta2/gitrepositories.md
@@ -763,17 +763,20 @@ factors:
 - The verification of the Git commit signature failed.
 - The credentials in the referenced Secret are invalid.
 - The GitRepository spec contains a generic misconfiguration.
+- A storage related failure when storing the artifact.
 
 When this happens, the controller sets the `Ready` Condition status to `False`,
 and adds a Condition with the following attributes to the GitRepository's
 `.status.conditions`:
 
-- `type: FetchFailed` | `type: IncludeUnavailableCondition`
+- `type: FetchFailed` | `type: IncludeUnavailable` | `type: StorageOperationFailed`
 - `status: "True"`
-- `reason: AuthenticationFailed` | `reason: GitOperationFailed` | `reason: StorageOperationFailed`
+- `reason: AuthenticationFailed` | `reason: GitOperationFailed`
 
 This condition has a ["negative polarity"][typical-status-properties],
 and is only present on the GitRepository while the status value is `"True"`.
+There may be more arbitrary values for the `reason` field to provide accurate
+reason for a condition.
 
 In addition to the above Condition types, when the
 [verification of a Git commit signature](#verification) fails. A condition with

--- a/docs/spec/v1beta2/helmcharts.md
+++ b/docs/spec/v1beta2/helmcharts.md
@@ -532,17 +532,20 @@ factors:
 - The credentials in the [Source reference](#source-reference) Secret are
   invalid.
 - The HelmChart spec contains a generic misconfiguration.
+- A storage related failure when storing the artifact.
 
 When this happens, the controller sets the `Ready` Condition status to `False`,
 and adds a Condition with the following attributes to the HelmChart's
 `.status.conditions`:
 
-- `type: FetchFailed`
+- `type: FetchFailed` | `type: StorageOperationFailed`
 - `status: "True"`
 - `reason: AuthenticationFailed` | `reason: StorageOperationFailed` | `reason: URLInvalid` | `reason: IllegalPath` | `reason: Failed`
 
 This condition has a ["negative polarity"][typical-status-properties],
 and is only present on the HelmChart while the status value is `"True"`.
+There may be more arbitrary values for the `reason` field to provide accurate
+reason for a condition.
 
 While the HelmChart has this Condition, the controller will continue to
 attempt to produce an Artifact for the resource with an exponential backoff,

--- a/docs/spec/v1beta2/helmrepositories.md
+++ b/docs/spec/v1beta2/helmrepositories.md
@@ -475,17 +475,20 @@ factors:
   non-existing Secret.
 - The credentials in the referenced Secret are invalid.
 - The HelmRepository spec contains a generic misconfiguration.
+- A storage related failure when storing the artifact.
 
 When this happens, the controller sets the `Ready` Condition status to `False`,
 and adds a Condition with the following attributes to the HelmRepository's
 `.status.conditions`:
 
-- `type: FetchFailed`
+- `type: FetchFailed` | `type: StorageOperationFailed`
 - `status: "True"`
 - `reason: AuthenticationFailed` | `reason: IndexationFailed` | `reason: Failed`
 
 This condition has a ["negative polarity"][typical-status-properties],
 and is only present on the HelmRepository while the status value is `"True"`.
+There may be more arbitrary values for the `reason` field to provide accurate
+reason for a condition.
 
 While the HelmRepository has this Condition, the controller will continue to
 attempt to produce an Artifact for the resource with an exponential backoff,


### PR DESCRIPTION
Introduce new condition `StorageOperationFailedCondition` for all the
failures related to the storage. It is a negative polarity condition and
is considered in computing summary of reconciliation.

Also, introduce more granular event reasons related to
`StorageOperationFailedCondition` for precise reasoning behind failures.
These replace the vague `StorageOperationFailedReason`.