### PR TITLE
tests: ignore proxy settings when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ build: check-deps $(LIBGIT2) ## Build manager binary
 
 KUBEBUILDER_ASSETS?="$(shell $(ENVTEST) --arch=$(ENVTEST_ARCH) use -i $(ENVTEST_KUBERNETES_VERSION) --bin-dir=$(ENVTEST_ASSETS_DIR) -p path)"
 test: $(LIBGIT2) install-envtest test-api check-deps ## Run tests
+	HTTPS_PROXY="" HTTP_PROXY="" \
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) \
 	GIT_CONFIG_GLOBAL=/dev/null \
 	go test $(GO_STATIC_FLAGS) \


### PR DESCRIPTION
Users environmental proxy settings should not impact the execution of the tests. The changes override both `HTTP_PROXY` and `HTTPS_PROXY` to ensure that is the case.
