### PR TITLE
Remove minio region

### DIFF
--- a/pkg/minio/minio_test.go
+++ b/pkg/minio/minio_test.go
@@ -39,7 +39,6 @@ import (
 const (
 	objectName string = "test.yaml"
 	objectEtag string = "2020beab5f1711919157756379622d1d"
-	region     string = "us-west-2"
 )
 
 var (
@@ -72,7 +71,6 @@ var (
 		Spec: sourcev1.BucketSpec{
 			BucketName: bucketName,
 			Endpoint:   "play.min.io",
-			Region:     region,
 			Provider:   "generic",
 			Insecure:   true,
 			SecretRef: &meta.LocalObjectReference{
@@ -88,7 +86,6 @@ var (
 		Spec: sourcev1.BucketSpec{
 			BucketName: bucketName,
 			Endpoint:   "play.min.io",
-			Region:     region,
 			Provider:   "aws",
 			Insecure:   true,
 		},
@@ -226,7 +223,7 @@ func TestValidateSecret(t *testing.T) {
 }
 
 func createBucket(ctx context.Context) {
-	if err := minioClient.Client.MakeBucket(ctx, bucketName, miniov7.MakeBucketOptions{Region: region}); err != nil {
+	if err := minioClient.Client.MakeBucket(ctx, bucketName, miniov7.MakeBucketOptions{}); err != nil {
 		exists, errBucketExists := minioClient.BucketExists(ctx, bucketName)
 		if errBucketExists == nil && exists {
 			deleteBucket(ctx)


### PR DESCRIPTION
Twice recently the minio region seemed to have changed, breaking the CI tests.
By unsetting the region seems to get the tests work, which aligns with minio documentation:
```
// Location is an optional argument, by default all buckets are
// created in US Standard Region.
```
https://github.com/minio/minio-go/blob/3237a5a7c17fb7beb0607b23c6831238b118ef93/api-put-bucket.go#L116-L117