### PR TITLE
test: source ignore for subdirectories in a repo

### DIFF
--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -772,6 +772,21 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			},
 		},
 		{
+			name: "source ignore for subdir ignore patterns",
+			dir:  "testdata/git/repowithsubdirs",
+			beforeFunc: func(obj *sourcev1.GitRepository) {
+				obj.Spec.Interval = metav1.Duration{Duration: interval}
+			},
+			afterFunc: func(t *WithT, obj *sourcev1.GitRepository) {
+				t.Expect(obj.GetArtifact()).ToNot(BeNil())
+				t.Expect(obj.GetArtifact().Checksum).To(Equal("29186e024dde5a414cfc990829c6b2e85f6b3bd2d950f50ca9f418f5d2261d79"))
+			},
+			want: sreconcile.ResultSuccess,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(meta.ReadyCondition, meta.SucceededReason, "stored artifact for revision 'main/revision'"),
+			},
+		},
+		{
 			name: "Removes ArtifactOutdatedCondition after creating new artifact",
 			dir:  "testdata/git/repository",
 			beforeFunc: func(obj *sourcev1.GitRepository) {

--- a/controllers/testdata/git/repowithsubdirs/.sourceignore
+++ b/controllers/testdata/git/repowithsubdirs/.sourceignore
@@ -1,0 +1,6 @@
+# Exclude all
+/*
+
+# Include manifest directories
+!/apps/
+!/clusters/

--- a/controllers/testdata/git/repowithsubdirs/apps/manifest.yaml
+++ b/controllers/testdata/git/repowithsubdirs/apps/manifest.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apps

--- a/controllers/testdata/git/repowithsubdirs/clusters/manifest.yaml
+++ b/controllers/testdata/git/repowithsubdirs/clusters/manifest.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clusters


### PR DESCRIPTION
Add gitrepository reconciler test for source ignore in a repository with
subdirectories where the subdirectories are part of the ignore patterns.

Test for #629 