### PR TITLE
gitrepo: Do not stall when no included artifact

### DIFF
--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -574,12 +574,12 @@ func (r *GitRepositoryReconciler) reconcileInclude(ctx context.Context,
 				Reason: "NotFound",
 			}
 			conditions.MarkTrue(obj, sourcev1.IncludeUnavailableCondition, e.Reason, e.Err.Error())
-			return sreconcile.ResultEmpty, err
+			return sreconcile.ResultEmpty, e
 		}
 
 		// Confirm include has an artifact
 		if dep.GetArtifact() == nil {
-			e := &serror.Stalling{
+			e := &serror.Event{
 				Err:    fmt.Errorf("no artifact available for include '%s'", incl.GitRepositoryRef.Name),
 				Reason: "NoArtifact",
 			}


### PR DESCRIPTION
The GitRepository object with included artifact should not stall when
the included artifact is not available since there's no way to signal a
reconciliation when the included artifact becomes available. The
reconciliation should fail and retry until the included artifact becomes
available.