### PR TITLE
Switch to gen-crd-api-reference-docs from master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 GEN_CRD_API_REFERENCE_DOCS = $(GOBIN)/gen-crd-api-reference-docs
 .PHONY: gen-crd-api-reference-docs
 gen-crd-api-reference-docs: ## Download gen-crd-api-reference-docs locally if necessary
-	$(call go-install-tool,$(GEN_CRD_API_REFERENCE_DOCS),github.com/ahmetb/gen-crd-api-reference-docs@v0.3.0)
+	$(call go-install-tool,$(GEN_CRD_API_REFERENCE_DOCS),github.com/ahmetb/gen-crd-api-reference-docs@3f29e6853552dcf08a8e846b1225f275ed0f3e3b)
 
 ENVTEST = $(GOBIN)/setup-envtest
 .PHONY: envtest

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -1630,8 +1630,8 @@ Artifact
 <td>
 <code>includedArtifacts</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.*./api/v1beta2.Artifact">
-[]*./api/v1beta2.Artifact
+<a href="#source.toolkit.fluxcd.io/v1beta2.Artifact">
+[]Artifact
 </a>
 </em>
 </td>


### PR DESCRIPTION
v0.3.0 of gen-crd-api-reference-docs has a bug that leads to it
rendering incorrect links for local types. This is fixed on the master
branch but not released, yet, so I'm pinning the version of the tool
to the latest current commit.