### PR TITLE
Add flag to allow configuration of SSH kex algos

### DIFF
--- a/pkg/git/libgit2/managed/ssh.go
+++ b/pkg/git/libgit2/managed/ssh.go
@@ -58,6 +58,7 @@ import (
 
 	"golang.org/x/crypto/ssh"
 
+	"github.com/fluxcd/source-controller/pkg/git"
 	git2go "github.com/libgit2/git2go/v33"
 )
 
@@ -343,6 +344,9 @@ func cacheKeyAndConfig(remoteAddress string, cred *git2go.Credential) (string, *
 		User:    username,
 		Auth:    []ssh.AuthMethod{ssh.PublicKeys(key)},
 		Timeout: sshConnectionTimeOut,
+	}
+	if len(git.KexAlgos) > 0 {
+		cfg.Config.KeyExchanges = git.KexAlgos
 	}
 
 	return ck, cfg, nil

--- a/pkg/git/options.go
+++ b/pkg/git/options.go
@@ -70,6 +70,9 @@ type AuthOptions struct {
 	CAFile     []byte
 }
 
+// List of custom key exchange algorithms to be used for ssh connections.
+var KexAlgos []string
+
 // Validate the AuthOptions against the defined Transport.
 func (o AuthOptions) Validate() error {
 	switch o.Transport {


### PR DESCRIPTION
Adds a runtime flag to specify which key exchange algorithms to use for ssh.

Ref: https://github.com/fluxcd/flux2/issues/2610

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>