### PR TITLE
GitRepositoryReconciler no-op clone improvements

### DIFF
--- a/api/v1beta2/condition_types.go
+++ b/api/v1beta2/condition_types.go
@@ -100,4 +100,7 @@ const (
 
 	// CacheOperationFailedReason signals a failure in cache operation.
 	CacheOperationFailedReason string = "CacheOperationFailed"
+
+	// CopyOperationFailedReason signals a failure in copying files.
+	CopyOperationFailedReason string = "CopyOperationFailed"
 )

--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -57,6 +57,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
+	"github.com/fluxcd/source-controller/internal/features"
 	sreconcile "github.com/fluxcd/source-controller/internal/reconcile"
 	"github.com/fluxcd/source-controller/internal/reconcile/summarize"
 	"github.com/fluxcd/source-controller/pkg/git"
@@ -499,6 +500,7 @@ func TestGitRepositoryReconciler_reconcileSource_authStrategy(t *testing.T) {
 				Client:        builder.Build(),
 				EventRecorder: record.NewFakeRecorder(32),
 				Storage:       testStorage,
+				features:      features.FeatureGates(),
 			}
 
 			for _, i := range testGitImplementations {
@@ -641,6 +643,7 @@ func TestGitRepositoryReconciler_reconcileSource_checkoutStrategy(t *testing.T) 
 		Client:        fakeclient.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
 		EventRecorder: record.NewFakeRecorder(32),
 		Storage:       testStorage,
+		features:      features.FeatureGates(),
 	}
 
 	for _, tt := range tests {
@@ -857,6 +860,7 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			r := &GitRepositoryReconciler{
 				EventRecorder: record.NewFakeRecorder(32),
 				Storage:       testStorage,
+				features:      features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1042,6 +1046,7 @@ func TestGitRepositoryReconciler_reconcileInclude(t *testing.T) {
 				EventRecorder:     record.NewFakeRecorder(32),
 				Storage:           storage,
 				requeueDependency: dependencyInterval,
+				features:          features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1206,6 +1211,7 @@ func TestGitRepositoryReconciler_reconcileStorage(t *testing.T) {
 			r := &GitRepositoryReconciler{
 				EventRecorder: record.NewFakeRecorder(32),
 				Storage:       testStorage,
+				features:      features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1247,6 +1253,7 @@ func TestGitRepositoryReconciler_reconcileDelete(t *testing.T) {
 	r := &GitRepositoryReconciler{
 		EventRecorder: record.NewFakeRecorder(32),
 		Storage:       testStorage,
+		features:      features.FeatureGates(),
 	}
 
 	obj := &sourcev1.GitRepository{
@@ -1384,6 +1391,7 @@ func TestGitRepositoryReconciler_verifyCommitSignature(t *testing.T) {
 			r := &GitRepositoryReconciler{
 				EventRecorder: record.NewFakeRecorder(32),
 				Client:        builder.Build(),
+				features:      features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1525,6 +1533,7 @@ func TestGitRepositoryReconciler_ConditionsUpdate(t *testing.T) {
 				Client:        builder.Build(),
 				EventRecorder: record.NewFakeRecorder(32),
 				Storage:       testStorage,
+				features:      features.FeatureGates(),
 			}
 
 			key := client.ObjectKeyFromObject(obj)
@@ -1857,6 +1866,7 @@ func TestGitRepositoryReconciler_notify(t *testing.T) {
 
 			reconciler := &GitRepositoryReconciler{
 				EventRecorder: recorder,
+				features:      features.FeatureGates(),
 			}
 			commit := &git.Commit{
 				Message: "test commit",

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -36,6 +36,7 @@ import (
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/fluxcd/source-controller/internal/cache"
+	"github.com/fluxcd/source-controller/internal/features"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -106,6 +107,7 @@ func TestMain(m *testing.M) {
 		EventRecorder: record.NewFakeRecorder(32),
 		Metrics:       testMetricsH,
 		Storage:       testStorage,
+		features:      features.FeatureGates(),
 	}).SetupWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Failed to start GitRepositoryReconciler: %v", err))
 	}

--- a/docs/spec/v1beta2/gitrepositories.md
+++ b/docs/spec/v1beta2/gitrepositories.md
@@ -406,8 +406,8 @@ reconciliations. It supports both `go-git` and `libgit2` implementations
 when cloning repositories using branches or tags.
 
 When enabled, avoids full clone operations by first checking whether
-the last revision is still the same at the target repository,
-and if that is so, skips the reconciliation.
+the revision of the last stored artifact is still the head of the remote
+repository, and if that is so, the local artifact is reused.
 
 This feature is enabled by default. It can be disabled by starting the
 controller with the argument `--feature-gates=OptimizedGitClones=false`.

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -118,3 +118,13 @@ type NoChangesError struct {
 func (e NoChangesError) Error() string {
 	return fmt.Sprintf("%s: observed revision '%s'", e.Message, e.ObservedRevision)
 }
+
+// IsConcreteCommit returns if a given commit is a concrete commit. Concrete
+// commits have most of commit metadata and commit content. In contrast, a
+// partial commit may only have some metadata and no commit content.
+func IsConcreteCommit(c Commit) bool {
+	if c.Hash != nil && c.Encoded != nil {
+		return true
+	}
+	return false
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -107,18 +107,6 @@ type CheckoutStrategy interface {
 	Checkout(ctx context.Context, path, url string, config *AuthOptions) (*Commit, error)
 }
 
-// NoChangesError represents the case in which a Git clone operation
-// is attempted, but cancelled as the revision is still the same as
-// the one observed on the last successful reconciliation.
-type NoChangesError struct {
-	Message          string
-	ObservedRevision string
-}
-
-func (e NoChangesError) Error() string {
-	return fmt.Sprintf("%s: observed revision '%s'", e.Message, e.ObservedRevision)
-}
-
 // IsConcreteCommit returns if a given commit is a concrete commit. Concrete
 // commits have most of commit metadata and commit content. In contrast, a
 // partial commit may only have some metadata and no commit content.

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -18,6 +18,7 @@ package git
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 )
@@ -260,6 +261,44 @@ of the commit`,
 
 			c := Commit{Message: tt.input}
 			g.Expect(c.ShortMessage()).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestIsConcreteCommit(t *testing.T) {
+	tests := []struct {
+		name   string
+		commit Commit
+		result bool
+	}{
+		{
+			name: "concrete commit",
+			commit: Commit{
+				Hash:      Hash("foo"),
+				Reference: "refs/tags/main",
+				Author: Signature{
+					Name: "user", Email: "user@example.com", When: time.Now(),
+				},
+				Committer: Signature{
+					Name: "user", Email: "user@example.com", When: time.Now(),
+				},
+				Signature: "signature",
+				Encoded:   []byte("commit-content"),
+				Message:   "commit-message",
+			},
+			result: true,
+		},
+		{
+			name:   "partial commit",
+			commit: Commit{Hash: Hash("foo")},
+			result: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(IsConcreteCommit(tt.commit)).To(Equal(tt.result))
 		})
 	}
 }

--- a/pkg/git/gogit/checkout.go
+++ b/pkg/git/gogit/checkout.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -78,10 +79,15 @@ func (c *CheckoutBranch) Checkout(ctx context.Context, path, url string, opts *g
 		}
 
 		if currentRevision != "" && currentRevision == c.LastRevision {
-			return nil, git.NoChangesError{
-				Message:          "no changes since last reconcilation",
-				ObservedRevision: currentRevision,
+			// Construct a partial commit with the existing information.
+			// Split the revision and take the last part as the hash.
+			// Example revision: main/43d7eb9c49cdd49b2494efd481aea1166fc22b67
+			ss := strings.Split(currentRevision, "/")
+			c := &git.Commit{
+				Hash:      git.Hash(ss[len(ss)-1]),
+				Reference: ref.String(),
 			}
+			return c, nil
 		}
 	}
 
@@ -153,10 +159,15 @@ func (c *CheckoutTag) Checkout(ctx context.Context, path, url string, opts *git.
 		}
 
 		if currentRevision != "" && currentRevision == c.LastRevision {
-			return nil, git.NoChangesError{
-				Message:          "no changes since last reconcilation",
-				ObservedRevision: currentRevision,
+			// Construct a partial commit with the existing information.
+			// Split the revision and take the last part as the hash.
+			// Example revision: 6.1.4/bf09377bfd5d3bcac1e895fa8ce52dc76695c060
+			ss := strings.Split(currentRevision, "/")
+			c := &git.Commit{
+				Hash:      git.Hash(ss[len(ss)-1]),
+				Reference: ref.String(),
 			}
+			return c, nil
 		}
 	}
 	repo, err := extgogit.PlainCloneContext(ctx, path, false, &extgogit.CloneOptions{

--- a/pkg/git/gogit/checkout_test.go
+++ b/pkg/git/gogit/checkout_test.go
@@ -67,32 +67,36 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		branch         string
-		filesCreated   map[string]string
-		expectedCommit string
-		expectedErr    string
-		lastRevision   string
+		name                   string
+		branch                 string
+		filesCreated           map[string]string
+		lastRevision           string
+		expectedCommit         string
+		expectedConcreteCommit bool
+		expectedErr            string
 	}{
 		{
-			name:           "Default branch",
-			branch:         "master",
-			filesCreated:   map[string]string{"branch": "init"},
-			expectedCommit: firstCommit.String(),
+			name:                   "Default branch",
+			branch:                 "master",
+			filesCreated:           map[string]string{"branch": "init"},
+			expectedCommit:         firstCommit.String(),
+			expectedConcreteCommit: true,
 		},
 		{
-			name:         "skip clone if LastRevision hasn't changed",
-			branch:       "master",
-			filesCreated: map[string]string{"branch": "init"},
-			expectedErr:  fmt.Sprintf("no changes since last reconcilation: observed revision 'master/%s'", firstCommit.String()),
-			lastRevision: fmt.Sprintf("master/%s", firstCommit.String()),
+			name:                   "skip clone if LastRevision hasn't changed",
+			branch:                 "master",
+			filesCreated:           map[string]string{"branch": "init"},
+			lastRevision:           fmt.Sprintf("master/%s", firstCommit.String()),
+			expectedCommit:         firstCommit.String(),
+			expectedConcreteCommit: false,
 		},
 		{
-			name:           "Other branch - revision has changed",
-			branch:         "test",
-			filesCreated:   map[string]string{"branch": "second"},
-			expectedCommit: secondCommit.String(),
-			lastRevision:   fmt.Sprintf("master/%s", firstCommit.String()),
+			name:                   "Other branch - revision has changed",
+			branch:                 "test",
+			filesCreated:           map[string]string{"branch": "second"},
+			lastRevision:           fmt.Sprintf("master/%s", firstCommit.String()),
+			expectedCommit:         secondCommit.String(),
+			expectedConcreteCommit: true,
 		},
 		{
 			name:        "Non existing branch",
@@ -120,58 +124,65 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(cc.String()).To(Equal(tt.branch + "/" + tt.expectedCommit))
+			g.Expect(git.IsConcreteCommit(*cc)).To(Equal(tt.expectedConcreteCommit))
 
-			for k, v := range tt.filesCreated {
-				g.Expect(filepath.Join(tmpDir, k)).To(BeARegularFile())
-				g.Expect(os.ReadFile(filepath.Join(tmpDir, k))).To(BeEquivalentTo(v))
+			// Check checked out content for actual checkouts only.
+			if tt.expectedConcreteCommit {
+				for k, v := range tt.filesCreated {
+					g.Expect(filepath.Join(tmpDir, k)).To(BeARegularFile())
+					g.Expect(os.ReadFile(filepath.Join(tmpDir, k))).To(BeEquivalentTo(v))
+				}
 			}
 		})
 	}
 }
 
 func TestCheckoutTag_Checkout(t *testing.T) {
+	type testTag struct {
+		name      string
+		annotated bool
+	}
+
 	tests := []struct {
-		name        string
-		tag         string
-		annotated   bool
-		checkoutTag string
-		expectTag   string
-		expectErr   string
-		lastRev     string
-		setLastRev  bool
+		name                 string
+		tagsInRepo           []testTag
+		checkoutTag          string
+		lastRevTag           string
+		expectConcreteCommit bool
+		expectErr            string
 	}{
 		{
-			name:        "Tag",
-			tag:         "tag-1",
-			checkoutTag: "tag-1",
-			expectTag:   "tag-1",
+			name:                 "Tag",
+			tagsInRepo:           []testTag{{"tag-1", false}},
+			checkoutTag:          "tag-1",
+			expectConcreteCommit: true,
 		},
 		{
-			name:        "Skip Tag if last revision hasn't changed",
-			tag:         "tag-2",
-			checkoutTag: "tag-2",
-			setLastRev:  true,
-			expectErr:   "no changes since last reconcilation",
+			name:                 "Annotated",
+			tagsInRepo:           []testTag{{"annotated", true}},
+			checkoutTag:          "annotated",
+			expectConcreteCommit: true,
 		},
 		{
-			name:        "Last revision changed",
-			tag:         "tag-3",
-			checkoutTag: "tag-3",
-			expectTag:   "tag-3",
-			lastRev:     "tag-3/<fake-hash>",
-		},
-		{
-			name:        "Annotated",
-			tag:         "annotated",
-			annotated:   true,
-			checkoutTag: "annotated",
-			expectTag:   "annotated",
-		},
-		{
-			name:        "Non existing tag",
-			tag:         "tag-1",
+			name: "Non existing tag",
+			// Without this go-git returns error "remote repository is empty".
+			tagsInRepo:  []testTag{{"tag-1", false}},
 			checkoutTag: "invalid",
 			expectErr:   "couldn't find remote ref \"refs/tags/invalid\"",
+		},
+		{
+			name:                 "Skip clone - last revision unchanged",
+			tagsInRepo:           []testTag{{"tag-1", false}},
+			checkoutTag:          "tag-1",
+			lastRevTag:           "tag-1",
+			expectConcreteCommit: false,
+		},
+		{
+			name:                 "Last revision changed",
+			tagsInRepo:           []testTag{{"tag-1", false}, {"tag-2", false}},
+			checkoutTag:          "tag-2",
+			lastRevTag:           "tag-1",
+			expectConcreteCommit: true,
 		},
 	}
 	for _, tt := range tests {
@@ -183,32 +194,37 @@ func TestCheckoutTag_Checkout(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var h plumbing.Hash
-			var tagHash *plumbing.Reference
-			if tt.tag != "" {
-				h, err = commitFile(repo, "tag", tt.tag, time.Now())
-				if err != nil {
-					t.Fatal(err)
-				}
-				tagHash, err = tag(repo, h, !tt.annotated, tt.tag, time.Now())
-				if err != nil {
-					t.Fatal(err)
+			// Collect tags and their associated commit hash for later
+			// reference.
+			tagCommits := map[string]string{}
+
+			// Populate the repo with commits and tags.
+			if tt.tagsInRepo != nil {
+				for _, tr := range tt.tagsInRepo {
+					h, err := commitFile(repo, "tag", tr.name, time.Now())
+					if err != nil {
+						t.Fatal(err)
+					}
+					_, err = tag(repo, h, tr.annotated, tr.name, time.Now())
+					if err != nil {
+						t.Fatal(err)
+					}
+					tagCommits[tr.name] = h.String()
 				}
 			}
 
-			tag := CheckoutTag{
+			checkoutTag := CheckoutTag{
 				Tag: tt.checkoutTag,
 			}
-			if tt.setLastRev {
-				tag.LastRevision = fmt.Sprintf("%s/%s", tt.tag, tagHash.Hash().String())
+			// If last revision is provided, configure it.
+			if tt.lastRevTag != "" {
+				lc := tagCommits[tt.lastRevTag]
+				checkoutTag.LastRevision = fmt.Sprintf("%s/%s", tt.lastRevTag, lc)
 			}
 
-			if tt.lastRev != "" {
-				tag.LastRevision = tt.lastRev
-			}
 			tmpDir := t.TempDir()
 
-			cc, err := tag.Checkout(context.TODO(), tmpDir, path, nil)
+			cc, err := checkoutTag.Checkout(context.TODO(), tmpDir, path, nil)
 			if tt.expectErr != "" {
 				g.Expect(err).ToNot(BeNil())
 				g.Expect(err.Error()).To(ContainSubstring(tt.expectErr))
@@ -216,10 +232,17 @@ func TestCheckoutTag_Checkout(t *testing.T) {
 				return
 			}
 
+			// Check successful checkout results.
+			g.Expect(git.IsConcreteCommit(*cc)).To(Equal(tt.expectConcreteCommit))
+			targetTagHash := tagCommits[tt.checkoutTag]
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(cc.String()).To(Equal(tt.expectTag + "/" + h.String()))
-			g.Expect(filepath.Join(tmpDir, "tag")).To(BeARegularFile())
-			g.Expect(os.ReadFile(filepath.Join(tmpDir, "tag"))).To(BeEquivalentTo(tt.tag))
+			g.Expect(cc.String()).To(Equal(tt.checkoutTag + "/" + targetTagHash))
+
+			// Check file content only when there's an actual checkout.
+			if tt.lastRevTag != tt.checkoutTag {
+				g.Expect(filepath.Join(tmpDir, "tag")).To(BeARegularFile())
+				g.Expect(os.ReadFile(filepath.Join(tmpDir, "tag"))).To(BeEquivalentTo(tt.checkoutTag))
+			}
 		})
 	}
 }

--- a/pkg/git/libgit2/checkout_test.go
+++ b/pkg/git/libgit2/checkout_test.go
@@ -83,44 +83,49 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		branch         string
-		filesCreated   map[string]string
-		expectedCommit string
-		expectedErr    string
-		lastRevision   string
+		name                   string
+		branch                 string
+		filesCreated           map[string]string
+		lastRevision           string
+		expectedCommit         string
+		expectedConcreteCommit bool
+		expectedErr            string
 	}{
 		{
-			name:           "Default branch",
-			branch:         defaultBranch,
-			filesCreated:   map[string]string{"branch": "second"},
-			expectedCommit: secondCommit.String(),
+			name:                   "Default branch",
+			branch:                 defaultBranch,
+			filesCreated:           map[string]string{"branch": "second"},
+			expectedCommit:         secondCommit.String(),
+			expectedConcreteCommit: true,
 		},
 		{
-			name:           "Other branch",
-			branch:         "test",
-			filesCreated:   map[string]string{"branch": "init"},
-			expectedCommit: firstCommit.String(),
+			name:                   "Other branch",
+			branch:                 "test",
+			filesCreated:           map[string]string{"branch": "init"},
+			expectedCommit:         firstCommit.String(),
+			expectedConcreteCommit: true,
 		},
 		{
-			name:        "Non existing branch",
-			branch:      "invalid",
-			expectedErr: "reference 'refs/remotes/origin/invalid' not found",
+			name:                   "Non existing branch",
+			branch:                 "invalid",
+			expectedErr:            "reference 'refs/remotes/origin/invalid' not found",
+			expectedConcreteCommit: true,
 		},
 		{
-			name:           "skip clone - lastRevision hasn't changed",
-			branch:         defaultBranch,
-			filesCreated:   map[string]string{"branch": "second"},
-			expectedCommit: secondCommit.String(),
-			lastRevision:   fmt.Sprintf("%s/%s", defaultBranch, secondCommit.String()),
-			expectedErr:    fmt.Sprintf("no changes since last reconciliation: observed revision '%s/%s'", defaultBranch, secondCommit.String()),
+			name:                   "skip clone - lastRevision hasn't changed",
+			branch:                 defaultBranch,
+			filesCreated:           map[string]string{"branch": "second"},
+			lastRevision:           fmt.Sprintf("%s/%s", defaultBranch, secondCommit.String()),
+			expectedCommit:         secondCommit.String(),
+			expectedConcreteCommit: false,
 		},
 		{
-			name:           "lastRevision is different",
-			branch:         defaultBranch,
-			filesCreated:   map[string]string{"branch": "second"},
-			expectedCommit: secondCommit.String(),
-			lastRevision:   fmt.Sprintf("%s/%s", defaultBranch, firstCommit.String()),
+			name:                   "lastRevision is different",
+			branch:                 defaultBranch,
+			filesCreated:           map[string]string{"branch": "second"},
+			expectedCommit:         secondCommit.String(),
+			lastRevision:           fmt.Sprintf("%s/%s", defaultBranch, firstCommit.String()),
+			expectedConcreteCommit: true,
 		},
 	}
 
@@ -143,37 +148,43 @@ func TestCheckoutBranch_Checkout(t *testing.T) {
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(cc.String()).To(Equal(tt.branch + "/" + tt.expectedCommit))
+			g.Expect(git.IsConcreteCommit(*cc)).To(Equal(tt.expectedConcreteCommit))
 
-			for k, v := range tt.filesCreated {
-				g.Expect(filepath.Join(tmpDir, k)).To(BeARegularFile())
-				g.Expect(os.ReadFile(filepath.Join(tmpDir, k))).To(BeEquivalentTo(v))
+			if tt.expectedConcreteCommit {
+				for k, v := range tt.filesCreated {
+					g.Expect(filepath.Join(tmpDir, k)).To(BeARegularFile())
+					g.Expect(os.ReadFile(filepath.Join(tmpDir, k))).To(BeEquivalentTo(v))
+				}
 			}
 		})
 	}
 }
 
 func TestCheckoutTag_Checkout(t *testing.T) {
+	type testTag struct {
+		name      string
+		annotated bool
+	}
+
 	tests := []struct {
-		name         string
-		tag          string
-		annotated    bool
-		checkoutTag  string
-		expectTag    string
-		expectErr    string
-		lastRevision bool
+		name                 string
+		tagsInRepo           []testTag
+		checkoutTag          string
+		lastRevTag           string
+		expectErr            string
+		expectConcreteCommit bool
 	}{
 		{
-			name:        "Tag",
-			tag:         "tag-1",
-			checkoutTag: "tag-1",
-			expectTag:   "tag-1",
+			name:                 "Tag",
+			tagsInRepo:           []testTag{{"tag-1", false}},
+			checkoutTag:          "tag-1",
+			expectConcreteCommit: true,
 		},
 		{
-			name:        "Annotated",
-			tag:         "annotated",
-			annotated:   true,
-			checkoutTag: "annotated",
-			expectTag:   "annotated",
+			name:                 "Annotated",
+			tagsInRepo:           []testTag{{"annotated", true}},
+			checkoutTag:          "annotated",
+			expectConcreteCommit: true,
 		},
 		{
 			name:        "Non existing tag",
@@ -181,19 +192,18 @@ func TestCheckoutTag_Checkout(t *testing.T) {
 			expectErr:   "unable to find 'invalid': no reference found for shorthand 'invalid'",
 		},
 		{
-			name:         "skip clone - last revision is unchanged",
-			tag:          "tag-1",
-			checkoutTag:  "tag-1",
-			expectTag:    "tag-1",
-			lastRevision: true,
-			expectErr:    "no changes since last reconciliation",
+			name:                 "Skip clone - last revision unchanged",
+			tagsInRepo:           []testTag{{"tag-1", false}},
+			checkoutTag:          "tag-1",
+			lastRevTag:           "tag-1",
+			expectConcreteCommit: false,
 		},
 		{
-			name:         "last revision changed",
-			tag:          "tag-1",
-			checkoutTag:  "tag-1",
-			expectTag:    "tag-2",
-			lastRevision: true,
+			name:                 "Last revision changed",
+			tagsInRepo:           []testTag{{"tag-1", false}, {"tag-2", false}},
+			checkoutTag:          "tag-2",
+			lastRevTag:           "tag-1",
+			expectConcreteCommit: true,
 		},
 	}
 	for _, tt := range tests {
@@ -206,68 +216,57 @@ func TestCheckoutTag_Checkout(t *testing.T) {
 			}
 			defer repo.Free()
 
-			var commit *git2go.Commit
-			if tt.tag != "" {
-				c, err := commitFile(repo, "tag", tt.tag, time.Now())
-				if err != nil {
-					t.Fatal(err)
-				}
-				if commit, err = repo.LookupCommit(c); err != nil {
-					t.Fatal(err)
-				}
-				_, err = tag(repo, commit.Id(), !tt.annotated, tt.tag, time.Now())
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
+			// Collect tags and their associated commit for later reference.
+			tagCommits := map[string]*git2go.Commit{}
 
-			checkoutTag := CheckoutTag{
-				Tag: tt.checkoutTag,
-			}
-			tmpDir := t.TempDir()
-
-			cc, err := checkoutTag.Checkout(context.TODO(), tmpDir, repo.Path(), nil)
-
-			if tt.expectErr != "" {
-				if tt.lastRevision {
-					tmpDir, _ = os.MkdirTemp("", "test")
-					defer os.RemoveAll(tmpDir)
-					checkoutTag.LastRevision = cc.String()
-					cc, err = checkoutTag.Checkout(context.TODO(), tmpDir, repo.Path(), nil)
-				}
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(ContainSubstring(tt.expectErr))
-				g.Expect(cc).To(BeNil())
-				return
-			}
-			if tt.lastRevision {
-				checkoutTag.LastRevision = fmt.Sprintf("%s/%s", tt.tag, commit.Id().String())
-				checkoutTag.Tag = tt.expectTag
-				if tt.tag != "" {
-					c, err := commitFile(repo, "tag", "changed tag", time.Now())
+			// Populate the repo with commits and tags.
+			if tt.tagsInRepo != nil {
+				for _, tr := range tt.tagsInRepo {
+					var commit *git2go.Commit
+					c, err := commitFile(repo, "tag", tr.name, time.Now())
 					if err != nil {
 						t.Fatal(err)
 					}
 					if commit, err = repo.LookupCommit(c); err != nil {
 						t.Fatal(err)
 					}
-					_, err = tag(repo, commit.Id(), !tt.annotated, tt.expectTag, time.Now())
+					_, err = tag(repo, commit.Id(), tr.annotated, tr.name, time.Now())
 					if err != nil {
 						t.Fatal(err)
 					}
-					tmpDir, _ = os.MkdirTemp("", "test")
-					defer os.RemoveAll(tmpDir)
-					cc, err = checkoutTag.Checkout(context.TODO(), tmpDir, repo.Path(), nil)
+					tagCommits[tr.name] = commit
 				}
 			}
 
+			checkoutTag := CheckoutTag{
+				Tag: tt.checkoutTag,
+			}
+			// If last revision is provided, configure it.
+			if tt.lastRevTag != "" {
+				lc := tagCommits[tt.lastRevTag]
+				checkoutTag.LastRevision = fmt.Sprintf("%s/%s", tt.lastRevTag, lc.Id().String())
+			}
+
+			tmpDir := t.TempDir()
+
+			cc, err := checkoutTag.Checkout(context.TODO(), tmpDir, repo.Path(), nil)
+			if tt.expectErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectErr))
+				g.Expect(cc).To(BeNil())
+				return
+			}
+
+			// Check successful checkout results.
+			g.Expect(git.IsConcreteCommit(*cc)).To(Equal(tt.expectConcreteCommit))
+			targetTagCommit := tagCommits[tt.checkoutTag]
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(cc.String()).To(Equal(tt.expectTag + "/" + commit.Id().String()))
-			g.Expect(filepath.Join(tmpDir, "tag")).To(BeARegularFile())
-			if tt.lastRevision {
-				g.Expect(os.ReadFile(filepath.Join(tmpDir, "tag"))).To(BeEquivalentTo("changed tag"))
-			} else {
-				g.Expect(os.ReadFile(filepath.Join(tmpDir, "tag"))).To(BeEquivalentTo(tt.tag))
+			g.Expect(cc.String()).To(Equal(tt.checkoutTag + "/" + targetTagCommit.Id().String()))
+
+			// Check file content only when there's an actual checkout.
+			if tt.lastRevTag != tt.checkoutTag {
+				g.Expect(filepath.Join(tmpDir, "tag")).To(BeARegularFile())
+				g.Expect(os.ReadFile(filepath.Join(tmpDir, "tag"))).To(BeEquivalentTo(tt.checkoutTag))
 			}
 		})
 	}

--- a/pkg/git/options.go
+++ b/pkg/git/options.go
@@ -49,8 +49,7 @@ type CheckoutOptions struct {
 	// not supported by all Implementations.
 	RecurseSubmodules bool
 
-	// LastRevision holds the revision observed on the last successful
-	// reconciliation.
+	// LastRevision holds the last observed revision of the local repository.
 	// It is used to skip clone operations when no changes were detected.
 	LastRevision string
 }


### PR DESCRIPTION
The no-op git clone implementation introduced some bugs in the GitRepo reconciler due to the way it's currently integrated in the reconciliation loop. Skipping the reconciliation in the middle leaves other critical subreconcilers to not operate on the object. This causes inconsistent behavior and sometimes persistent reconciliation failure.

This change updates the GitRepo reconciler to attempt no-op git clone optimization only when an artifact is already present in the storage. The git packages are also updated to not return error anymore but a **partial commit** which contains commit hash and reference. On full clone, **concrete commit** is returned which contains all the commit metadata and content fetched from remote repository. With these, the GitRepo reconciler receives a partial commit when no-op clone takes place. In `reconcileSource()` subreconciler, it then populates the source build directory with the existing artifact content and lets the rest of the reconciliation continue. The other subreconcilers then continue building the source with any changes in the GitRepo attributes, like include, ignore, etc, when attributes related to them change but the remote repository has not changed.

Previous logs and events related to no-op clone are no longer present by default because we are doing full reconciliation every time now. When log level is set to debug, the no-op clone is logged:

```json
{"level":"debug","ts":"2022-05-15T00:43:26.373+0530","logger":"controller.gitrepository","msg":"no changes since last reconciliation, observed revision '6.1.4/bf09377bfd5d3bcac1e895fa8ce52dc76695c060'","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"podinfo","namespace":"default"}
{"level":"info","ts":"2022-05-15T00:43:26.377+0530","logger":"controller.gitrepository","msg":"artifact up-to-date with remote revision: '6.1.4/bf09377bfd5d3bcac1e895fa8ce52dc76695c060'","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"podinfo","namespace":"default"}
```
Failure recovery notification message for no-op clone results in:

> stored artifact for commit 'main/e09078f6979fb97d255e4b2178611de7d6f7553d'

as the partial commit doesn't contain the commit message information.

Since it's not ideal to use global flags to set feature gates in the tests, the GitRepositoryReconciler now has a `features` field containing all the enabled features. This makes it easier to configure the feature per test without affecting other tests. All the tests now have the default feature gates enabled.

These improvements are based on a series of attempts to find and fix the issues mentioned above, see https://github.com/fluxcd/source-controller/compare/gitrepo-rec-fixes?expand=1 . Some of the ideas from there may be added in the future separately.