### PR TITLE
Use main go.mod for fuzz tests

### DIFF
--- a/tests/fuzz/go.mod
+++ b/tests/fuzz/go.mod
@@ -1,7 +1,6 @@
 module github.com/fluxcd/source-controller/tests/fuzz
+// This module is used only to avoid polluting the main module
+// with fuzz dependencies.
+// It is managed by oss_fuzz_build.sh.
 
 go 1.17
-
-replace github.com/fluxcd/kustomize-controller/api => ../../api
-
-replace github.com/fluxcd/kustomize-controller => ../../

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -54,7 +54,15 @@ export PKG_CONFIG_PATH="${TARGET_DIR}/lib/pkgconfig:${TARGET_DIR}/lib64/pkgconfi
 export CGO_CFLAGS="-I${TARGET_DIR}/include -I${TARGET_DIR}/include/openssl"
 export CGO_LDFLAGS="$(pkg-config --libs --static --cflags libssh2 openssl libgit2)"
 
-go mod tidy
+# Use main go.mod in order to conserve the same version across all dependencies.
+cp ../../go.mod .
+cp ../../go.sum .
+
+sed -i 's;module .*;module github.com/fluxcd/kustomize-controller/tests/fuzz;g' go.mod
+sed -i 's;api => ./api;api => ../../api;g' go.mod
+echo "replace github.com/fluxcd/kustomize-controller => ../../" >> go.mod
+
+go mod download
 
 # The implementation of libgit2 is sensitive to the versions of git2go.
 # Leaving it to its own devices, the minimum version of git2go used may not


### PR DESCRIPTION
Fixes issues building fuzzers whilst also ensuring
that they are linking back to current version of
source-controller and ./api.