### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/controllers/bucket_controller_test.go
+++ b/controllers/bucket_controller_test.go
@@ -539,9 +539,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 				Client:        builder.Build(),
 				Storage:       testStorage,
 			}
-			tmpDir, err := os.MkdirTemp("", "reconcile-bucket-source-")
-			g.Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			obj := &sourcev1.Bucket{
 				TypeMeta: metav1.TypeMeta{
@@ -834,9 +832,7 @@ func TestBucketReconciler_reconcileSource_gcs(t *testing.T) {
 				Client:        builder.Build(),
 				Storage:       testStorage,
 			}
-			tmpDir, err := os.MkdirTemp("", "reconcile-bucket-source-")
-			g.Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			// Test bucket object.
 			obj := &sourcev1.Bucket{
@@ -992,9 +988,7 @@ func TestBucketReconciler_reconcileArtifact(t *testing.T) {
 				Storage:       testStorage,
 			}
 
-			tmpDir, err := os.MkdirTemp("", "reconcile-bucket-artifact-")
-			g.Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			obj := &sourcev1.Bucket{
 				TypeMeta: metav1.TypeMeta{

--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -509,9 +509,7 @@ func TestGitRepositoryReconciler_reconcileSource_authStrategy(t *testing.T) {
 						t.Skipf("Skipped for Git implementation %q", i)
 					}
 
-					tmpDir, err := os.MkdirTemp("", "auth-strategy-")
-					g.Expect(err).To(BeNil())
-					defer os.RemoveAll(tmpDir)
+					tmpDir := t.TempDir()
 
 					obj := obj.DeepCopy()
 					obj.Spec.GitImplementation = i
@@ -671,9 +669,7 @@ func TestGitRepositoryReconciler_reconcileSource_checkoutStrategy(t *testing.T) 
 						t.Skipf("Skipped for Git implementation %q", i)
 					}
 
-					tmpDir, err := os.MkdirTemp("", "checkout-strategy-")
-					g.Expect(err).NotTo(HaveOccurred())
-					defer os.RemoveAll(tmpDir)
+					tmpDir := t.TempDir()
 
 					obj := obj.DeepCopy()
 					obj.Spec.GitImplementation = i
@@ -1072,9 +1068,7 @@ func TestGitRepositoryReconciler_reconcileInclude(t *testing.T) {
 				tt.beforeFunc(obj)
 			}
 
-			tmpDir, err := os.MkdirTemp("", "include-")
-			g.Expect(err).NotTo(HaveOccurred())
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			var commit git.Commit
 			var includes artifactSet

--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -307,9 +307,7 @@ func TestHelmChartReconciler_reconcileStorage(t *testing.T) {
 func TestHelmChartReconciler_reconcileSource(t *testing.T) {
 	g := NewWithT(t)
 
-	tmpDir, err := os.MkdirTemp("", "reconcile-tarball-")
-	g.Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	storage, err := NewStorage(tmpDir, "example.com", retentionTTL, retentionRecords)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -781,9 +779,7 @@ func TestHelmChartReconciler_buildFromHelmRepository(t *testing.T) {
 func TestHelmChartReconciler_buildFromTarballArtifact(t *testing.T) {
 	g := NewWithT(t)
 
-	tmpDir, err := os.MkdirTemp("", "reconcile-tarball-")
-	g.Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	storage, err := NewStorage(tmpDir, "example.com", retentionTTL, retentionRecords)
 	g.Expect(err).ToNot(HaveOccurred())

--- a/controllers/helmrepository_controller_test.go
+++ b/controllers/helmrepository_controller_test.go
@@ -728,9 +728,7 @@ func TestHelmRepositoryReconciler_reconcileArtifact(t *testing.T) {
 				},
 			}
 
-			tmpDir, err := os.MkdirTemp("", "test-reconcile-artifact-")
-			g.Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			// Create an empty cache file.
 			cachePath := filepath.Join(tmpDir, "index.yaml")

--- a/internal/helm/chart/builder_local_test.go
+++ b/internal/helm/chart/builder_local_test.go
@@ -177,9 +177,7 @@ fullnameOverride: "full-foo-name-override"`),
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			workDir, err := os.MkdirTemp("", "local-builder-")
-			g.Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(workDir)
+			workDir := t.TempDir()
 
 			// Only if the reference is a LocalReference, set the WorkDir.
 			localRef, ok := tt.reference.(LocalReference)
@@ -213,7 +211,6 @@ fullnameOverride: "full-foo-name-override"`),
 
 			// Target path with name similar to the workDir.
 			targetPath := workDir + ".tgz"
-			defer os.RemoveAll(targetPath)
 
 			dm := NewDependencyManager(
 				WithRepositories(tt.repositories),
@@ -247,18 +244,14 @@ fullnameOverride: "full-foo-name-override"`),
 func TestLocalBuilder_Build_CachedChart(t *testing.T) {
 	g := NewWithT(t)
 
-	workDir, err := os.MkdirTemp("", "local-builder-")
-	g.Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(workDir)
+	workDir := t.TempDir()
 
 	testChartPath := "./../testdata/charts/helmchart"
 
 	dm := NewDependencyManager()
 	b := NewLocalBuilder(dm)
 
-	tmpDir, err := os.MkdirTemp("", "local-chart-")
-	g.Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Copy the source chart into the workdir.
 	g.Expect(copy.Copy(testChartPath, filepath.Join(workDir, "testdata", "charts", filepath.Base("helmchart")))).ToNot(HaveOccurred())
@@ -275,7 +268,6 @@ func TestLocalBuilder_Build_CachedChart(t *testing.T) {
 	buildOpts.CachedChart = cb.Path
 
 	targetPath2 := filepath.Join(tmpDir, "chart2.tgz")
-	defer os.RemoveAll(targetPath2)
 	cb, err = b.Build(context.TODO(), reference, targetPath2, buildOpts)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(cb.Path).To(Equal(targetPath))
@@ -331,9 +323,7 @@ func Test_mergeFileValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			baseDir, err := os.MkdirTemp("", "merge-file-values-*")
-			g.Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(baseDir)
+			baseDir := t.TempDir()
 
 			for _, f := range tt.files {
 				g.Expect(os.WriteFile(filepath.Join(baseDir, f.Name), f.Data, 0o640)).To(Succeed())

--- a/internal/helm/chart/builder_remote_test.go
+++ b/internal/helm/chart/builder_remote_test.go
@@ -159,9 +159,7 @@ entries:
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			tmpDir, err := os.MkdirTemp("", "remote-chart-builder-")
-			g.Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 			targetPath := filepath.Join(tmpDir, "chart.tgz")
 
 			if tt.repository != nil {
@@ -237,13 +235,10 @@ entries:
 
 	b := NewRemoteBuilder(repository)
 
-	tmpDir, err := os.MkdirTemp("", "remote-chart-")
-	g.Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Build first time.
 	targetPath := filepath.Join(tmpDir, "chart1.tgz")
-	defer os.RemoveAll(targetPath)
 	buildOpts := BuildOptions{}
 	cb, err := b.Build(context.TODO(), reference, targetPath, buildOpts)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -253,7 +248,6 @@ entries:
 
 	// Rebuild with a new path.
 	targetPath2 := filepath.Join(tmpDir, "chart2.tgz")
-	defer os.RemoveAll(targetPath2)
 	cb, err = b.Build(context.TODO(), reference, targetPath2, buildOpts)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(cb.Path).To(Equal(targetPath))
@@ -342,16 +336,13 @@ func Test_mergeChartValues(t *testing.T) {
 func Test_validatePackageAndWriteToPath(t *testing.T) {
 	g := NewWithT(t)
 
-	tmpDir, err := os.MkdirTemp("", "validate-pkg-chart-")
-	g.Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	validF, err := os.Open("./../testdata/charts/helmchart-0.1.0.tgz")
 	g.Expect(err).ToNot(HaveOccurred())
 	defer validF.Close()
 
 	chartPath := filepath.Join(tmpDir, "chart.tgz")
-	defer os.Remove(chartPath)
 	err = validatePackageAndWriteToPath(validF, chartPath)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(chartPath).To(BeARegularFile())

--- a/internal/helm/chart/metadata_test.go
+++ b/internal/helm/chart/metadata_test.go
@@ -134,9 +134,7 @@ func TestLoadChartMetadataFromDir(t *testing.T) {
 	g := NewWithT(t)
 
 	// Create a chart file that exceeds the max chart file size.
-	tmpDir, err := os.MkdirTemp("", "load-chart-")
-	g.Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	copy.Copy("../testdata/charts/helmchart", tmpDir)
 	bigRequirementsFile := filepath.Join(tmpDir, "requirements.yaml")
 	data := make([]byte, helm.MaxChartFileSize+10)
@@ -200,9 +198,7 @@ func TestLoadChartMetadataFromArchive(t *testing.T) {
 	g := NewWithT(t)
 
 	// Create a chart archive that exceeds the max chart size.
-	tmpDir, err := os.MkdirTemp("", "load-chart-")
-	g.Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	bigArchiveFile := filepath.Join(tmpDir, "chart.tgz")
 	data := make([]byte, helm.MaxChartSize+10)
 	g.Expect(os.WriteFile(bigArchiveFile, data, 0o640)).ToNot(HaveOccurred())

--- a/internal/helm/repository/chart_repository_test.go
+++ b/internal/helm/repository/chart_repository_test.go
@@ -358,9 +358,7 @@ func TestChartRepository_LoadIndexFromFile(t *testing.T) {
 	g := NewWithT(t)
 
 	// Create an index file that exceeds the max index size.
-	tmpDir, err := os.MkdirTemp("", "load-index-")
-	g.Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	bigIndexFile := filepath.Join(tmpDir, "index.yaml")
 	data := make([]byte, helm.MaxIndexSize+10)
 	g.Expect(os.WriteFile(bigIndexFile, data, 0o640)).ToNot(HaveOccurred())

--- a/pkg/gcp/gcp_test.go
+++ b/pkg/gcp/gcp_test.go
@@ -202,9 +202,7 @@ func TestVisitObjectsCallbackErr(t *testing.T) {
 }
 
 func TestFGetObject(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", bucketName)
-	assert.NilError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	gcpClient := &GCSClient{
 		Client: client,
 	}
@@ -218,9 +216,7 @@ func TestFGetObject(t *testing.T) {
 
 func TestFGetObjectNotExists(t *testing.T) {
 	object := "notexists.txt"
-	tempDir, err := os.MkdirTemp("", bucketName)
-	assert.NilError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	gcsClient := &GCSClient{
 		Client: client,
 	}
@@ -233,9 +229,7 @@ func TestFGetObjectNotExists(t *testing.T) {
 }
 
 func TestFGetObjectDirectoryIsFileName(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", bucketName)
-	assert.NilError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	gcpClient := &GCSClient{
 		Client: client,
 	}

--- a/pkg/git/gogit/checkout_test.go
+++ b/pkg/git/gogit/checkout_test.go
@@ -35,11 +35,10 @@ import (
 )
 
 func TestCheckoutBranch_Checkout(t *testing.T) {
-	repo, path, err := initRepo()
+	repo, path, err := initRepo(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(path)
 
 	firstCommit, err := commitFile(repo, "branch", "init", time.Now())
 	if err != nil {
@@ -88,8 +87,7 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 			branch := CheckoutBranch{
 				Branch: tt.branch,
 			}
-			tmpDir, _ := os.MkdirTemp("", "test")
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			cc, err := branch.Checkout(context.TODO(), tmpDir, path, nil)
 			if tt.expectedErr != "" {
@@ -142,11 +140,10 @@ func TestCheckoutTag_Checkout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			repo, path, err := initRepo()
+			repo, path, err := initRepo(t)
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer os.RemoveAll(path)
 
 			var h plumbing.Hash
 			if tt.tag != "" {
@@ -163,8 +160,7 @@ func TestCheckoutTag_Checkout(t *testing.T) {
 			tag := CheckoutTag{
 				Tag: tt.checkoutTag,
 			}
-			tmpDir, _ := os.MkdirTemp("", "test")
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			cc, err := tag.Checkout(context.TODO(), tmpDir, path, nil)
 			if tt.expectErr != "" {
@@ -182,11 +178,10 @@ func TestCheckoutTag_Checkout(t *testing.T) {
 }
 
 func TestCheckoutCommit_Checkout(t *testing.T) {
-	repo, path, err := initRepo()
+	repo, path, err := initRepo(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(path)
 
 	firstCommit, err := commitFile(repo, "commit", "init", time.Now())
 	if err != nil {
@@ -242,11 +237,7 @@ func TestCheckoutCommit_Checkout(t *testing.T) {
 				Branch: tt.branch,
 			}
 
-			tmpDir, err := os.MkdirTemp("", "git2go")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			cc, err := commit.Checkout(context.TODO(), tmpDir, path, nil)
 			if tt.expectError != "" {
@@ -326,11 +317,10 @@ func TestCheckoutTagSemVer_Checkout(t *testing.T) {
 		},
 	}
 
-	repo, path, err := initRepo()
+	repo, path, err := initRepo(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(path)
 
 	refs := make(map[string]string, len(tags))
 	for _, tt := range tags {
@@ -352,8 +342,7 @@ func TestCheckoutTagSemVer_Checkout(t *testing.T) {
 			semVer := CheckoutSemVer{
 				SemVer: tt.constraint,
 			}
-			tmpDir, _ := os.MkdirTemp("", "test")
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			cc, err := semVer.Checkout(context.TODO(), tmpDir, path, nil)
 			if tt.expectErr != nil {
@@ -370,16 +359,11 @@ func TestCheckoutTagSemVer_Checkout(t *testing.T) {
 	}
 }
 
-func initRepo() (*extgogit.Repository, string, error) {
-	tmpDir, err := os.MkdirTemp("", "gogit")
-	if err != nil {
-		os.RemoveAll(tmpDir)
-		return nil, "", err
-	}
+func initRepo(t *testing.T) (*extgogit.Repository, string, error) {
+	tmpDir := t.TempDir()
 	sto := filesystem.NewStorage(osfs.New(tmpDir), cache.NewObjectLRUDefault())
 	repo, err := extgogit.Init(sto, memfs.New())
 	if err != nil {
-		os.RemoveAll(tmpDir)
 		return nil, "", err
 	}
 	return repo, tmpDir, err

--- a/pkg/git/libgit2/checkout_test.go
+++ b/pkg/git/libgit2/checkout_test.go
@@ -37,12 +37,11 @@ import (
 )
 
 func TestCheckoutBranch_Checkout(t *testing.T) {
-	repo, err := initBareRepo()
+	repo, err := initBareRepo(t)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer repo.Free()
-	defer os.RemoveAll(filepath.Join(repo.Path(), ".."))
 
 	cfg, err := git2go.OpenDefault()
 	if err != nil {
@@ -105,8 +104,7 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 			branch := CheckoutBranch{
 				Branch: tt.branch,
 			}
-			tmpDir, _ := os.MkdirTemp("", "test")
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			cc, err := branch.Checkout(context.TODO(), tmpDir, repo.Path(), nil)
 			if tt.expectedErr != "" {
@@ -158,12 +156,11 @@ func TestCheckoutTag_Checkout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			repo, err := initBareRepo()
+			repo, err := initBareRepo(t)
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer repo.Free()
-			defer os.RemoveAll(filepath.Join(repo.Path(), ".."))
 
 			var commit *git2go.Commit
 			if tt.tag != "" {
@@ -183,8 +180,7 @@ func TestCheckoutTag_Checkout(t *testing.T) {
 			tag := CheckoutTag{
 				Tag: tt.checkoutTag,
 			}
-			tmpDir, _ := os.MkdirTemp("", "test")
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			cc, err := tag.Checkout(context.TODO(), tmpDir, repo.Path(), nil)
 			if tt.expectErr != "" {
@@ -205,12 +201,11 @@ func TestCheckoutTag_Checkout(t *testing.T) {
 func TestCheckoutCommit_Checkout(t *testing.T) {
 	g := NewWithT(t)
 
-	repo, err := initBareRepo()
+	repo, err := initBareRepo(t)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer repo.Free()
-	defer os.RemoveAll(filepath.Join(repo.Path(), ".."))
 
 	c, err := commitFile(repo, "commit", "init", time.Now())
 	if err != nil {
@@ -223,11 +218,7 @@ func TestCheckoutCommit_Checkout(t *testing.T) {
 	commit := CheckoutCommit{
 		Commit: c.String(),
 	}
-	tmpDir, err := os.MkdirTemp("", "git2go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	cc, err := commit.Checkout(context.TODO(), tmpDir, repo.Path(), nil)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -239,11 +230,7 @@ func TestCheckoutCommit_Checkout(t *testing.T) {
 	commit = CheckoutCommit{
 		Commit: "4dc3185c5fc94eb75048376edeb44571cece25f4",
 	}
-	tmpDir2, err := os.MkdirTemp("", "git2go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir2)
+	tmpDir2 := t.TempDir()
 
 	cc, err = commit.Checkout(context.TODO(), tmpDir2, repo.Path(), nil)
 	g.Expect(err).To(HaveOccurred())
@@ -313,12 +300,11 @@ func TestCheckoutTagSemVer_Checkout(t *testing.T) {
 		},
 	}
 
-	repo, err := initBareRepo()
+	repo, err := initBareRepo(t)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer repo.Free()
-	defer os.RemoveAll(filepath.Join(repo.Path(), ".."))
 
 	refs := make(map[string]string, len(tags))
 	for _, tt := range tags {
@@ -349,8 +335,7 @@ func TestCheckoutTagSemVer_Checkout(t *testing.T) {
 			semVer := CheckoutSemVer{
 				SemVer: tt.constraint,
 			}
-			tmpDir, _ := os.MkdirTemp("", "test")
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			cc, err := semVer.Checkout(context.TODO(), tmpDir, repo.Path(), nil)
 			if tt.expectErr != nil {
@@ -367,14 +352,10 @@ func TestCheckoutTagSemVer_Checkout(t *testing.T) {
 	}
 }
 
-func initBareRepo() (*git2go.Repository, error) {
-	tmpDir, err := os.MkdirTemp("", "git2go-")
-	if err != nil {
-		return nil, err
-	}
+func initBareRepo(t *testing.T) (*git2go.Repository, error) {
+	tmpDir := t.TempDir()
 	repo, err := git2go.InitRepository(tmpDir, false)
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
 		return nil, err
 	}
 	return repo, nil
@@ -514,8 +495,7 @@ func TestCheckout_ED25519(t *testing.T) {
 
 	// Prepare for checkout.
 	branchCheckoutStrat := &CheckoutBranch{Branch: git.DefaultBranch}
-	tmpDir, _ := os.MkdirTemp("", "test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 	defer cancel()

--- a/pkg/git/libgit2/managed/managed_test.go
+++ b/pkg/git/libgit2/managed/managed_test.go
@@ -258,8 +258,7 @@ func TestManagedTransport_E2E(t *testing.T) {
 	err = server.InitRepo("../testdata/git/repo", git.DefaultBranch, repoPath)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	tmpDir, _ := os.MkdirTemp("", "test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Test HTTP transport
 
@@ -285,8 +284,7 @@ func TestManagedTransport_E2E(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	repo.Free()
 
-	tmpDir2, _ := os.MkdirTemp("", "test")
-	defer os.RemoveAll(tmpDir2)
+	tmpDir2 := t.TempDir()
 
 	kp, err := ssh.NewEd25519Generator().Generate()
 	g.Expect(err).ToNot(HaveOccurred())
@@ -313,8 +311,7 @@ func TestManagedTransport_E2E(t *testing.T) {
 func TestManagedTransport_HandleRedirect(t *testing.T) {
 	g := NewWithT(t)
 
-	tmpDir, _ := os.MkdirTemp("", "test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Force managed transport to be enabled
 	InitManagedTransport(logr.Discard())

--- a/pkg/git/strategy/proxy/strategy_proxy_test.go
+++ b/pkg/git/strategy/proxy/strategy_proxy_test.go
@@ -264,9 +264,7 @@ func TestCheckoutStrategyForImplementation_Proxied(t *testing.T) {
 			})
 			g.Expect(err).ToNot(HaveOccurred())
 
-			tmpDir, err := os.MkdirTemp("", "test-checkout")
-			g.Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			// for the NO_PROXY test we dont want to wait the 30s for it to timeout/fail, so shorten the timeout
 			checkoutCtx := context.TODO()

--- a/pkg/git/strategy/strategy_test.go
+++ b/pkg/git/strategy/strategy_test.go
@@ -180,9 +180,7 @@ func TestCheckoutStrategyForImplementation_Auth(t *testing.T) {
 			checkoutStrategy, err := CheckoutStrategyForImplementation(context.TODO(), impl, checkoutOpts)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			tmpDir, err := os.MkdirTemp("", "test-checkout")
-			g.Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			tt.wantFunc(g, checkoutStrategy, tmpDir, repoURL, authOpts)
 		}
@@ -271,9 +269,7 @@ func TestCheckoutStrategyForImplementation_SemVerCheckout(t *testing.T) {
 	}
 
 	// Clone the repo locally.
-	cloneDir, err := os.MkdirTemp("", "test-clone")
-	g.Expect(err).ToNot(HaveOccurred())
-	defer os.RemoveAll(cloneDir)
+	cloneDir := t.TempDir()
 	repo, err := extgogit.PlainClone(cloneDir, false, &extgogit.CloneOptions{
 		URL: repoURL,
 	})
@@ -332,9 +328,7 @@ func TestCheckoutStrategyForImplementation_SemVerCheckout(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Checkout and verify.
-			tmpDir, err := os.MkdirTemp("", "test-checkout")
-			g.Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			cc, err := checkoutStrategy.Checkout(context.TODO(), tmpDir, repoURL, authOpts)
 			if tt.expectErr != nil {
@@ -425,9 +419,7 @@ func TestCheckoutStrategyForImplementation_WithCtxTimeout(t *testing.T) {
 			checkoutStrategy, err := CheckoutStrategyForImplementation(context.TODO(), impl, checkoutOpts)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			tmpDir, err := os.MkdirTemp("", "test-checkout")
-			g.Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			checkoutCtx, cancel := context.WithTimeout(context.TODO(), tt.timeout)
 			defer cancel()

--- a/pkg/minio/minio_test.go
+++ b/pkg/minio/minio_test.go
@@ -144,22 +144,18 @@ func TestBucketNotExists(t *testing.T) {
 
 func TestFGetObject(t *testing.T) {
 	ctx := context.Background()
-	tempDir, err := os.MkdirTemp("", bucketName)
-	assert.NilError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	path := filepath.Join(tempDir, sourceignore.IgnoreFile)
-	_, err = minioClient.FGetObject(ctx, bucketName, objectName, path)
+	_, err := minioClient.FGetObject(ctx, bucketName, objectName, path)
 	assert.NilError(t, err)
 }
 
 func TestFGetObjectNotExists(t *testing.T) {
 	ctx := context.Background()
-	tempDir, err := os.MkdirTemp("", bucketName)
-	assert.NilError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	badKey := "invalid.txt"
 	path := filepath.Join(tempDir, badKey)
-	_, err = minioClient.FGetObject(ctx, bucketName, badKey, path)
+	_, err := minioClient.FGetObject(ctx, bucketName, badKey, path)
 	assert.Error(t, err, "The specified key does not exist.")
 	assert.Check(t, minioClient.ObjectIsNotFound(err))
 }

--- a/pkg/sourceignore/sourceignore_test.go
+++ b/pkg/sourceignore/sourceignore_test.go
@@ -197,11 +197,7 @@ func TestDefaultPatterns(t *testing.T) {
 }
 
 func TestLoadExcludePatterns(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "sourceignore-load-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	files := map[string]string{
 		".sourceignore":     "root.txt",
 		"d/.gitignore":      "ignored",
@@ -209,10 +205,10 @@ func TestLoadExcludePatterns(t *testing.T) {
 		"a/b/.sourceignore": "subdir.txt",
 	}
 	for n, c := range files {
-		if err = os.MkdirAll(filepath.Join(tmpDir, filepath.Dir(n)), 0o750); err != nil {
+		if err := os.MkdirAll(filepath.Join(tmpDir, filepath.Dir(n)), 0o750); err != nil {
 			t.Fatal(err)
 		}
-		if err = os.WriteFile(filepath.Join(tmpDir, n), []byte(c), 0o640); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, n), []byte(c), 0o640); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmp)

	// now
	tmpDir := t.TempDir()
}
```