### PR TITLE
Garbage collect with provided retention options

### DIFF
--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -632,14 +632,19 @@ func (r *BucketReconciler) garbageCollect(ctx context.Context, obj *sourcev1.Buc
 		return nil
 	}
 	if obj.GetArtifact() != nil {
-		if deleted, err := r.Storage.RemoveAllButCurrent(*obj.GetArtifact()); err != nil {
-			return &serror.Event{
-				Err:    fmt.Errorf("garbage collection of old artifacts failed: %s", err),
+		delFiles, err := r.Storage.GarbageCollect(ctx, *obj.GetArtifact(), time.Second*5)
+		if err != nil {
+			e := &serror.Event{
+				Err:    fmt.Errorf("garbage collection of artifacts failed: %w", err),
 				Reason: "GarbageCollectionFailed",
 			}
-		} else if len(deleted) > 0 {
+			r.eventLogf(ctx, obj, corev1.EventTypeWarning, e.Reason, e.Err.Error())
+			return e
+		}
+		if len(delFiles) > 0 {
 			r.eventLogf(ctx, obj, events.EventTypeTrace, "GarbageCollectionSucceeded",
-				"garbage collected old artifacts")
+				fmt.Sprintf("garbage collected %d artifacts", len(delFiles)))
+			return nil
 		}
 	}
 	return nil

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -708,13 +708,19 @@ func (r *GitRepositoryReconciler) garbageCollect(ctx context.Context, obj *sourc
 		return nil
 	}
 	if obj.GetArtifact() != nil {
-		if deleted, err := r.Storage.RemoveAllButCurrent(*obj.GetArtifact()); err != nil {
-			return &serror.Event{
-				Err: fmt.Errorf("garbage collection of old artifacts failed: %w", err),
+		delFiles, err := r.Storage.GarbageCollect(ctx, *obj.GetArtifact(), time.Second*5)
+		if err != nil {
+			e := &serror.Event{
+				Err:    fmt.Errorf("garbage collection of artifacts failed: %w", err),
+				Reason: "GarbageCollectionFailed",
 			}
-		} else if len(deleted) > 0 {
+			r.eventLogf(ctx, obj, corev1.EventTypeWarning, e.Reason, e.Err.Error())
+			return e
+		}
+		if len(delFiles) > 0 {
 			r.eventLogf(ctx, obj, events.EventTypeTrace, "GarbageCollectionSucceeded",
-				"garbage collected old artifacts")
+				fmt.Sprintf("garbage collected %d artifacts", len(delFiles)))
+			return nil
 		}
 	}
 	return nil

--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -177,7 +177,7 @@ func TestHelmChartReconciler_reconcileStorage(t *testing.T) {
 		{
 			name: "garbage collects",
 			beforeFunc: func(obj *sourcev1.HelmChart, storage *Storage) error {
-				revisions := []string{"a", "b", "c"}
+				revisions := []string{"a", "b", "c", "d"}
 				for n := range revisions {
 					v := revisions[n]
 					obj.Status.Artifact = &sourcev1.Artifact{
@@ -187,21 +187,25 @@ func TestHelmChartReconciler_reconcileStorage(t *testing.T) {
 					if err := testStorage.MkdirAll(*obj.Status.Artifact); err != nil {
 						return err
 					}
-					if err := testStorage.AtomicWriteFile(obj.Status.Artifact, strings.NewReader(v), 0644); err != nil {
+					if err := testStorage.AtomicWriteFile(obj.Status.Artifact, strings.NewReader(v), 0o644); err != nil {
 						return err
+					}
+					if n != len(revisions)-1 {
+						time.Sleep(time.Second * 1)
 					}
 				}
 				testStorage.SetArtifactURL(obj.Status.Artifact)
 				return nil
 			},
 			assertArtifact: &sourcev1.Artifact{
-				Path:     "/reconcile-storage/c.txt",
-				Revision: "c",
-				Checksum: "2e7d2c03a9507ae265ecf5b5356885a53393a2029d241394997265a1a25aefc6",
-				URL:      testStorage.Hostname + "/reconcile-storage/c.txt",
-				Size:     int64p(int64(len("c"))),
+				Path:     "/reconcile-storage/d.txt",
+				Revision: "d",
+				Checksum: "18ac3e7343f016890c510e93f935261169d9e3f565436429830faf0934f4f8e4",
+				URL:      testStorage.Hostname + "/reconcile-storage/d.txt",
+				Size:     int64p(int64(len("d"))),
 			},
 			assertPaths: []string{
+				"/reconcile-storage/d.txt",
 				"/reconcile-storage/c.txt",
 				"!/reconcile-storage/b.txt",
 				"!/reconcile-storage/a.txt",
@@ -238,7 +242,7 @@ func TestHelmChartReconciler_reconcileStorage(t *testing.T) {
 				if err := testStorage.MkdirAll(*obj.Status.Artifact); err != nil {
 					return err
 				}
-				if err := testStorage.AtomicWriteFile(obj.Status.Artifact, strings.NewReader("file"), 0644); err != nil {
+				if err := testStorage.AtomicWriteFile(obj.Status.Artifact, strings.NewReader("file"), 0o644); err != nil {
 					return err
 				}
 				return nil
@@ -259,6 +263,10 @@ func TestHelmChartReconciler_reconcileStorage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
+
+			defer func() {
+				g.Expect(os.RemoveAll(filepath.Join(testStorage.BasePath, "/reconcile-storage"))).To(Succeed())
+			}()
 
 			r := &HelmChartReconciler{
 				EventRecorder: record.NewFakeRecorder(32),
@@ -303,7 +311,7 @@ func TestHelmChartReconciler_reconcileSource(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	defer os.RemoveAll(tmpDir)
 
-	storage, err := NewStorage(tmpDir, "example.com", timeout)
+	storage, err := NewStorage(tmpDir, "example.com", retentionTTL, retentionRecords)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	gitArtifact := &sourcev1.Artifact{
@@ -777,7 +785,7 @@ func TestHelmChartReconciler_buildFromTarballArtifact(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	defer os.RemoveAll(tmpDir)
 
-	storage, err := NewStorage(tmpDir, "example.com", timeout)
+	storage, err := NewStorage(tmpDir, "example.com", retentionTTL, retentionRecords)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	chartsArtifact := &sourcev1.Artifact{

--- a/controllers/helmrepository_controller_test.go
+++ b/controllers/helmrepository_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/darkowlzz/controller-check/status"
 	"github.com/fluxcd/pkg/apis/meta"
@@ -146,7 +147,7 @@ func TestHelmRepositoryReconciler_reconcileStorage(t *testing.T) {
 		{
 			name: "garbage collects",
 			beforeFunc: func(obj *sourcev1.HelmRepository, storage *Storage) error {
-				revisions := []string{"a", "b", "c"}
+				revisions := []string{"a", "b", "c", "d"}
 				for n := range revisions {
 					v := revisions[n]
 					obj.Status.Artifact = &sourcev1.Artifact{
@@ -156,21 +157,25 @@ func TestHelmRepositoryReconciler_reconcileStorage(t *testing.T) {
 					if err := testStorage.MkdirAll(*obj.Status.Artifact); err != nil {
 						return err
 					}
-					if err := testStorage.AtomicWriteFile(obj.Status.Artifact, strings.NewReader(v), 0644); err != nil {
+					if err := testStorage.AtomicWriteFile(obj.Status.Artifact, strings.NewReader(v), 0o644); err != nil {
 						return err
+					}
+					if n != len(revisions)-1 {
+						time.Sleep(time.Second * 1)
 					}
 				}
 				testStorage.SetArtifactURL(obj.Status.Artifact)
 				return nil
 			},
 			assertArtifact: &sourcev1.Artifact{
-				Path:     "/reconcile-storage/c.txt",
-				Revision: "c",
-				Checksum: "2e7d2c03a9507ae265ecf5b5356885a53393a2029d241394997265a1a25aefc6",
-				URL:      testStorage.Hostname + "/reconcile-storage/c.txt",
-				Size:     int64p(int64(len("c"))),
+				Path:     "/reconcile-storage/d.txt",
+				Revision: "d",
+				Checksum: "18ac3e7343f016890c510e93f935261169d9e3f565436429830faf0934f4f8e4",
+				URL:      testStorage.Hostname + "/reconcile-storage/d.txt",
+				Size:     int64p(int64(len("d"))),
 			},
 			assertPaths: []string{
+				"/reconcile-storage/d.txt",
 				"/reconcile-storage/c.txt",
 				"!/reconcile-storage/b.txt",
 				"!/reconcile-storage/a.txt",
@@ -207,7 +212,7 @@ func TestHelmRepositoryReconciler_reconcileStorage(t *testing.T) {
 				if err := testStorage.MkdirAll(*obj.Status.Artifact); err != nil {
 					return err
 				}
-				if err := testStorage.AtomicWriteFile(obj.Status.Artifact, strings.NewReader("file"), 0644); err != nil {
+				if err := testStorage.AtomicWriteFile(obj.Status.Artifact, strings.NewReader("file"), 0o644); err != nil {
 					return err
 				}
 				return nil

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -46,8 +46,10 @@ import (
 // Gomega.
 
 const (
-	timeout  = 10 * time.Second
-	interval = 1 * time.Second
+	timeout          = 10 * time.Second
+	interval         = 1 * time.Second
+	retentionTTL     = 2 * time.Second
+	retentionRecords = 2
 )
 
 var (
@@ -181,7 +183,7 @@ func initTestTLS() {
 }
 
 func newTestStorage(s *testserver.HTTPServer) (*Storage, error) {
-	storage, err := NewStorage(s.Root(), s.URL(), timeout)
+	storage, err := NewStorage(s.Root(), s.URL(), retentionTTL, retentionRecords)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/fuzz/gitrepository_fuzzer.go
+++ b/tests/fuzz/gitrepository_fuzzer.go
@@ -174,7 +174,7 @@ func startEnvServer(setupReconcilers func(manager.Manager)) *envtest.Environment
 		panic(err)
 	}
 	defer os.RemoveAll(tmpStoragePath)
-	storage, err = controllers.NewStorage(tmpStoragePath, "localhost:5050", time.Second*30)
+	storage, err = controllers.NewStorage(tmpStoragePath, "localhost:5050", time.Minute*1, 2)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Adds two ways (a ttl for each artifact and max number of artifact per objects) to customize garbage collection. Adds a timeout context to cancel garbage collection after a duration. 

Ref: #602 

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>