### PR TITLE
Update artifact tarball when `spec.ignore` changes

### DIFF
--- a/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
@@ -379,6 +379,10 @@ spec:
                   checksum:
                     description: Checksum is the SHA256 checksum of the Artifact file.
                     type: string
+                  excludedPatternsChecksum:
+                    description: ExcludedPatternsChecksum is a SHA256 checksum of
+                      the excluded patterns applied in the last reconciliation.
+                    type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to
                       the last update of the Artifact.

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -149,8 +149,8 @@ spec:
               secretRef:
                 description: The secret name containing the Git credentials. For HTTPS
                   repositories the secret must contain username and password fields.
-                  For SSH repositories the secret must contain identity and known_hosts
-                  fields.
+                  For SSH repositories the secret must contain identity, identity.pub
+                  and known_hosts fields.
                 properties:
                   name:
                     description: Name of the referent.
@@ -554,6 +554,10 @@ spec:
                   checksum:
                     description: Checksum is the SHA256 checksum of the Artifact file.
                     type: string
+                  excludedPatternsChecksum:
+                    description: ExcludedPatternsChecksum is a SHA256 checksum of
+                      the excluded patterns applied in the last reconciliation.
+                    type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to
                       the last update of the Artifact.
@@ -662,6 +666,10 @@ spec:
                     checksum:
                       description: Checksum is the SHA256 checksum of the Artifact
                         file.
+                      type: string
+                    excludedPatternsChecksum:
+                      description: ExcludedPatternsChecksum is a SHA256 checksum of
+                        the excluded patterns applied in the last reconciliation.
                       type: string
                     lastUpdateTime:
                       description: LastUpdateTime is the timestamp corresponding to

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -427,6 +427,10 @@ spec:
                   checksum:
                     description: Checksum is the SHA256 checksum of the Artifact file.
                     type: string
+                  excludedPatternsChecksum:
+                    description: ExcludedPatternsChecksum is a SHA256 checksum of
+                      the excluded patterns applied in the last reconciliation.
+                    type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to
                       the last update of the Artifact.

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -350,6 +350,10 @@ spec:
                   checksum:
                     description: Checksum is the SHA256 checksum of the Artifact file.
                     type: string
+                  excludedPatternsChecksum:
+                    description: ExcludedPatternsChecksum is a SHA256 checksum of
+                      the excluded patterns applied in the last reconciliation.
+                    type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to
                       the last update of the Artifact.


### PR DESCRIPTION
This commit adds a new field `status.artifact.excludedPatternsChecksum` which is used to detect changes on `spec.ignore`, that controls the exclusions for the object's `status.artifact`.

Fix: https://github.com/fluxcd/source-controller/issues/704