### PR TITLE
docs: Remove all traces of "identity.pub" from docs

### DIFF
--- a/api/v1beta2/gitrepository_types.go
+++ b/api/v1beta2/gitrepository_types.go
@@ -56,7 +56,7 @@ type GitRepositorySpec struct {
 	// the GitRepository.
 	// For HTTPS repositories the Secret must contain 'username' and 'password'
 	// fields.
-	// For SSH repositories the Secret must contain 'identity', 'identity.pub'
+	// For SSH repositories the Secret must contain 'identity'
 	// and 'known_hosts' fields.
 	// +optional
 	SecretRef *meta.LocalObjectReference `json:"secretRef,omitempty"`

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -149,8 +149,8 @@ spec:
               secretRef:
                 description: The secret name containing the Git credentials. For HTTPS
                   repositories the secret must contain username and password fields.
-                  For SSH repositories the secret must contain identity, identity.pub
-                  and known_hosts fields.
+                  For SSH repositories the secret must contain identity and known_hosts
+                  fields.
                 properties:
                   name:
                     description: Name of the referent.
@@ -493,8 +493,7 @@ spec:
                 description: SecretRef specifies the Secret containing authentication
                   credentials for the GitRepository. For HTTPS repositories the Secret
                   must contain 'username' and 'password' fields. For SSH repositories
-                  the Secret must contain 'identity', 'identity.pub' and 'known_hosts'
-                  fields.
+                  the Secret must contain 'identity' and 'known_hosts' fields.
                 properties:
                   name:
                     description: Name of the referent.

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -321,7 +321,7 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 the GitRepository.
 For HTTPS repositories the Secret must contain &lsquo;username&rsquo; and &lsquo;password&rsquo;
 fields.
-For SSH repositories the Secret must contain &lsquo;identity&rsquo;, &lsquo;identity.pub&rsquo;
+For SSH repositories the Secret must contain &lsquo;identity&rsquo;
 and &lsquo;known_hosts&rsquo; fields.</p>
 </td>
 </tr>
@@ -1405,7 +1405,7 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 the GitRepository.
 For HTTPS repositories the Secret must contain &lsquo;username&rsquo; and &lsquo;password&rsquo;
 fields.
-For SSH repositories the Secret must contain &lsquo;identity&rsquo;, &lsquo;identity.pub&rsquo;
+For SSH repositories the Secret must contain &lsquo;identity&rsquo;
 and &lsquo;known_hosts&rsquo; fields.</p>
 </td>
 </tr>

--- a/docs/spec/v1beta2/gitrepositories.md
+++ b/docs/spec/v1beta2/gitrepositories.md
@@ -152,9 +152,8 @@ data:
 #### SSH authentication
 
 To authenticate towards a Git repository over SSH, the referenced Secret is
-expected to contain `.data.identity`, `.data.identity.pub` and `known_hosts`
-fields. With the respective private and public key of the SSH key pair, and the
-host keys of the Git repository.
+expected to contain `.data.identity` and `known_hosts` fields. With the respective
+private key of the SSH key pair, and the host keys of the Git repository.
 
 ```yaml
 ---
@@ -165,7 +164,6 @@ metadata:
 type: Opaque
 data:
   identity: <BASE64>
-  identity.pub: <BASE64>
   known_hosts: <BASE64>
 ```
 


### PR DESCRIPTION
"identity.pub" is referenced multiple times in CRDs and docs. This secret
is however never used in any place. Instead, the public key is derived from
the "identity" private key.

This commit/PR removes all traces of "identity.pub", including from older
api versions.