### PR TITLE
Improve memory and cpu performance

### DIFF
--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -1483,3 +1483,28 @@ func mockChartBuild(name, version, path string) *chart.Build {
 		Path:    copyP,
 	}
 }
+
+func runBenchHelmChartReconciler(b *testing.B) {
+	r := &HelmChartReconciler{
+		EventRecorder: record.NewFakeRecorder(32),
+		Storage:       testStorage,
+	}
+
+	obj := &sourcev1.HelmChart{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "reconcile-artifact-",
+			Generation:   1,
+		},
+		Status: sourcev1.HelmChartStatus{},
+	}
+
+	build := mockChartBuild("helmchart", "0.1.0", "testdata/charts/helmchart-0.1.0.tgz")
+
+	for i := 0; i < b.N; i++ {
+		r.reconcileArtifact(ctx, obj, build)
+	}
+}
+
+func BenchmarkHelmChart(b *testing.B) {
+	runBenchHelmChartReconciler(b)
+}

--- a/internal/helm/repository/chart_repository_test.go
+++ b/internal/helm/repository/chart_repository_test.go
@@ -614,3 +614,19 @@ func TestChartRepository_RemoveCache(t *testing.T) {
 	g.Expect(r.CachePath).To(BeEmpty())
 	g.Expect(r.Cached).To(BeFalse())
 }
+
+func runBenchHelmChartIndex(b *testing.B) {
+	g := NewWithT(b)
+	index, err := os.ReadFile(testFile)
+	g.Expect(err).ToNot(HaveOccurred())
+	r := newChartRepository()
+	for i := 0; i < b.N; i++ {
+		err := r.LoadIndexFromBytes(index)
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
+}
+
+func BenchmarkHelmChartIndex(b *testing.B) {
+	runBenchHelmChartIndex(b)
+}


### PR DESCRIPTION
- add a simple check on the sha to abort re-marshaling the index if the sha hasnt changed.
- adds some simple benchmarks to validate this change.

pre-change
```
go test -bench=. -v -benchmem github.com/fluxcd/source-controller/internal/helm/repository -run=^a -benchtime=10s
goos: linux
goarch: amd64
pkg: github.com/fluxcd/source-controller/internal/helm/repository
cpu: AMD FX(tm)-6100 Six-Core Processor
BenchmarkHelmChartIndex
BenchmarkHelmChartIndex-6   	   15674	    765526 ns/op	   47414 B/op	     883 allocs/op
PASS
ok  	github.com/fluxcd/source-controller/internal/helm/repository	19.777s
```

post-change
```
go test -bench=. -v -benchmem github.com/fluxcd/source-controller/internal/helm/repository -run=^a -benchtime=10s
goos: linux
goarch: amd64
pkg: github.com/fluxcd/source-controller/internal/helm/repository
cpu: AMD FX(tm)-6100 Six-Core Processor
BenchmarkHelmChartIndex
BenchmarkHelmChartIndex-6   	  621212	     18005 ns/op	     304 B/op	       6 allocs/op
PASS
ok  	github.com/fluxcd/source-controller/internal/helm/repository	11.451s
```