### PR TITLE
Removes empty credentials from Basic Auth

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -128,3 +128,31 @@ Deploy `source-controller` into the cluster that is configured in the local kube
 ```sh
 make deploy
 ```
+
+### Debugging controller with VSCode
+
+Create a `.vscode/launch.json` file:
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "envFile": "${workspaceFolder}/build/.env",
+            "program": "${workspaceFolder}/main.go"
+        }
+    ]
+}
+```
+
+Create the environment file containing details on how to load 
+`libgit2` dependencies:
+```bash
+make env
+```
+
+Start debugging by either clicking `Run` > `Start Debugging` or using
+the relevant shortcut.

--- a/pkg/git/gogit/transport.go
+++ b/pkg/git/gogit/transport.go
@@ -36,10 +36,15 @@ func transportAuth(opts *git.AuthOptions) (transport.AuthMethod, error) {
 	}
 	switch opts.Transport {
 	case git.HTTPS, git.HTTP:
-		return &http.BasicAuth{
-			Username: opts.Username,
-			Password: opts.Password,
-		}, nil
+		// Some providers (i.e. GitLab) will reject empty credentials for
+		// public repositories.
+		if opts.Username != "" || opts.Password != "" {
+			return &http.BasicAuth{
+				Username: opts.Username,
+				Password: opts.Password,
+			}, nil
+		}
+		return nil, nil
 	case git.SSH:
 		if len(opts.Identity) > 0 {
 			pk, err := ssh.NewPublicKeys(opts.Username, opts.Identity, opts.Password)

--- a/pkg/git/gogit/transport_test.go
+++ b/pkg/git/gogit/transport_test.go
@@ -75,6 +75,24 @@ func Test_transportAuth(t *testing.T) {
 		wantErr  error
 	}{
 		{
+			name: "Public HTTP Repositories",
+			opts: &git.AuthOptions{
+				Transport: git.HTTP,
+			},
+			wantFunc: func(g *WithT, t transport.AuthMethod, opts *git.AuthOptions) {
+				g.Expect(t).To(BeNil())
+			},
+		},
+		{
+			name: "Public HTTPS Repositories",
+			opts: &git.AuthOptions{
+				Transport: git.HTTP,
+			},
+			wantFunc: func(g *WithT, t transport.AuthMethod, opts *git.AuthOptions) {
+				g.Expect(t).To(BeNil())
+			},
+		},
+		{
 			name: "HTTP basic auth",
 			opts: &git.AuthOptions{
 				Transport: git.HTTP,


### PR DESCRIPTION
Some git servers are more accommodating than others. Gitlab will try to validate credentials when they are provided, even if they are empty and the target repository is public, leading to a failed authentication error.

Fixes https://github.com/fluxcd/flux2/issues/2596