### PR TITLE
helm: optimise repository index loading

### DIFF
--- a/api/v1beta2/artifact_types.go
+++ b/api/v1beta2/artifact_types.go
@@ -56,13 +56,22 @@ type Artifact struct {
 	Size *int64 `json:"size,omitempty"`
 }
 
-// HasRevision returns true if the given revision matches the current Revision
-// of the Artifact.
+// HasRevision returns if the given revision matches the current Revision of
+// the Artifact.
 func (in *Artifact) HasRevision(revision string) bool {
 	if in == nil {
 		return false
 	}
 	return in.Revision == revision
+}
+
+// HasChecksum returns if the given checksum matches the current Checksum of
+// the Artifact.
+func (in *Artifact) HasChecksum(checksum string) bool {
+	if in == nil {
+		return false
+	}
+	return in.Checksum == checksum
 }
 
 // ArtifactDir returns the artifact dir path in the form of

--- a/internal/helm/repository/chart_repository.go
+++ b/internal/helm/repository/chart_repository.go
@@ -66,7 +66,8 @@ type ChartRepository struct {
 	// Index contains a loaded chart repository index if not nil.
 	Index *repo.IndexFile
 	// Checksum contains the SHA256 checksum of the loaded chart repository
-	// index bytes.
+	// index bytes. This is different from the checksum of the CachePath, which
+	// may contain unordered entries.
 	Checksum string
 
 	tlsConfig *tls.Config
@@ -87,7 +88,7 @@ type cacheInfo struct {
 	RecordIndexCacheMetric RecordMetricsFunc
 }
 
-// ChartRepositoryOptions is a function that can be passed to NewChartRepository
+// ChartRepositoryOption is a function that can be passed to NewChartRepository
 // to configure a ChartRepository.
 type ChartRepositoryOption func(*ChartRepository) error
 


### PR DESCRIPTION
Avoid validating (and thus loading) indexes if the checksum already exists in storage.
In other words, if the YAML is identical to the Artifact in storage, the reconciliation should
be a no-op, and therefore can short-circuit long/heavy operations.