### PR TITLE
fix panic when HelmRepository's artifact size is nil

### DIFF
--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -255,14 +255,17 @@ func (r *HelmRepositoryReconciler) notify(oldObj, newObj *sourcev1.HelmRepositor
 			sourcev1.GroupVersion.Group + "/checksum": newObj.Status.Artifact.Checksum,
 		}
 
-		size := units.HumanSize(float64(*newObj.Status.Artifact.Size))
+		humanReadableSize := "unknown size"
+		if size := newObj.Status.Artifact.Size; size != nil {
+			humanReadableSize = fmt.Sprintf("size %s", units.HumanSize(float64(*size)))
+		}
 
 		var oldChecksum string
 		if oldObj.GetArtifact() != nil {
 			oldChecksum = oldObj.GetArtifact().Checksum
 		}
 
-		message := fmt.Sprintf("stored fetched index of size %s from '%s'", size, chartRepo.URL)
+		message := fmt.Sprintf("stored fetched index of %s from '%s'", humanReadableSize, chartRepo.URL)
 
 		// Notify on new artifact and failure recovery.
 		if oldChecksum != newObj.GetArtifact().Checksum {

--- a/controllers/helmrepository_controller_test.go
+++ b/controllers/helmrepository_controller_test.go
@@ -860,6 +860,15 @@ func TestHelmRepositoryReconciler_notify(t *testing.T) {
 			resErr: errors.New("some error"),
 		},
 		{
+			name:   "new artifact with nil size",
+			res:    sreconcile.ResultSuccess,
+			resErr: nil,
+			newObjBeforeFunc: func(obj *sourcev1.HelmRepository) {
+				obj.Status.Artifact = &sourcev1.Artifact{Revision: "xxx", Checksum: "yyy", Size: nil}
+			},
+			wantEvent: "Normal NewArtifact stored fetched index of unknown size",
+		},
+		{
 			name:   "new artifact",
 			res:    sreconcile.ResultSuccess,
 			resErr: nil,


### PR DESCRIPTION
This fixes the immediate issue of the nil pointer dereference but we
still haven't isolated the actual cause of the size being nil to begin
with. This is ongoing work and as soon as we have boiled that down to
the simplest case we will provide a regression test for that case.

closes #680