### PR TITLE
build: update to libssl 1.1.1n-r0 from edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,10 @@ RUN xx-verify --static /source-controller
 FROM alpine:3.15
 
 ARG TARGETPLATFORM
+
+# Mitigate CVE-2022-0778
+RUN apk --no-cache add libssl1.1 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+
 RUN apk --no-cache add ca-certificates \
   && update-ca-certificates
 


### PR DESCRIPTION
This mitigates CVE-2022-0778.

```console
$ trivy fluxcd/source-controller:latest
2022-03-17T10:13:29.282+0100    INFO    Detected OS: alpine
2022-03-17T10:13:29.282+0100    INFO    Detecting Alpine vulnerabilities...
2022-03-17T10:13:29.282+0100    INFO    Number of language-specific files: 1
2022-03-17T10:13:29.283+0100    INFO    Detecting gobinary vulnerabilities...

fluxcd/source-controller:latest (alpine 3.15.1)
===============================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


usr/local/bin/source-controller (gobinary)
==========================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```