### PR TITLE
libgit2: managed transport improvements

### DIFF
--- a/pkg/git/libgit2/managed/const.go
+++ b/pkg/git/libgit2/managed/const.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managed
+
+const (
+	// URLMaxLength represents the max length for the entire URL
+	// when cloning Git repositories via HTTP(S).
+	URLMaxLength = 2048
+
+	// PathMaxLength represents the max length for the path element
+	// when cloning Git repositories via SSH.
+	PathMaxLength = 4096
+)

--- a/pkg/git/libgit2/managed/http.go
+++ b/pkg/git/libgit2/managed/http.go
@@ -171,6 +171,10 @@ func createClientRequest(targetUrl string, action git2go.SmartServiceAction, t *
 		}
 	}
 
+	if len(finalUrl) > 2048 {
+		return nil, nil, fmt.Errorf("URL exceeds the max length (2048)")
+	}
+
 	client := &http.Client{
 		Transport: t,
 		Timeout:   fullHttpClientTimeOut,

--- a/pkg/git/libgit2/managed/http.go
+++ b/pkg/git/libgit2/managed/http.go
@@ -171,8 +171,8 @@ func createClientRequest(targetUrl string, action git2go.SmartServiceAction, t *
 		}
 	}
 
-	if len(finalUrl) > 2048 {
-		return nil, nil, fmt.Errorf("URL exceeds the max length (2048)")
+	if len(finalUrl) > URLMaxLength {
+		return nil, nil, fmt.Errorf("URL exceeds the max length (%d)", URLMaxLength)
 	}
 
 	client := &http.Client{

--- a/pkg/git/libgit2/managed/ssh.go
+++ b/pkg/git/libgit2/managed/ssh.go
@@ -165,7 +165,7 @@ func (t *sshSmartSubtransport) Action(urlString string, action git2go.SmartServi
 		return nil, fmt.Errorf("unexpected action: %v", action)
 	}
 
-	cred, err := t.transport.SmartCredentials("", git2go.CredentialTypeSSHKey|git2go.CredentialTypeSSHMemory)
+	cred, err := t.transport.SmartCredentials("", git2go.CredentialTypeSSHMemory)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/git/libgit2/managed/ssh.go
+++ b/pkg/git/libgit2/managed/ssh.go
@@ -130,8 +130,8 @@ func (t *sshSmartSubtransport) Action(urlString string, action git2go.SmartServi
 		return nil, err
 	}
 
-	if len(u.Path) > 4096 {
-		return nil, fmt.Errorf("path exceeds the max length (4096)")
+	if len(u.Path) > PathMaxLength {
+		return nil, fmt.Errorf("path exceeds the max length (%d)", PathMaxLength)
 	}
 
 	// decode URI's path

--- a/pkg/git/libgit2/managed/ssh.go
+++ b/pkg/git/libgit2/managed/ssh.go
@@ -125,12 +125,19 @@ func (t *sshSmartSubtransport) Action(urlString string, action git2go.SmartServi
 		return nil, err
 	}
 
-	// Escape \ and '.
-	uPath := strings.Replace(u.Path, `\`, `\\`, -1)
-	uPath = strings.Replace(uPath, `'`, `\'`, -1)
+	if len(u.Path) > 4096 {
+		return nil, fmt.Errorf("path exceeds the max length (4096)")
+	}
 
-	// TODO: Add percentage decode similar to libgit2.
-	// Refer: https://github.com/libgit2/libgit2/blob/358a60e1b46000ea99ef10b4dd709e92f75ff74b/src/str.c#L455-L481
+	// decode URI's path
+	uPath, err := url.PathUnescape(u.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Escape \ and '.
+	uPath = strings.Replace(uPath, `\`, `\\`, -1)
+	uPath = strings.Replace(uPath, `'`, `\'`, -1)
 
 	var cmd string
 	switch action {


### PR DESCRIPTION
### Stability and reliability improvements
- Retry on stale connections: fixes the issue of long-running connections resulting in `EOF` for GitLab servers. Although this may also affect other Git Servers in different scenarios.
- Handle closing of stale connections: dispose resources and remove connection from cache.
- Optimise mutex on cached connections for decreased waiting time when competing go-routines try to create a SSH connection.

### Low Impact Breaking Changes
- HTTP(S) URLs must be 2048 characters long.
- SSH Path must be 4096 characters long.