### PR TITLE
libgit2: Add support for hashed known_hosts

### DIFF
--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -478,7 +478,7 @@ func TestGitRepositoryReconciler_reconcileSource_authStrategy(t *testing.T) {
 					u, err := url.Parse(obj.Spec.URL)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(u.Host).ToNot(BeEmpty())
-					knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos)
+					knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos, false)
 					g.Expect(err).NotTo(HaveOccurred())
 					secret.Data["known_hosts"] = knownHosts
 				}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/fluxcd/pkg/helmtestserver v0.7.2
 	github.com/fluxcd/pkg/lockedfile v0.1.0
 	github.com/fluxcd/pkg/runtime v0.15.1
-	github.com/fluxcd/pkg/ssh v0.3.3
+	github.com/fluxcd/pkg/ssh v0.3.4
 	github.com/fluxcd/pkg/testserver v0.2.0
 	github.com/fluxcd/pkg/untar v0.1.0
 	github.com/fluxcd/pkg/version v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,8 @@ github.com/fluxcd/pkg/lockedfile v0.1.0/go.mod h1:EJLan8t9MiOcgTs8+puDjbE6I/KAfH
 github.com/fluxcd/pkg/runtime v0.13.0-rc.6/go.mod h1:4oKUO19TeudXrnCRnxCfMSS7EQTYpYlgfXwlQuDJ/Eg=
 github.com/fluxcd/pkg/runtime v0.15.1 h1:PKooYqlZM+KLhnNz10sQnBH0AHllS40PIDHtiRH/BGU=
 github.com/fluxcd/pkg/runtime v0.15.1/go.mod h1:TPAoOEgUFG60FXBA4ID41uaPldxuXCEI4jt3qfd5i5Q=
-github.com/fluxcd/pkg/ssh v0.3.3 h1:/tc7W7LO1VoVUI5jB+p9ZHCA+iQaXTkaSCDZJsxcZ9k=
-github.com/fluxcd/pkg/ssh v0.3.3/go.mod h1:+bKhuv0/pJy3HZwkK54Shz68sNv1uf5aI6wtPaEHaYk=
+github.com/fluxcd/pkg/ssh v0.3.4 h1:Ko+MUNiiQG3evyoMO19iRk7d4X0VJ6w6+GEeVQ1jLC0=
+github.com/fluxcd/pkg/ssh v0.3.4/go.mod h1:KGgOUOy1uI6RC6+qxIBLvP1AeOOs/nLB25Ca6TZMIXE=
 github.com/fluxcd/pkg/testserver v0.2.0 h1:Mj0TapmKaywI6Fi5wvt1LAZpakUHmtzWQpJNKQ0Krt4=
 github.com/fluxcd/pkg/testserver v0.2.0/go.mod h1:bgjjydkXsZTeFzjz9Cr4heGANr41uTB1Aj1Q5qzuYVk=
 github.com/fluxcd/pkg/untar v0.1.0 h1:k97V/xV5hFrAkIkVPuv5AVhyxh1ZzzAKba/lbDfGo6o=

--- a/pkg/git/gogit/checkout_test.go
+++ b/pkg/git/gogit/checkout_test.go
@@ -461,7 +461,7 @@ func Test_KeyTypes(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(u.Host).ToNot(BeEmpty())
 
-	knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos)
+	knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos, false)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	for _, tt := range tests {
@@ -600,7 +600,7 @@ func Test_KeyExchangeAlgos(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(u.Host).ToNot(BeEmpty())
 
-			knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos)
+			knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos, false)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// No authentication is required for this test, but it is
@@ -644,6 +644,7 @@ func TestHostKeyAlgos(t *testing.T) {
 		name               string
 		keyType            ssh.KeyPairType
 		ClientHostKeyAlgos []string
+		hashHostNames      bool
 	}{
 		{
 			name:               "support for hostkey: ssh-rsa",
@@ -679,6 +680,48 @@ func TestHostKeyAlgos(t *testing.T) {
 			name:               "support for hostkey: ssh-ed25519",
 			keyType:            ssh.ED25519,
 			ClientHostKeyAlgos: []string{"ssh-ed25519"},
+		},
+		{
+			name:               "support for hostkey: ssh-rsa with hashed host names",
+			keyType:            ssh.RSA_4096,
+			ClientHostKeyAlgos: []string{"ssh-rsa"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: rsa-sha2-256 with hashed host names",
+			keyType:            ssh.RSA_4096,
+			ClientHostKeyAlgos: []string{"rsa-sha2-256"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: rsa-sha2-512 with hashed host names",
+			keyType:            ssh.RSA_4096,
+			ClientHostKeyAlgos: []string{"rsa-sha2-512"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: ecdsa-sha2-nistp256 with hashed host names",
+			keyType:            ssh.ECDSA_P256,
+			ClientHostKeyAlgos: []string{"ecdsa-sha2-nistp256"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: ecdsa-sha2-nistp384 with hashed host names",
+			keyType:            ssh.ECDSA_P384,
+			ClientHostKeyAlgos: []string{"ecdsa-sha2-nistp384"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: ecdsa-sha2-nistp521 with hashed host names",
+			keyType:            ssh.ECDSA_P521,
+			ClientHostKeyAlgos: []string{"ecdsa-sha2-nistp521"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: ssh-ed25519 with hashed host names",
+			keyType:            ssh.ED25519,
+			ClientHostKeyAlgos: []string{"ssh-ed25519"},
+			hashHostNames:      true,
 		},
 	}
 
@@ -727,7 +770,7 @@ func TestHostKeyAlgos(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(u.Host).ToNot(BeEmpty())
 
-			knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos)
+			knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos, tt.hashHostNames)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// No authentication is required for this test, but it is

--- a/pkg/git/libgit2/managed_test.go
+++ b/pkg/git/libgit2/managed_test.go
@@ -96,7 +96,7 @@ func Test_ManagedSSH_KeyTypes(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(u.Host).ToNot(BeEmpty())
 
-	knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos)
+	knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos, false)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	for _, tt := range tests {
@@ -238,7 +238,7 @@ func Test_ManagedSSH_KeyExchangeAlgos(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(u.Host).ToNot(BeEmpty())
 
-			knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos)
+			knownHosts, err := ssh.ScanHostKey(u.Host, timeout, git.HostKeyAlgos, false)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// No authentication is required for this test, but it is
@@ -282,6 +282,7 @@ func Test_ManagedSSH_HostKeyAlgos(t *testing.T) {
 		name               string
 		keyType            ssh.KeyPairType
 		ClientHostKeyAlgos []string
+		hashHostNames      bool
 	}{
 		{
 			name:               "support for hostkey: ssh-rsa",
@@ -317,6 +318,48 @@ func Test_ManagedSSH_HostKeyAlgos(t *testing.T) {
 			name:               "support for hostkey: ssh-ed25519",
 			keyType:            ssh.ED25519,
 			ClientHostKeyAlgos: []string{"ssh-ed25519"},
+		},
+		{
+			name:               "support for hostkey: ssh-rsa with hashed host names",
+			keyType:            ssh.RSA_4096,
+			ClientHostKeyAlgos: []string{"ssh-rsa"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: rsa-sha2-256 with hashed host names",
+			keyType:            ssh.RSA_4096,
+			ClientHostKeyAlgos: []string{"rsa-sha2-256"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: rsa-sha2-512 with hashed host names",
+			keyType:            ssh.RSA_4096,
+			ClientHostKeyAlgos: []string{"rsa-sha2-512"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: ecdsa-sha2-nistp256 with hashed host names",
+			keyType:            ssh.ECDSA_P256,
+			ClientHostKeyAlgos: []string{"ecdsa-sha2-nistp256"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: ecdsa-sha2-nistp384 with hashed host names",
+			keyType:            ssh.ECDSA_P384,
+			ClientHostKeyAlgos: []string{"ecdsa-sha2-nistp384"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: ecdsa-sha2-nistp521 with hashed host names",
+			keyType:            ssh.ECDSA_P521,
+			ClientHostKeyAlgos: []string{"ecdsa-sha2-nistp521"},
+			hashHostNames:      true,
+		},
+		{
+			name:               "support for hostkey: ssh-ed25519 with hashed host names",
+			keyType:            ssh.ED25519,
+			ClientHostKeyAlgos: []string{"ssh-ed25519"},
+			hashHostNames:      true,
 		},
 	}
 
@@ -368,7 +411,7 @@ func Test_ManagedSSH_HostKeyAlgos(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(u.Host).ToNot(BeEmpty())
 
-			knownHosts, err := ssh.ScanHostKey(u.Host, timeout, tt.ClientHostKeyAlgos)
+			knownHosts, err := ssh.ScanHostKey(u.Host, timeout, tt.ClientHostKeyAlgos, tt.hashHostNames)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// No authentication is required for this test, but it is

--- a/pkg/git/strategy/strategy_test.go
+++ b/pkg/git/strategy/strategy_test.go
@@ -97,7 +97,7 @@ func TestCheckoutStrategyForImplementation_Auth(t *testing.T) {
 				return getSSHRepoURL(srv.SSHAddress(), repoPath)
 			},
 			authOptsFunc: func(g *WithT, u *url.URL, user, pswd string, ca []byte) *git.AuthOptions {
-				knownhosts, err := ssh.ScanHostKey(u.Host, 5*time.Second, git.HostKeyAlgos)
+				knownhosts, err := ssh.ScanHostKey(u.Host, 5*time.Second, git.HostKeyAlgos, false)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				keygen := ssh.NewRSAGenerator(2048)


### PR DESCRIPTION
Hashed `known_hosts` was previously only supported when using `go-git`. 
Now both Git implementations benefit from this feature, and the code coverage across them can ensure no future regression.

Fixes: https://github.com/fluxcd/flux2/issues/1593
Depends on: https://github.com/fluxcd/pkg/pull/274