### PR TITLE
summarize: Consider obj status condition in result

### DIFF
--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -52,7 +52,12 @@ const (
 // can be implemented to build custom results based on the context of the
 // reconciler.
 type RuntimeResultBuilder interface {
+	// BuildRuntimeResult analyzes the result and error to return a runtime
+	// result.
 	BuildRuntimeResult(rr Result, err error) ctrl.Result
+	// IsSuccess returns if a given runtime result is success for a
+	// RuntimeResultBuilder.
+	IsSuccess(ctrl.Result) bool
 }
 
 // AlwaysRequeueResultBuilder implements a RuntimeResultBuilder for always
@@ -80,6 +85,12 @@ func (r AlwaysRequeueResultBuilder) BuildRuntimeResult(rr Result, err error) ctr
 	default:
 		return ctrl.Result{}
 	}
+}
+
+// IsSuccess returns true if the given Result has the same RequeueAfter value
+// as of the AlwaysRequeueResultBuilder.
+func (r AlwaysRequeueResultBuilder) IsSuccess(result ctrl.Result) bool {
+	return result.RequeueAfter == r.RequeueAfter
 }
 
 // ComputeReconcileResult analyzes the reconcile results (result + error),


### PR DESCRIPTION
`SummarizeAndPatch()` should also consider the object's status conditions
when computing and returning the runtime results to avoid any
inconsistency in the runtime result and status condition of the object.
When an object's Ready conditions are False, the reconciler should retry
unless it's in stalled state.

### Detailed description

Summarize and patch takes the abstracted result and error, and computes the runtime result from it. Separately, it takes the object with status conditions and calculates the status summary and patches the object status.
This can result in a situation where the (sub)reconcilers return a successful result without any error, resulting in a success runtime result. But a negative status condition on the object set by one of the sub-reconcilers would result in the Ready status condition to be False. As a result of this, an object would have Ready=False status and the reconciler wouldn't be attempting any retry to reconcile it. We expect this behavior to only happen when the status condition Stalled=True. Unless Ready=True, the reconciler should always retry.

To make the model consistent, the summarize and patch process can take into consideration the status condition summary for Ready condition.

Runtime result behavior with respect to Ready condition:

- If Ready=True, but the abstracted result is `ResultRequeue` and nil error, the runtime result should have `Requeue: true`.

- If Ready=True, but the abstracted result is `ResultSuccess` and nil error, the runtime result should have `RequeueAfter: <interval>`.

- If Ready=True, but the reconciler error is not nil, a runtime error is returned, resulting in runtime requeuing the object for reconciliation. Since an error in itself can't be used to set the Ready=False with reason and message, we can't change the status condition to reflect this failure. The retry will happen in the background without anything visible in the object status.

- **[New behavior]** If Ready=False, but the abstracted result is Success and reconciler error is nil, the reconciler error can be changed to reflect the reason for Ready=False by setting the error to be the Ready condition message. This will result in the object to have Ready=False and the reconciler performing a retry.