### PR TITLE
GitRepositoryReconciler no-op clone improvements

### DIFF
--- a/api/v1beta2/gitrepository_types.go
+++ b/api/v1beta2/gitrepository_types.go
@@ -211,6 +211,18 @@ type GitRepositoryStatus struct {
 	// +optional
 	IncludedArtifacts []*Artifact `json:"includedArtifacts,omitempty"`
 
+	// ContentConfigChecksum is a checksum of all the configurations related to
+	// the content of the source artifact:
+	//  - .spec.ignore
+	//  - .spec.recurseSubmodules
+	//  - .spec.included and the checksum of the included artifacts
+	// observed in .status.observedGeneration version of the object. This can
+	// be used to determine if the content of the included repository has
+	// changed.
+	// It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
+	// +optional
+	ContentConfigChecksum string `json:"contentConfigChecksum,omitempty"`
+
 	meta.ReconcileRequestStatus `json:",inline"`
 }
 

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -653,6 +653,15 @@ spec:
                   - type
                   type: object
                 type: array
+              contentConfigChecksum:
+                description: 'ContentConfigChecksum is a checksum of all the configurations
+                  related to the content of the source artifact:  - .spec.ignore  -
+                  .spec.recurseSubmodules  - .spec.included and the checksum of the
+                  included artifacts observed in .status.observedGeneration version
+                  of the object. This can be used to determine if the content of the
+                  included repository has changed. It has the format of `<algo>:<checksum>`,
+                  for example: `sha256:<checksum>`.'
+                type: string
               includedArtifacts:
                 description: IncludedArtifacts contains a list of the last successfully
                   included Artifacts as instructed by GitRepositorySpec.Include.

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -115,6 +115,7 @@ type GitRepositoryReconciler struct {
 	ControllerName string
 
 	requeueDependency time.Duration
+	features          map[string]bool
 }
 
 type GitRepositoryReconcilerOptions struct {
@@ -133,6 +134,15 @@ func (r *GitRepositoryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *GitRepositoryReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, opts GitRepositoryReconcilerOptions) error {
 	r.requeueDependency = opts.DependencyRequeueInterval
+
+	if r.features == nil {
+		r.features = map[string]bool{}
+	}
+
+	// Check and enable gated features.
+	if oc, _ := features.Enabled(features.OptimizedGitClones); oc {
+		r.features[features.OptimizedGitClones] = true
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sourcev1.GitRepository{}, builder.WithPredicates(
@@ -414,7 +424,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context,
 		checkoutOpts.SemVer = ref.SemVer
 	}
 
-	if oc, _ := features.Enabled(features.OptimizedGitClones); oc {
+	if val, ok := r.features[features.OptimizedGitClones]; ok && val {
 		// Only if the object is ready, use the last revision to attempt
 		// short-circuiting clone operation.
 		if conditions.IsTrue(obj, meta.ReadyCondition) {

--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -57,6 +57,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
+	serror "github.com/fluxcd/source-controller/internal/error"
 	"github.com/fluxcd/source-controller/internal/features"
 	sreconcile "github.com/fluxcd/source-controller/internal/reconcile"
 	"github.com/fluxcd/source-controller/internal/reconcile/summarize"
@@ -141,6 +142,7 @@ Oomb3gD/TRf/nAdVED+k81GdLzciYdUGtI71/qI47G0nMBluLRE=
 =/4e+
 -----END PGP PUBLIC KEY BLOCK-----
 `
+	emptyContentConfigChecksum = "sha256:fcbcf165908dd18a9e49f7ff27810176db8e9f63b4352213741664245224f8aa"
 )
 
 var (
@@ -551,27 +553,31 @@ func TestGitRepositoryReconciler_reconcileSource_checkoutStrategy(t *testing.T) 
 		want                  sreconcile.Result
 		wantErr               bool
 		wantRevision          string
+		wantArtifactOutdated  bool
 	}{
 		{
-			name:         "Nil reference (default branch)",
-			want:         sreconcile.ResultSuccess,
-			wantRevision: "master/<commit>",
+			name:                 "Nil reference (default branch)",
+			want:                 sreconcile.ResultSuccess,
+			wantRevision:         "master/<commit>",
+			wantArtifactOutdated: true,
 		},
 		{
 			name: "Branch",
 			reference: &sourcev1.GitRepositoryRef{
 				Branch: "staging",
 			},
-			want:         sreconcile.ResultSuccess,
-			wantRevision: "staging/<commit>",
+			want:                 sreconcile.ResultSuccess,
+			wantRevision:         "staging/<commit>",
+			wantArtifactOutdated: true,
 		},
 		{
 			name: "Tag",
 			reference: &sourcev1.GitRepositoryRef{
 				Tag: "v0.1.0",
 			},
-			want:         sreconcile.ResultSuccess,
-			wantRevision: "v0.1.0/<commit>",
+			want:                 sreconcile.ResultSuccess,
+			wantRevision:         "v0.1.0/<commit>",
+			wantArtifactOutdated: true,
 		},
 		{
 			name:                  "Branch commit",
@@ -580,8 +586,9 @@ func TestGitRepositoryReconciler_reconcileSource_checkoutStrategy(t *testing.T) 
 				Branch: "staging",
 				Commit: "<commit>",
 			},
-			want:         sreconcile.ResultSuccess,
-			wantRevision: "staging/<commit>",
+			want:                 sreconcile.ResultSuccess,
+			wantRevision:         "staging/<commit>",
+			wantArtifactOutdated: true,
 		},
 		{
 			name:                  "Branch commit",
@@ -590,60 +597,81 @@ func TestGitRepositoryReconciler_reconcileSource_checkoutStrategy(t *testing.T) 
 				Branch: "staging",
 				Commit: "<commit>",
 			},
-			want:         sreconcile.ResultSuccess,
-			wantRevision: "HEAD/<commit>",
+			want:                 sreconcile.ResultSuccess,
+			wantRevision:         "HEAD/<commit>",
+			wantArtifactOutdated: true,
 		},
 		{
 			name: "SemVer",
 			reference: &sourcev1.GitRepositoryRef{
 				SemVer: "*",
 			},
-			want:         sreconcile.ResultSuccess,
-			wantRevision: "v2.0.0/<commit>",
+			want:                 sreconcile.ResultSuccess,
+			wantRevision:         "v2.0.0/<commit>",
+			wantArtifactOutdated: true,
 		},
 		{
 			name: "SemVer range",
 			reference: &sourcev1.GitRepositoryRef{
 				SemVer: "<v0.2.1",
 			},
-			want:         sreconcile.ResultSuccess,
-			wantRevision: "0.2.0/<commit>",
+			want:                 sreconcile.ResultSuccess,
+			wantRevision:         "0.2.0/<commit>",
+			wantArtifactOutdated: true,
 		},
 		{
 			name: "SemVer prerelease",
 			reference: &sourcev1.GitRepositoryRef{
 				SemVer: ">=1.0.0-0 <1.1.0-0",
 			},
-			wantRevision: "v1.0.0-alpha/<commit>",
-			want:         sreconcile.ResultSuccess,
+			wantRevision:         "v1.0.0-alpha/<commit>",
+			want:                 sreconcile.ResultSuccess,
+			wantArtifactOutdated: true,
 		},
 		{
-			name: "Optimized clone, Ready=True",
+			name: "Optimized clone",
 			reference: &sourcev1.GitRepositoryRef{
 				Branch: "staging",
 			},
 			beforeFunc: func(obj *sourcev1.GitRepository, latestRev string) {
+				// Add existing artifact on the object and storage.
 				obj.Status = sourcev1.GitRepositoryStatus{
 					Artifact: &sourcev1.Artifact{
 						Revision: "staging/" + latestRev,
+						Path:     randStringRunes(10),
 					},
+					// Checksum with all the relevant fields unset.
+					ContentConfigChecksum: emptyContentConfigChecksum,
 				}
-				conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "ready")
+				conditions.MarkTrue(obj, sourcev1.ArtifactInStorageCondition, meta.SucceededReason, "foo")
 			},
-			want:         sreconcile.ResultEmpty,
-			wantErr:      true,
-			wantRevision: "staging/<commit>",
+			want:                 sreconcile.ResultEmpty,
+			wantErr:              true,
+			wantRevision:         "staging/<commit>",
+			wantArtifactOutdated: false,
 		},
 		{
-			name: "Optimized clone, Ready=False",
+			name: "Optimized clone different ignore",
 			reference: &sourcev1.GitRepositoryRef{
 				Branch: "staging",
 			},
 			beforeFunc: func(obj *sourcev1.GitRepository, latestRev string) {
-				conditions.MarkFalse(obj, meta.ReadyCondition, meta.FailedReason, "not ready")
+				// Set new ignore value.
+				obj.Spec.Ignore = pointer.StringPtr("foo")
+				// Add existing artifact on the object and storage.
+				obj.Status = sourcev1.GitRepositoryStatus{
+					Artifact: &sourcev1.Artifact{
+						Revision: "staging/" + latestRev,
+						Path:     randStringRunes(10),
+					},
+					// Checksum with all the relevant fields unset.
+					ContentConfigChecksum: emptyContentConfigChecksum,
+				}
+				conditions.MarkTrue(obj, sourcev1.ArtifactInStorageCondition, meta.SucceededReason, "foo")
 			},
-			want:         sreconcile.ResultSuccess,
-			wantRevision: "staging/<commit>",
+			want:                 sreconcile.ResultSuccess,
+			wantRevision:         "staging/<commit>",
+			wantArtifactOutdated: false,
 		},
 	}
 
@@ -721,7 +749,7 @@ func TestGitRepositoryReconciler_reconcileSource_checkoutStrategy(t *testing.T) 
 					if tt.wantRevision != "" && !tt.wantErr {
 						revision := strings.ReplaceAll(tt.wantRevision, "<commit>", headRef.Hash().String())
 						g.Expect(commit.String()).To(Equal(revision))
-						g.Expect(conditions.IsTrue(obj, sourcev1.ArtifactOutdatedCondition)).To(BeTrue())
+						g.Expect(conditions.IsTrue(obj, sourcev1.ArtifactOutdatedCondition)).To(Equal(tt.wantArtifactOutdated))
 					}
 				})
 			}
@@ -780,7 +808,8 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			beforeFunc: func(obj *sourcev1.GitRepository) {
 				obj.Spec.Interval = metav1.Duration{Duration: interval}
 				obj.Status.Artifact = &sourcev1.Artifact{Revision: "main/revision"}
-				obj.Status.IncludedArtifacts = []*sourcev1.Artifact{{Revision: "main/revision"}}
+				obj.Status.IncludedArtifacts = []*sourcev1.Artifact{{Revision: "main/revision", Checksum: "some-checksum"}}
+				obj.Status.ContentConfigChecksum = "sha256:f825d11a1c5987e033d2cb36449a3b0435a6abc9b2bfdbcdcc7c49bf40e9285d"
 			},
 			afterFunc: func(t *WithT, obj *sourcev1.GitRepository) {
 				t.Expect(obj.Status.URL).To(BeEmpty())
@@ -985,39 +1014,6 @@ func TestGitRepositoryReconciler_reconcileInclude(t *testing.T) {
 				{name: "b", toPath: "b/", shouldExist: true},
 			},
 			want: sreconcile.ResultSuccess,
-			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.ArtifactOutdatedCondition, "IncludeChange", "included artifacts differ from last observed includes"),
-				*conditions.TrueCondition(meta.ReconcilingCondition, "IncludeChange", "included artifacts differ from last observed includes"),
-			},
-		},
-		{
-			name: "Include get failure makes IncludeUnavailable=True and returns error",
-			includes: []include{
-				{name: "a", toPath: "a/"},
-			},
-			wantErr: true,
-			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.IncludeUnavailableCondition, "NotFound", "could not get resource for include 'a': gitrepositories.source.toolkit.fluxcd.io \"a\" not found"),
-			},
-		},
-		{
-			name: "Include without an artifact makes IncludeUnavailable=True",
-			dependencies: []dependency{
-				{
-					name:         "a",
-					withArtifact: false,
-					conditions: []metav1.Condition{
-						*conditions.TrueCondition(sourcev1.IncludeUnavailableCondition, "Foo", "foo unavailable"),
-					},
-				},
-			},
-			includes: []include{
-				{name: "a", toPath: "a/"},
-			},
-			wantErr: true,
-			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.IncludeUnavailableCondition, "NoArtifact", "no artifact available for include 'a'"),
-			},
 		},
 		{
 			name: "Invalid FromPath makes IncludeUnavailable=True and returns error",
@@ -1032,16 +1028,8 @@ func TestGitRepositoryReconciler_reconcileInclude(t *testing.T) {
 			},
 			wantErr: true,
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.IncludeUnavailableCondition, "CopyFailure", "unpack/path: no such file or directory"),
+				*conditions.TrueCondition(sourcev1.StorageOperationFailedCondition, "CopyFailure", "unpack/path: no such file or directory"),
 			},
-		},
-		{
-			name: "Outdated IncludeUnavailable is removed",
-			beforeFunc: func(obj *sourcev1.GitRepository) {
-				conditions.MarkTrue(obj, sourcev1.IncludeUnavailableCondition, "NoArtifact", "")
-			},
-			want:             sreconcile.ResultSuccess,
-			assertConditions: []metav1.Condition{},
 		},
 	}
 	for _, tt := range tests {
@@ -1110,6 +1098,11 @@ func TestGitRepositoryReconciler_reconcileInclude(t *testing.T) {
 
 			var commit git.Commit
 			var includes artifactSet
+
+			// Build includes artifactSet.
+			artifactSet, err := r.fetchIncludes(ctx, obj)
+			g.Expect(err).ToNot(HaveOccurred())
+			includes = *artifactSet
 
 			got, err := r.reconcileInclude(ctx, obj, &commit, &includes, tmpDir)
 			g.Expect(obj.GetConditions()).To(conditions.MatchConditions(tt.assertConditions))
@@ -1815,12 +1808,25 @@ func TestGitRepositoryReconciler_statusConditions(t *testing.T) {
 }
 
 func TestGitRepositoryReconciler_notify(t *testing.T) {
+	concreteCommit := git.Commit{
+		Hash:    git.Hash("some-hash"),
+		Message: "test commit",
+		Encoded: []byte("content"),
+	}
+	partialCommit := git.Commit{
+		Hash: git.Hash("some-hash"),
+	}
+
+	noopErr := serror.NewGeneric(fmt.Errorf("some no-op error"), "NoOpReason")
+	noopErr.Ignore = true
+
 	tests := []struct {
 		name             string
 		res              sreconcile.Result
 		resErr           error
 		oldObjBeforeFunc func(obj *sourcev1.GitRepository)
 		newObjBeforeFunc func(obj *sourcev1.GitRepository)
+		commit           git.Commit
 		wantEvent        string
 	}{
 		{
@@ -1835,7 +1841,8 @@ func TestGitRepositoryReconciler_notify(t *testing.T) {
 			newObjBeforeFunc: func(obj *sourcev1.GitRepository) {
 				obj.Status.Artifact = &sourcev1.Artifact{Revision: "xxx", Checksum: "yyy"}
 			},
-			wantEvent: "Normal NewArtifact stored artifact for commit",
+			commit:    concreteCommit,
+			wantEvent: "Normal NewArtifact stored artifact for commit 'test commit'",
 		},
 		{
 			name:   "recovery from failure",
@@ -1850,7 +1857,8 @@ func TestGitRepositoryReconciler_notify(t *testing.T) {
 				obj.Status.Artifact = &sourcev1.Artifact{Revision: "xxx", Checksum: "yyy"}
 				conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "ready")
 			},
-			wantEvent: "Normal Succeeded stored artifact for commit",
+			commit:    concreteCommit,
+			wantEvent: "Normal Succeeded stored artifact for commit 'test commit'",
 		},
 		{
 			name:   "recovery and new artifact",
@@ -1865,7 +1873,8 @@ func TestGitRepositoryReconciler_notify(t *testing.T) {
 				obj.Status.Artifact = &sourcev1.Artifact{Revision: "aaa", Checksum: "bbb"}
 				conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "ready")
 			},
-			wantEvent: "Normal NewArtifact stored artifact for commit",
+			commit:    concreteCommit,
+			wantEvent: "Normal NewArtifact stored artifact for commit 'test commit'",
 		},
 		{
 			name:   "no updates",
@@ -1879,6 +1888,22 @@ func TestGitRepositoryReconciler_notify(t *testing.T) {
 				obj.Status.Artifact = &sourcev1.Artifact{Revision: "xxx", Checksum: "yyy"}
 				conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "ready")
 			},
+		},
+		{
+			name:   "no-op error result",
+			res:    sreconcile.ResultEmpty,
+			resErr: noopErr,
+			oldObjBeforeFunc: func(obj *sourcev1.GitRepository) {
+				obj.Status.Artifact = &sourcev1.Artifact{Revision: "xxx", Checksum: "yyy"}
+				conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, sourcev1.GitOperationFailedReason, "fail")
+				conditions.MarkFalse(obj, meta.ReadyCondition, meta.FailedReason, "foo")
+			},
+			newObjBeforeFunc: func(obj *sourcev1.GitRepository) {
+				obj.Status.Artifact = &sourcev1.Artifact{Revision: "xxx", Checksum: "yyy"}
+				conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "ready")
+			},
+			commit:    partialCommit, // no-op will always result in partial commit.
+			wantEvent: "Normal Succeeded stored artifact for commit 'HEAD/some-hash'",
 		},
 	}
 
@@ -1901,10 +1926,7 @@ func TestGitRepositoryReconciler_notify(t *testing.T) {
 				EventRecorder: recorder,
 				features:      features.FeatureGates(),
 			}
-			commit := &git.Commit{
-				Message: "test commit",
-			}
-			reconciler.notify(oldObj, newObj, *commit, tt.res, tt.resErr)
+			reconciler.notify(oldObj, newObj, tt.commit, tt.res, tt.resErr)
 
 			select {
 			case x, ok := <-recorder.Events:
@@ -1919,4 +1941,204 @@ func TestGitRepositoryReconciler_notify(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGitRepositoryReconciler_fetchIncludes(t *testing.T) {
+	type dependency struct {
+		name         string
+		withArtifact bool
+		conditions   []metav1.Condition
+	}
+
+	type include struct {
+		name        string
+		fromPath    string
+		toPath      string
+		shouldExist bool
+	}
+
+	tests := []struct {
+		name             string
+		dependencies     []dependency
+		includes         []include
+		beforeFunc       func(obj *sourcev1.GitRepository)
+		wantErr          bool
+		wantArtifactSet  artifactSet
+		assertConditions []metav1.Condition
+	}{
+		{
+			name: "Existing includes",
+			dependencies: []dependency{
+				{
+					name:         "a",
+					withArtifact: true,
+					conditions: []metav1.Condition{
+						*conditions.TrueCondition(meta.ReadyCondition, "Foo", "foo ready"),
+					},
+				},
+				{
+					name:         "b",
+					withArtifact: true,
+					conditions: []metav1.Condition{
+						*conditions.TrueCondition(meta.ReadyCondition, "Bar", "bar ready"),
+					},
+				},
+			},
+			includes: []include{
+				{name: "a", toPath: "a/", shouldExist: true},
+				{name: "b", toPath: "b/", shouldExist: true},
+			},
+			wantErr: false,
+			wantArtifactSet: []*sourcev1.Artifact{
+				{Revision: "a"},
+				{Revision: "b"},
+			},
+		},
+		{
+			name: "Include get failure",
+			includes: []include{
+				{name: "a", toPath: "a/"},
+			},
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(sourcev1.IncludeUnavailableCondition, "NotFound", "could not get resource for include 'a': gitrepositories.source.toolkit.fluxcd.io \"a\" not found"),
+			},
+		},
+		{
+			name: "Include without an artifact makes IncludeUnavailable=True",
+			dependencies: []dependency{
+				{
+					name:         "a",
+					withArtifact: false,
+					conditions: []metav1.Condition{
+						*conditions.TrueCondition(sourcev1.IncludeUnavailableCondition, "Foo", "foo unavailable"),
+					},
+				},
+			},
+			includes: []include{
+				{name: "a", toPath: "a/"},
+			},
+			wantErr: true,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(sourcev1.IncludeUnavailableCondition, "NoArtifact", "no artifact available for include 'a'"),
+			},
+		},
+		{
+			name: "Outdated IncludeUnavailable is removed",
+			beforeFunc: func(obj *sourcev1.GitRepository) {
+				conditions.MarkTrue(obj, sourcev1.IncludeUnavailableCondition, "NoArtifact", "")
+			},
+			assertConditions: []metav1.Condition{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			var depObjs []client.Object
+			for _, d := range tt.dependencies {
+				obj := &sourcev1.GitRepository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: d.name,
+					},
+					Status: sourcev1.GitRepositoryStatus{
+						Conditions: d.conditions,
+					},
+				}
+				if d.withArtifact {
+					obj.Status.Artifact = &sourcev1.Artifact{
+						Path:           d.name + ".tar.gz",
+						Revision:       d.name,
+						LastUpdateTime: metav1.Now(),
+					}
+				}
+				depObjs = append(depObjs, obj)
+			}
+
+			builder := fakeclient.NewClientBuilder().WithScheme(testEnv.GetScheme())
+			if len(tt.dependencies) > 0 {
+				builder.WithObjects(depObjs...)
+			}
+
+			r := &GitRepositoryReconciler{
+				Client:        builder.Build(),
+				EventRecorder: record.NewFakeRecorder(32),
+			}
+
+			obj := &sourcev1.GitRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "reconcile-include",
+				},
+				Spec: sourcev1.GitRepositorySpec{
+					Interval: metav1.Duration{Duration: interval},
+				},
+			}
+
+			for i, incl := range tt.includes {
+				incl := sourcev1.GitRepositoryInclude{
+					GitRepositoryRef: meta.LocalObjectReference{Name: incl.name},
+					FromPath:         incl.fromPath,
+					ToPath:           incl.toPath,
+				}
+				tt.includes[i].fromPath = incl.GetFromPath()
+				tt.includes[i].toPath = incl.GetToPath()
+				obj.Spec.Include = append(obj.Spec.Include, incl)
+			}
+
+			gotArtifactSet, err := r.fetchIncludes(ctx, obj)
+			g.Expect(err != nil).To(Equal(tt.wantErr))
+			g.Expect(obj.GetConditions()).To(conditions.MatchConditions(tt.assertConditions))
+			if !tt.wantErr && gotArtifactSet != nil {
+				g.Expect(gotArtifactSet.Diff(tt.wantArtifactSet)).To(BeFalse())
+			}
+		})
+	}
+}
+
+func TestGitRepositoryReconciler_calculateContentConfigChecksum(t *testing.T) {
+	g := NewWithT(t)
+	obj := &sourcev1.GitRepository{}
+	r := &GitRepositoryReconciler{}
+
+	emptyChecksum := r.calculateContentConfigChecksum(obj, nil)
+	g.Expect(emptyChecksum).To(Equal(emptyContentConfigChecksum))
+
+	// Ignore modified.
+	obj.Spec.Ignore = pointer.String("some-rule")
+	ignoreModChecksum := r.calculateContentConfigChecksum(obj, nil)
+	g.Expect(emptyChecksum).ToNot(Equal(ignoreModChecksum))
+
+	// Recurse submodules modified.
+	obj.Spec.RecurseSubmodules = true
+	submodModChecksum := r.calculateContentConfigChecksum(obj, nil)
+	g.Expect(ignoreModChecksum).ToNot(Equal(submodModChecksum))
+
+	// Include modified.
+	obj.Spec.Include = []sourcev1.GitRepositoryInclude{
+		{
+			GitRepositoryRef: meta.LocalObjectReference{Name: "foo"},
+			FromPath:         "aaa",
+			ToPath:           "bbb",
+		},
+	}
+	artifacts := &artifactSet{
+		&sourcev1.Artifact{Revision: "some-revision-1", Checksum: "some-checksum-1"},
+	}
+	includeModChecksum := r.calculateContentConfigChecksum(obj, artifacts)
+	g.Expect(submodModChecksum).ToNot(Equal(includeModChecksum))
+
+	// Artifact modified revision.
+	artifacts = &artifactSet{
+		&sourcev1.Artifact{Revision: "some-revision-2", Checksum: "some-checksum-1"},
+	}
+	artifactModChecksum := r.calculateContentConfigChecksum(obj, artifacts)
+	g.Expect(includeModChecksum).ToNot(Equal(artifactModChecksum))
+
+	// Artifact modified checksum.
+	artifacts = &artifactSet{
+		&sourcev1.Artifact{Revision: "some-revision-2", Checksum: "some-checksum-2"},
+	}
+	artifactCsumModChecksum := r.calculateContentConfigChecksum(obj, artifacts)
+	g.Expect(artifactModChecksum).ToNot(Equal(artifactCsumModChecksum))
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -48,6 +48,7 @@ import (
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/fluxcd/source-controller/internal/cache"
+	"github.com/fluxcd/source-controller/internal/features"
 	"github.com/fluxcd/source-controller/internal/helm/util"
 	// +kubebuilder:scaffold:imports
 )
@@ -211,6 +212,7 @@ func TestMain(m *testing.M) {
 		EventRecorder: record.NewFakeRecorder(32),
 		Metrics:       testMetricsH,
 		Storage:       testStorage,
+		features:      features.FeatureGates(),
 	}).SetupWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Failed to start GitRepositoryReconciler: %v", err))
 	}

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -1656,6 +1656,26 @@ Artifacts as instructed by GitRepositorySpec.Include.</p>
 </tr>
 <tr>
 <td>
+<code>contentConfigChecksum</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContentConfigChecksum is a checksum of all the configurations related to
+the content of the source artifact:
+- .spec.ignore
+- .spec.recurseSubmodules
+- .spec.included and the checksum of the included artifacts
+observed in .status.observedGeneration version of the object. This can
+be used to determine if the content of the included repository has
+changed.
+It has the format of <code>&lt;algo&gt;:&lt;checksum&gt;</code>, for example: <code>sha256:&lt;checksum&gt;</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>ReconcileRequestStatus</code><br>
 <em>
 <a href="https://godoc.org/github.com/fluxcd/pkg/apis/meta#ReconcileRequestStatus">

--- a/docs/spec/v1beta2/gitrepositories.md
+++ b/docs/spec/v1beta2/gitrepositories.md
@@ -405,9 +405,12 @@ Optimized Git clones decreases resource utilization for GitRepository
 reconciliations. It supports both `go-git` and `libgit2` implementations
 when cloning repositories using branches or tags.
 
-When enabled, avoids full clone operations by first checking whether
-the last revision is still the same at the target repository,
-and if that is so, skips the reconciliation.
+When enabled, it avoids full Git clone operations by first checking whether
+the revision of the last stored artifact is still the head of the remote
+repository and none of the other factors that contribute to a change in the
+artifact, like ignore rules and included repositories, have changed. If that is
+so, the reconciliation is skipped. Else, a full reconciliation is performed as
+usual.
 
 This feature is enabled by default. It can be disabled by starting the
 controller with the argument `--feature-gates=OptimizedGitClones=false`.
@@ -837,6 +840,13 @@ exponential backoff, until it succeeds and the GitRepository is marked as
 Note that a GitRepository can be [reconciling](#reconciling-gitrepository)
 while failing at the same time, for example due to a newly introduced
 configuration issue in the GitRepository spec.
+
+### Content Configuration Checksum
+
+The source-controller calculates the SHA256 checksum of the various
+configurations of the GitRepository that indicate a change in source and
+records it in `.status.contentConfigChecksum`. This field is used to determine
+if the source artifact needs to be rebuilt.
 
 ### Observed Generation
 

--- a/internal/error/error.go
+++ b/internal/error/error.go
@@ -16,16 +16,53 @@ limitations under the License.
 
 package error
 
-import "time"
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EventTypeNone indicates no error event. It can be used to disable error
+// events.
+const EventTypeNone = "None"
+
+// Config is the error configuration. It is embedded in the errors and can be
+// used to configure how the error should be handled. These configurations
+// mostly define actions to be taken on the errors. Not all the configurations
+// may apply to every error.
+type Config struct {
+	// Event is the event type of an error. It is used to configure what type of
+	// event an error should result in.
+	// Valid values:
+	//   - EventTypeNone
+	//   - corev1.EventTypeNormal
+	//   - corev1.EventTypeWarning
+	Event string
+	// Log is used to configure if an error should be logged. The log level is
+	// derived from the Event type.
+	// None event - info log
+	// Normal event - info log
+	// Warning event - error log
+	Log bool
+	// Notification is used to emit an error as a notification alert to a
+	// a notification service.
+	Notification bool
+	// Ignore is used to suppress the error for no-op reconciliations. It may
+	// be applicable to non-contextual errors only.
+	Ignore bool
+}
 
 // Stalling is the reconciliation stalled state error. It contains an error
-// and a reason for the stalled condition.
+// and a reason for the stalled condition. It is a contextual error, used to
+// express the scenario which contributed to the reconciliation result.
 type Stalling struct {
 	// Reason is the stalled condition reason string.
 	Reason string
 	// Err is the error that caused stalling. This can be used as the message in
 	// stalled condition.
 	Err error
+	// Config is the error handler configuration.
+	Config
 }
 
 // Error implements error interface.
@@ -38,8 +75,26 @@ func (se *Stalling) Unwrap() error {
 	return se.Err
 }
 
+// NewStalling constructs a new Stalling error with default configuration.
+func NewStalling(err error, reason string) *Stalling {
+	// Stalling errors are not returned to the runtime. Log it explicitly.
+	// Since this failure requires user interaction, send warning notification.
+	return &Stalling{
+		Reason: reason,
+		Err:    err,
+		Config: Config{
+			Event:        corev1.EventTypeWarning,
+			Log:          true,
+			Notification: true,
+		},
+	}
+}
+
 // Event is an error event. It can be used to construct an event to be
 // recorded.
+// Deprecated: use Generic error with NewGeneric() for the same behavior and
+// replace the RecordContextualError with ErrorActionHandler for result
+// processing.
 type Event struct {
 	// Reason is the reason for the event error.
 	Reason string
@@ -58,7 +113,10 @@ func (ee *Event) Unwrap() error {
 }
 
 // Waiting is the reconciliation wait state error. It contains an error, wait
-// duration and a reason for the wait.
+// duration and a reason for the wait. It is a contextual error, used to express
+// the scenario which contributed to the reconciliation result.
+// It is for scenarios where a reconciliation needs to wait for something else
+// to take place first.
 type Waiting struct {
 	// RequeueAfter is the wait duration after which to requeue.
 	RequeueAfter time.Duration
@@ -66,9 +124,11 @@ type Waiting struct {
 	Reason string
 	// Err is the error that caused the wait.
 	Err error
+	// Config is the error handler configuration.
+	Config
 }
 
-// Error implement error interface.
+// Error implements error interface.
 func (we *Waiting) Error() string {
 	return we.Err.Error()
 }
@@ -76,4 +136,54 @@ func (we *Waiting) Error() string {
 // Unwrap returns the underlying error.
 func (we *Waiting) Unwrap() error {
 	return we.Err
+}
+
+// NewWaiting constructs a new Waiting error with default configuration.
+func NewWaiting(err error, reason string) *Waiting {
+	// Waiting errors are not returned to the runtime. Log it explicitly.
+	// Since this failure results in reconciliation delay, send warning
+	// notification.
+	return &Waiting{
+		Reason: reason,
+		Err:    err,
+		Config: Config{
+			Event: corev1.EventTypeNormal,
+			Log:   true,
+		},
+	}
+}
+
+// Generic error is a generic reconcile error. It can be used in scenarios that
+// don't have any special contextual meaning.
+type Generic struct {
+	// Reason is the reason for the generic error.
+	Reason string
+	// Error is the error that caused the generic error.
+	Err error
+	// Config is the error handler configuration.
+	Config
+}
+
+// Error implements error interface.
+func (g *Generic) Error() string {
+	return g.Err.Error()
+}
+
+// Unwrap returns the underlying error.
+func (g *Generic) Unwrap() error {
+	return g.Err
+}
+
+// NewGeneric constructs a new Generic error with default configuration.
+func NewGeneric(err error, reason string) *Generic {
+	// Since it's a error, ensure to log and send failure notification.
+	return &Generic{
+		Reason: reason,
+		Err:    err,
+		Config: Config{
+			Event:        corev1.EventTypeWarning,
+			Log:          true,
+			Notification: true,
+		},
+	}
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -118,3 +118,13 @@ type NoChangesError struct {
 func (e NoChangesError) Error() string {
 	return fmt.Sprintf("%s: observed revision '%s'", e.Message, e.ObservedRevision)
 }
+
+// IsConcreteCommit returns if a given commit is a concrete commit. Concrete
+// commits have most of commit metadata and commit content. In contrast, a
+// partial commit may only have some metadata and no commit content.
+func IsConcreteCommit(c Commit) bool {
+	if c.Hash != nil && c.Encoded != nil {
+		return true
+	}
+	return false
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -107,18 +107,6 @@ type CheckoutStrategy interface {
 	Checkout(ctx context.Context, path, url string, config *AuthOptions) (*Commit, error)
 }
 
-// NoChangesError represents the case in which a Git clone operation
-// is attempted, but cancelled as the revision is still the same as
-// the one observed on the last successful reconciliation.
-type NoChangesError struct {
-	Message          string
-	ObservedRevision string
-}
-
-func (e NoChangesError) Error() string {
-	return fmt.Sprintf("%s: observed revision '%s'", e.Message, e.ObservedRevision)
-}
-
 // IsConcreteCommit returns if a given commit is a concrete commit. Concrete
 // commits have most of commit metadata and commit content. In contrast, a
 // partial commit may only have some metadata and no commit content.

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -18,6 +18,7 @@ package git
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 )
@@ -260,6 +261,44 @@ of the commit`,
 
 			c := Commit{Message: tt.input}
 			g.Expect(c.ShortMessage()).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestIsConcreteCommit(t *testing.T) {
+	tests := []struct {
+		name   string
+		commit Commit
+		result bool
+	}{
+		{
+			name: "concrete commit",
+			commit: Commit{
+				Hash:      Hash("foo"),
+				Reference: "refs/tags/main",
+				Author: Signature{
+					Name: "user", Email: "user@example.com", When: time.Now(),
+				},
+				Committer: Signature{
+					Name: "user", Email: "user@example.com", When: time.Now(),
+				},
+				Signature: "signature",
+				Encoded:   []byte("commit-content"),
+				Message:   "commit-message",
+			},
+			result: true,
+		},
+		{
+			name:   "partial commit",
+			commit: Commit{Hash: Hash("foo")},
+			result: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(IsConcreteCommit(tt.commit)).To(Equal(tt.result))
 		})
 	}
 }

--- a/pkg/git/libgit2/checkout.go
+++ b/pkg/git/libgit2/checkout.go
@@ -34,6 +34,8 @@ import (
 	"github.com/fluxcd/source-controller/pkg/git/libgit2/managed"
 )
 
+const defaultRemoteName = "origin"
+
 // CheckoutStrategyForOptions returns the git.CheckoutStrategy for the given
 // git.CheckoutOptions.
 func CheckoutStrategyForOptions(ctx context.Context, opt git.CheckoutOptions) git.CheckoutStrategy {
@@ -67,26 +69,43 @@ type CheckoutBranch struct {
 func (c *CheckoutBranch) Checkout(ctx context.Context, path, url string, opts *git.AuthOptions) (_ *git.Commit, err error) {
 	defer recoverPanic(&err)
 
-	repo, remote, free, err := getBlankRepoAndRemote(ctx, path, url, opts)
+	remoteCallBacks := RemoteCallbacks(ctx, opts)
+	proxyOpts := &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto}
+
+	repo, remote, err := initializeRepoWithRemote(ctx, path, url, opts)
 	if err != nil {
 		return nil, err
 	}
-	defer free()
+	// Open remote connection.
+	err = remote.ConnectFetch(&remoteCallBacks, proxyOpts, nil)
+	if err != nil {
+		remote.Free()
+		repo.Free()
+		return nil, fmt.Errorf("unable to fetch-connect to remote '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
+	}
+	defer func() {
+		remote.Disconnect()
+		remote.Free()
+		repo.Free()
+	}()
 
-	// When the last observed revision is set, check whether it is still
-	// the same at the remote branch. If so, short-circuit the clone operation here.
+	// When the last observed revision is set, check whether it is still the
+	// same at the remote branch. If so, short-circuit the clone operation here.
 	if c.LastRevision != "" {
 		heads, err := remote.Ls(c.Branch)
 		if err != nil {
 			return nil, fmt.Errorf("unable to remote ls for '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
 		}
 		if len(heads) > 0 {
-			currentRevision := fmt.Sprintf("%s/%s", c.Branch, heads[0].Id.String())
+			hash := heads[0].Id.String()
+			currentRevision := fmt.Sprintf("%s/%s", c.Branch, hash)
 			if currentRevision == c.LastRevision {
-				return nil, git.NoChangesError{
-					Message:          "no changes since last reconciliation",
-					ObservedRevision: currentRevision,
+				// Construct a partial commit with the existing information.
+				c := &git.Commit{
+					Hash:      git.Hash(hash),
+					Reference: "refs/heads/" + c.Branch,
 				}
+				return c, nil
 			}
 		}
 	}
@@ -95,7 +114,7 @@ func (c *CheckoutBranch) Checkout(ctx context.Context, path, url string, opts *g
 	err = remote.Fetch([]string{c.Branch},
 		&git2go.FetchOptions{
 			DownloadTags:    git2go.DownloadTagsNone,
-			RemoteCallbacks: RemoteCallbacks(ctx, opts),
+			RemoteCallbacks: remoteCallBacks,
 			ProxyOptions:    git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
 		},
 		"")
@@ -151,33 +170,53 @@ type CheckoutTag struct {
 func (c *CheckoutTag) Checkout(ctx context.Context, path, url string, opts *git.AuthOptions) (_ *git.Commit, err error) {
 	defer recoverPanic(&err)
 
-	repo, remote, free, err := getBlankRepoAndRemote(ctx, path, url, opts)
+	remoteCallBacks := RemoteCallbacks(ctx, opts)
+	proxyOpts := &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto}
+
+	repo, remote, err := initializeRepoWithRemote(ctx, path, url, opts)
 	if err != nil {
 		return nil, err
 	}
-	defer free()
+	// Open remote connection.
+	err = remote.ConnectFetch(&remoteCallBacks, proxyOpts, nil)
+	if err != nil {
+		remote.Free()
+		repo.Free()
+		return nil, fmt.Errorf("unable to fetch-connect to remote '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
+	}
+	defer func() {
+		remote.Disconnect()
+		remote.Free()
+		repo.Free()
+	}()
 
+	// When the last observed revision is set, check whether it is still the
+	// same at the remote branch. If so, short-circuit the clone operation here.
 	if c.LastRevision != "" {
 		heads, err := remote.Ls(c.Tag)
 		if err != nil {
 			return nil, fmt.Errorf("unable to remote ls for '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
 		}
 		if len(heads) > 0 {
-			currentRevision := fmt.Sprintf("%s/%s", c.Tag, heads[0].Id.String())
+			hash := heads[0].Id.String()
+			currentRevision := fmt.Sprintf("%s/%s", c.Tag, hash)
 			var same bool
 			if currentRevision == c.LastRevision {
 				same = true
 			} else if len(heads) > 1 {
-				currentAnnotatedRevision := fmt.Sprintf("%s/%s", c.Tag, heads[1].Id.String())
+				hash = heads[1].Id.String()
+				currentAnnotatedRevision := fmt.Sprintf("%s/%s", c.Tag, hash)
 				if currentAnnotatedRevision == c.LastRevision {
 					same = true
 				}
 			}
 			if same {
-				return nil, git.NoChangesError{
-					Message:          "no changes since last reconciliation",
-					ObservedRevision: currentRevision,
+				// Construct a partial commit with the existing information.
+				c := &git.Commit{
+					Hash:      git.Hash(hash),
+					Reference: "refs/tags/" + c.Tag,
 				}
+				return c, nil
 			}
 		}
 	}
@@ -185,8 +224,8 @@ func (c *CheckoutTag) Checkout(ctx context.Context, path, url string, opts *git.
 	err = remote.Fetch([]string{c.Tag},
 		&git2go.FetchOptions{
 			DownloadTags:    git2go.DownloadTagsAuto,
-			RemoteCallbacks: RemoteCallbacks(ctx, opts),
-			ProxyOptions:    git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
+			RemoteCallbacks: remoteCallBacks,
+			ProxyOptions:    *proxyOpts,
 		},
 		"")
 
@@ -408,34 +447,34 @@ func buildSignature(s *git2go.Signature) git.Signature {
 	}
 }
 
-// getBlankRepoAndRemote returns a newly initialized repository, and a remote connected to the provided url.
-// Callers must call the returning function to free all git2go objects.
-func getBlankRepoAndRemote(ctx context.Context, path, url string, opts *git.AuthOptions) (*git2go.Repository, *git2go.Remote, func(), error) {
+// initializeRepoWithRemote initializes or opens a repository at the given path
+// and configures it with the given remote "origin" URL. If a remote already
+// exists with a different URL, it returns an error.
+func initializeRepoWithRemote(ctx context.Context, path, url string, opts *git.AuthOptions) (*git2go.Repository, *git2go.Remote, error) {
 	repo, err := git2go.InitRepository(path, false)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unable to init repository for '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
+		return nil, nil, fmt.Errorf("unable to init repository for '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
 	}
 
-	remote, err := repo.Remotes.Create("origin", url)
+	remote, err := repo.Remotes.Create(defaultRemoteName, url)
 	if err != nil {
-		repo.Free()
-		return nil, nil, nil, fmt.Errorf("unable to create remote for '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
+		// If the remote already exists, lookup the remote.
+		if git2go.IsErrorCode(err, git2go.ErrorCodeExists) {
+			remote, err = repo.Remotes.Lookup(defaultRemoteName)
+			if err != nil {
+				repo.Free()
+				return nil, nil, fmt.Errorf("unable to create or lookup remote '%s'", defaultRemoteName)
+			}
+			if remote.Url() != url {
+				repo.Free()
+				return nil, nil, fmt.Errorf("remote '%s' with different address '%s' already exists", defaultRemoteName, remote.Url())
+			}
+		} else {
+			repo.Free()
+			return nil, nil, fmt.Errorf("unable to create remote for '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
+		}
 	}
-
-	callBacks := RemoteCallbacks(ctx, opts)
-	err = remote.ConnectFetch(&callBacks, &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto}, nil)
-	if err != nil {
-		remote.Free()
-		repo.Free()
-		return nil, nil, nil, fmt.Errorf("unable to fetch-connect to remote '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
-	}
-
-	free := func() {
-		remote.Disconnect()
-		remote.Free()
-		repo.Free()
-	}
-	return repo, remote, free, nil
+	return repo, remote, nil
 }
 
 func recoverPanic(err *error) {

--- a/pkg/git/options.go
+++ b/pkg/git/options.go
@@ -49,8 +49,7 @@ type CheckoutOptions struct {
 	// not supported by all Implementations.
 	RecurseSubmodules bool
 
-	// LastRevision holds the revision observed on the last successful
-	// reconciliation.
+	// LastRevision holds the last observed revision of the local repository.
 	// It is used to skip clone operations when no changes were detected.
 	LastRevision string
 }


### PR DESCRIPTION
The no-op git clone implementation resulted in some bugs in the GitRepository reconciler due to the way it's currently integrated in the reconciliation loop. Skipping the reconciliation in the middle based on no update in the remote repository ignores the other factors that contribute to the source artifact like recursive submodules, ignore rules and included repositories, ignore rules, included repositories, etc. This causes inconsistent behavior and sometimes persistent reconciliation failures.

This change restructures the GitRepository reconciler to be able to correctly determine if the reconciliation can be skipped and updates all the other components affected by this change in behavior like the reconciliation result builder and processor, recovery notifications, etc.

### Errors

It introduces a new error configurations for the reconciliation error abstractions to add action information in those errors. There are both contextual and actionable errors in reconciliation errors. Certain scenarios require an error to be both contextual and actionable. The error config helps achieve that by embedding action related configurations in the errors. Using this, a user of an error can configure if the error should result in logging or event notification or just ignored. For ease of use, the reconciliation errors now have constructors with default configurations for their expected behavior in most of the cases. Some of the error configurations may not always be effectual for contextual errors due to the contextual meaning. For example, the Stalling contextual error with ignore option should not result in the error being ignored. For ignorable no-op error result, a non-contextual error is more appropriate.

It also introduces a `Generic` error type which can be used to replace the existing non-contextual errors like the Event error. Generic error can be configured to replace Event error and also add more custom behaviors based on the requirement of the caller.

### Error action handler

Since the error configurations now allow define action based configurations in the errors, a new reconciliation result processor `ErrorActionHancler` is introduced to handle the error configurations accordingly. It implements the result processor and can replace the existing error processors.

### Runtime results

The runtime result builder has been updated to identify Generic errors which may have an ignore option for a no-op result.
Generic ignorable errors do result in status observed generation to be updated.

### Git packages

The Git implementations have been updated to return a partial commit when it's a no-op clone. The partial commit contains only the hash and reference of a commit, since we don't have full commit information without cloning again. A concrete commit contains all the information related to a commit.

### GitRepository Reconciler

The GitRepositoryReconciler's `reconcileSource` is updated to fetch all the information required to determine if the reconciliation can be skipped. This includes fetching the metadata of all the included repositories and comparing them with the previously seen included repositories.

A new status field `contentConfigChecksum` is introduced to calculate a checksum of all the configuration values that contribute to a change in the source artifact.

When no-op git clone is enabled, the remote repo is checked for an update and a partial commit is returned if there's no update. If the `contentConfigChecksum` hasn't changed, the reconciliation is skipped. But if the `contentConfigChecksum` has changed, another git checkout is performed for a concrete commit to perform a full reconciliation to build a new artifact.

All the Event error in the reconciler are replaced with Generic error. Other reconcilers can adopt Generic error gradually, both the errors work for now.

All the GitRepositoryReconciler tests have been updated to use the feature gates.

**NOTE:** This change updates the GitRepository CRD with a new field which should be updated before any testing.