### PR TITLE
Implements conditional no-op before CheckoutTag in gogit

### DIFF
--- a/pkg/git/gogit/checkout_test.go
+++ b/pkg/git/gogit/checkout_test.go
@@ -145,7 +145,7 @@ func TestCheckoutTag_Checkout(t *testing.T) {
 			expectErr:   "no changes since last reconcilation",
 		},
 		{
-			name:        "Tag",
+			name:        "Last revision changed",
 			tag:         "tag-3",
 			checkoutTag: "tag-3",
 			expectTag:   "tag-3",

--- a/pkg/minio/minio_test.go
+++ b/pkg/minio/minio_test.go
@@ -39,7 +39,7 @@ import (
 const (
 	objectName string = "test.yaml"
 	objectEtag string = "2020beab5f1711919157756379622d1d"
-	region     string = "us-east-1"
+	region     string = "us-west-2"
 )
 
 var (


### PR DESCRIPTION
This pull request implements the conditional no-op in the rest of the strategy for go-git.
The rest of the checkout strategies don't have the no-op implemented due to reasons listed in [#696](https://github.com/fluxcd/source-controller/pull/696)
TL,DR:
`CheckoutCommit` still requires a fetch to check if the commit still exists upstream and
`CheckoutTag` can only be optimized partially and requires complex logic. Therefore, it requires further discussion.

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>