### PR TITLE
Prefix event annotations with API Group FQDN

### DIFF
--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -570,8 +570,8 @@ func (r *BucketReconciler) reconcileArtifact(ctx context.Context, obj *sourcev1.
 		return sreconcile.ResultEmpty, e
 	}
 	r.annotatedEventLogf(ctx, obj, map[string]string{
-		"revision": artifact.Revision,
-		"checksum": artifact.Checksum,
+		sourcev1.GroupVersion.Group + "/revision": artifact.Revision,
+		sourcev1.GroupVersion.Group + "/checksum": artifact.Checksum,
 	}, corev1.EventTypeNormal, "NewArtifact", "fetched %d files from '%s'", index.Len(), obj.Spec.BucketName)
 
 	// Record it on the object

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -519,8 +519,8 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context,
 		return sreconcile.ResultEmpty, e
 	}
 	r.AnnotatedEventf(obj, map[string]string{
-		"revision": artifact.Revision,
-		"checksum": artifact.Checksum,
+		sourcev1.GroupVersion.Group + "/revision": artifact.Revision,
+		sourcev1.GroupVersion.Group + "/checksum": artifact.Checksum,
 	}, corev1.EventTypeNormal, "NewArtifact", "stored artifact for commit '%s'", commit.ShortMessage())
 
 	// Record it on the object

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -676,8 +676,8 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, obj *source
 
 	// Publish an event
 	r.AnnotatedEventf(obj, map[string]string{
-		"revision": artifact.Revision,
-		"checksum": artifact.Checksum,
+		sourcev1.GroupVersion.Group + "/revision": artifact.Revision,
+		sourcev1.GroupVersion.Group + "/checksum": artifact.Checksum,
 	}, corev1.EventTypeNormal, reasonForBuild(b), b.Summary())
 
 	// Update symlink on a "best effort" basis

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -453,8 +453,8 @@ func (r *HelmRepositoryReconciler) reconcileArtifact(ctx context.Context, obj *s
 	size := units.HumanSize(float64(fi.Size()))
 
 	r.AnnotatedEventf(obj, map[string]string{
-		"revision": artifact.Revision,
-		"checksum": artifact.Checksum,
+		sourcev1.GroupVersion.Group + "/revision": artifact.Revision,
+		sourcev1.GroupVersion.Group + "/checksum": artifact.Checksum,
 	}, corev1.EventTypeNormal, "NewArtifact", "fetched index of size %s from '%s'", size, chartRepo.URL)
 
 	// Record it on the object.


### PR DESCRIPTION
This to facilitate improvements on the notification-controller side,
where annotations prefixed with the FQDN of the Group of the Involved
Object will be transformed into "fields".