### PR TITLE
Add Support for SAS keys in Azure Blob

### DIFF
--- a/docs/spec/v1beta2/buckets.md
+++ b/docs/spec/v1beta2/buckets.md
@@ -295,6 +295,7 @@ sets of `.data` fields:
 - `clientId` for authenticating using a Managed Identity.
 - `accountKey` for authenticating using a
   [Shared Key](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/storage/azblob#SharedKeyCredential).
+- `sasKey` for authenticating using a [SAS Token](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview)
 
 For any Managed Identity and/or Azure Active Directory authentication method,
 the base URL can be configured using `.data.authorityHost`. If not supplied,
@@ -503,6 +504,41 @@ spec:
   bucketName: testsas
   endpoint: https://testfluxsas.blob.core.windows.net
 ```
+
+##### Azure Blob SAS Token example
+
+```yaml
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: Bucket
+metadata:
+  name: azure-sas-token
+  namespace: default
+spec:
+  interval: 5m0s
+  provider: azure
+  bucketName: <bucket-name>
+  endpoint: https://<account-name>.blob.core.windows.net
+  secretRef:
+    name: azure-key
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-key
+  namespace: default
+type: Opaque
+data:
+  sasKey: <base64>
+```
+
+The sasKey only contains the SAS token e.g `?sv=2020-08-0&ss=bfqt&srt=co&sp=rwdlacupitfx&se=2022-05-26T21:55:35Z&st=2022-05...`.
+The leading question mark is optional.
+The query values from the `sasKey` data field in the Secrets gets merged with the ones in the `spec.endpoint` of the `Bucket`.
+If the same key is present in the both of them, the value in the `sasKey` takes precedence.
+
+Note that the Azure SAS Token has an expiry date and it should be updated before it expires so that Flux can
+continue to access Azure Storage.
 
 #### GCP
 

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/fluxcd/pkg/gitutil v0.1.0
 	github.com/fluxcd/pkg/helmtestserver v0.7.4
 	github.com/fluxcd/pkg/lockedfile v0.1.0
+	github.com/fluxcd/pkg/masktoken v0.0.1
 	github.com/fluxcd/pkg/oci v0.3.0
 	github.com/fluxcd/pkg/runtime v0.16.2
 	github.com/fluxcd/pkg/ssh v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -399,6 +399,8 @@ github.com/fluxcd/pkg/helmtestserver v0.7.4 h1:/Xj2+XLz7wr38MI3uPYvVAsZB9wQOq6rp
 github.com/fluxcd/pkg/helmtestserver v0.7.4/go.mod h1:aL5V4o8wUOMqeHMfjbVHS057E3ejzHMRVMqEbsK9FUQ=
 github.com/fluxcd/pkg/lockedfile v0.1.0 h1:YsYFAkd6wawMCcD74ikadAKXA4s2sukdxrn7w8RB5eo=
 github.com/fluxcd/pkg/lockedfile v0.1.0/go.mod h1:EJLan8t9MiOcgTs8+puDjbE6I/KAfHbdvIy9VUgIjm8=
+github.com/fluxcd/pkg/masktoken v0.0.1 h1:egWR/ibTzf4L3PxE8TauKO1srD1Ye/aalgQRQuKKRdU=
+github.com/fluxcd/pkg/masktoken v0.0.1/go.mod h1:sQmMtX4s5RwdGlByJazzNasWFFgBdmtNcgeZcGBI72Y=
 github.com/fluxcd/pkg/oci v0.3.0 h1:GFn6JZeg5fV2K4vsQ0s5lJFid6qrpA4RybLXL+7qUbQ=
 github.com/fluxcd/pkg/oci v0.3.0/go.mod h1:c1pj9E/G5927gSa6ooACAyZe+HwjgmPk9johL7oXDHw=
 github.com/fluxcd/pkg/runtime v0.16.2 h1:CexfMmJK+r12sHTvKWyAax0pcPomjd6VnaHXcxjUrRY=


### PR DESCRIPTION
This pull request adds support for SAS Keys in Azure Blob.
The SAS token is specified in the secret under `sasKey` field.

Fixes: #719 

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>