### PR TITLE
HelmChart: enable dependency manager to use the in memory cache

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -129,15 +129,17 @@ func TestMain(m *testing.M) {
 		panic(fmt.Sprintf("Failed to start HelmRepositoryReconciler: %v", err))
 	}
 
-	cache := cache.New(5, 1*time.Second)
+	c := cache.New(5, 1*time.Second)
+	cacheRecorder := cache.MustMakeMetrics()
 	if err := (&HelmChartReconciler{
 		Client:        testEnv,
 		EventRecorder: record.NewFakeRecorder(32),
 		Metrics:       testMetricsH,
 		Getters:       testGetters,
 		Storage:       testStorage,
-		Cache:         cache,
+		Cache:         c,
 		TTL:           1 * time.Second,
+		CacheRecorder: cacheRecorder,
 	}).SetupWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Failed to start HelmRepositoryReconciler: %v", err))
 	}

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.24
 	github.com/onsi/gomega v1.19.0
 	github.com/otiai10/copy v1.7.0
+	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -173,7 +174,6 @@ require (
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/internal/cache/metrics.go
+++ b/internal/cache/metrics.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	// CacheEventTypeMiss is the event type for cache misses.
+	CacheEventTypeMiss = "cache_miss"
+	// CacheEventTypeHit is the event type for cache hits.
+	CacheEventTypeHit = "cache_hit"
+)
+
+// CacheRecorder is a recorder for cache events.
+type CacheRecorder struct {
+	// cacheEventsCounter is a counter for cache events.
+	cacheEventsCounter *prometheus.CounterVec
+}
+
+// NewCacheRecorder returns a new CacheRecorder.
+// The configured labels are: event_type, name, namespace.
+// The event_type is one of:
+//   - "miss"
+//   - "hit"
+//   - "update"
+// The name is the name of the reconciled resource.
+// The namespace is the namespace of the reconciled resource.
+func NewCacheRecorder() *CacheRecorder {
+	return &CacheRecorder{
+		cacheEventsCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "gotk_cache_events_total",
+				Help: "Total number of cache retrieval events for a Gitops Toolkit resource reconciliation.",
+			},
+			[]string{"event_type", "name", "namespace"},
+		),
+	}
+}
+
+// Collectors returns the metrics.Collector objects for the CacheRecorder.
+func (r *CacheRecorder) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		r.cacheEventsCounter,
+	}
+}
+
+// IncCacheEventCount increment by 1 the cache event count for the given event type, name and namespace.
+func (r *CacheRecorder) IncCacheEvents(event, name, namespace string) {
+	r.cacheEventsCounter.WithLabelValues(event, name, namespace).Inc()
+}
+
+// MustMakeMetrics creates a new CacheRecorder, and registers the metrics collectors in the controller-runtime metrics registry.
+func MustMakeMetrics() *CacheRecorder {
+	r := NewCacheRecorder()
+	metrics.Registry.MustRegister(r.Collectors()...)
+
+	return r
+}

--- a/internal/helm/chart/builder_remote.go
+++ b/internal/helm/chart/builder_remote.go
@@ -73,11 +73,9 @@ func (b *remoteChartBuilder) Build(_ context.Context, ref Reference, p string, o
 	}
 
 	// Load the repository index if not already present.
-	if b.remote.Index == nil {
-		if err := b.remote.LoadFromCache(); err != nil {
-			err = fmt.Errorf("could not load repository index for remote chart reference: %w", err)
-			return nil, &BuildError{Reason: ErrChartPull, Err: err}
-		}
+	if err := b.remote.StrategicallyLoadIndex(); err != nil {
+		err = fmt.Errorf("could not load repository index for remote chart reference: %w", err)
+		return nil, &BuildError{Reason: ErrChartPull, Err: err}
 	}
 
 	// Get the current version for the RemoteReference

--- a/internal/helm/chart/dependency_manager.go
+++ b/internal/helm/chart/dependency_manager.go
@@ -97,6 +97,9 @@ func NewDependencyManager(opts ...DependencyManagerOption) *DependencyManager {
 func (dm *DependencyManager) Clear() []error {
 	var errs []error
 	for _, v := range dm.repositories {
+		if err := v.CacheIndexInMemory(); err != nil {
+			errs = append(errs, err)
+		}
 		v.Unload()
 		if err := v.RemoveCache(); err != nil {
 			errs = append(errs, err)

--- a/main.go
+++ b/main.go
@@ -233,6 +233,9 @@ func main() {
 
 		c = cache.New(helmCacheMaxSize, interval)
 	}
+
+	cacheRecorder := cache.MustMakeMetrics()
+
 	if err = (&controllers.HelmChartReconciler{
 		Client:         mgr.GetClient(),
 		Storage:        storage,
@@ -242,6 +245,7 @@ func main() {
 		ControllerName: controllerName,
 		Cache:          c,
 		TTL:            ttl,
+		CacheRecorder: cacheRecorder,
 	}).SetupWithManagerAndOptions(mgr, controllers.HelmChartReconcilerOptions{
 		MaxConcurrentReconciles: concurrent,
 		RateLimiter:             helper.GetRateLimiter(rateLimiterOptions),


### PR DESCRIPTION
This PR:
- enables a chartRepository to strategically load an Index from a memory cache
- provide cache events metrics

## Tests

### With cache enabled

for the case we used the following flags
```yaml
     spec:
       containers:
       - args:
         - --helm-cache-purge-interval=10m
         - --helm-cache-ttl=1h
         - --helm-cache-max-size=10
         - --events-addr=http://notification-controller.flux-system.svc.cluster.local./
         - --watch-all-namespaces=true
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
         - --storage-path=/data
         - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
```

We have 2 HelmRepositories:
- Bitnami (interval 10m), 12.8 MB, with 10 running Helmrelease (interval 1m)
- Prometheus-Stack(Interval 10M), with 1 running HelmRelease (interval 1m)

After 1h, we have gathered the followiing information from grafana

<img width="672" alt="Screenshot 2022-04-12 at 15 08 22" src="https://user-images.githubusercontent.com/16276346/162969555-824beff0-ca65-4b23-82f6-f4004a05def8.png">


<img width="672" alt="Screenshot 2022-04-12 at 15 09 42" src="https://user-images.githubusercontent.com/16276346/162969760-c17f4655-c3b5-4dc3-8d13-a76cc9d6b193.png">

<img width="1337" alt="Screenshot 2022-04-12 at 15 12 37" src="https://user-images.githubusercontent.com/16276346/162970298-a6057da0-11a2-48e5-9de7-9ff22a7a5821.png">

the metric query for HitRate is `sum(rate(gotk_cache_events_total{event_type="cache_hit"}[1m]))/sum(rate(gotk_cache_events_total[1m]))`

### With cache disabled

<img width="676" alt="Screenshot 2022-04-19 at 11 44 23" src="https://user-images.githubusercontent.com/16276346/163976766-5b8327b7-2d13-4339-b03f-b3291f64c901.png">

<img width="676" alt="Screenshot 2022-04-19 at 11 44 43" src="https://user-images.githubusercontent.com/16276346/163976788-42be5a93-d8ab-41cd-b109-8f6d36cd1a7d.png">



Signed-off-by: Soule BA <soule@weave.works>