### PR TITLE
Avoid event logging GC failure

### DIFF
--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -634,12 +634,10 @@ func (r *BucketReconciler) garbageCollect(ctx context.Context, obj *sourcev1.Buc
 	if obj.GetArtifact() != nil {
 		delFiles, err := r.Storage.GarbageCollect(ctx, *obj.GetArtifact(), time.Second*5)
 		if err != nil {
-			e := &serror.Event{
+			return &serror.Event{
 				Err:    fmt.Errorf("garbage collection of artifacts failed: %w", err),
 				Reason: "GarbageCollectionFailed",
 			}
-			r.eventLogf(ctx, obj, corev1.EventTypeWarning, e.Reason, e.Err.Error())
-			return e
 		}
 		if len(delFiles) > 0 {
 			r.eventLogf(ctx, obj, events.EventTypeTrace, "GarbageCollectionSucceeded",

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -710,12 +710,10 @@ func (r *GitRepositoryReconciler) garbageCollect(ctx context.Context, obj *sourc
 	if obj.GetArtifact() != nil {
 		delFiles, err := r.Storage.GarbageCollect(ctx, *obj.GetArtifact(), time.Second*5)
 		if err != nil {
-			e := &serror.Event{
+			return &serror.Event{
 				Err:    fmt.Errorf("garbage collection of artifacts failed: %w", err),
 				Reason: "GarbageCollectionFailed",
 			}
-			r.eventLogf(ctx, obj, corev1.EventTypeWarning, e.Reason, e.Err.Error())
-			return e
 		}
 		if len(delFiles) > 0 {
 			r.eventLogf(ctx, obj, events.EventTypeTrace, "GarbageCollectionSucceeded",

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -806,12 +806,10 @@ func (r *HelmChartReconciler) garbageCollect(ctx context.Context, obj *sourcev1.
 	if obj.GetArtifact() != nil {
 		delFiles, err := r.Storage.GarbageCollect(ctx, *obj.GetArtifact(), time.Second*5)
 		if err != nil {
-			e := &serror.Event{
+			return &serror.Event{
 				Err:    fmt.Errorf("garbage collection of artifacts failed: %w", err),
 				Reason: "GarbageCollectionFailed",
 			}
-			r.eventLogf(ctx, obj, corev1.EventTypeWarning, e.Reason, e.Err.Error())
-			return e
 		}
 		if len(delFiles) > 0 {
 			r.eventLogf(ctx, obj, events.EventTypeTrace, "GarbageCollectionSucceeded",

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -520,12 +520,10 @@ func (r *HelmRepositoryReconciler) garbageCollect(ctx context.Context, obj *sour
 	if obj.GetArtifact() != nil {
 		delFiles, err := r.Storage.GarbageCollect(ctx, *obj.GetArtifact(), time.Second*5)
 		if err != nil {
-			e := &serror.Event{
+			return &serror.Event{
 				Err:    fmt.Errorf("garbage collection of artifacts failed: %w", err),
 				Reason: "GarbageCollectionFailed",
 			}
-			r.eventLogf(ctx, obj, corev1.EventTypeWarning, e.Reason, e.Err.Error())
-			return e
 		}
 		if len(delFiles) > 0 {
 			r.eventLogf(ctx, obj, events.EventTypeTrace, "GarbageCollectionSucceeded",


### PR DESCRIPTION
We try to avoid affecting the source reconciliation when there's a
garbage collection related failure.

The event logging was resulting in events and notifications related to
GC failure when the artifact directory isn't created initially in the first
reconciliation of an object.

This change reverts to how it was before, refer https://github.com/fluxcd/source-controller/blob/v0.22.5/controllers/gitrepository_controller.go#L711-L718 .