### PR TITLE
helmrepo: Fix test flake in type update test

### DIFF
--- a/controllers/helmrepository_controller_test.go
+++ b/controllers/helmrepository_controller_test.go
@@ -1166,9 +1166,11 @@ func TestHelmRepositoryReconciler_ReconcileTypeUpdatePredicateFilter(t *testing.
 		Name: secret.Name,
 	}
 
+	oldGen := obj.GetGeneration()
 	g.Expect(testEnv.Update(ctx, obj)).To(Succeed())
+	newGen := oldGen + 1
 
-	// Wait for HelmRepository to be Ready
+	// Wait for HelmRepository to be Ready with new generation.
 	g.Eventually(func() bool {
 		if err := testEnv.Get(ctx, key, obj); err != nil {
 			return false
@@ -1178,8 +1180,8 @@ func TestHelmRepositoryReconciler_ReconcileTypeUpdatePredicateFilter(t *testing.
 		}
 		readyCondition := conditions.Get(obj, meta.ReadyCondition)
 		return readyCondition.Status == metav1.ConditionTrue &&
-			obj.Generation == readyCondition.ObservedGeneration &&
-			obj.Generation == obj.Status.ObservedGeneration
+			newGen == readyCondition.ObservedGeneration &&
+			newGen == obj.Status.ObservedGeneration
 	}, timeout).Should(BeTrue())
 
 	// Check if the object status is valid.


### PR DESCRIPTION
In `TestHelmRepositoryReconciler_ReconcileTypeUpdatePredicateFilter`, when
the type of HelmRepo is updated and immediately checked for the object
to be ready, if the check happens before the client cache is updated, it
results in observing the object to be ready in the previous generation.
This results in status check failure:

```
[Check-FAIL]: [Ready condition must be False when the ObservedGeneration is less than the object Generation, Ready condition must be False when any of the status condition's ObservedGeneration is less than the object Generation: [Ready ArtifactInStorage]]
```

Explicitly look for the object with the next generation to prevent such
failure.

Refer: https://github.com/fluxcd/source-controller/runs/6575146265?check_suite_focus=true#step:5:443