### PR TITLE
libgit2: enforce context timeout

### DIFF
--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -721,7 +721,10 @@ func (r *GitRepositoryReconciler) gitCheckout(ctx context.Context,
 		}
 	}
 
-	checkoutStrategy, err := strategy.CheckoutStrategyForImplementation(ctx,
+	gitCtx, cancel := context.WithTimeout(ctx, obj.Spec.Timeout.Duration)
+	defer cancel()
+
+	checkoutStrategy, err := strategy.CheckoutStrategyForImplementation(gitCtx,
 		git.Implementation(obj.Spec.GitImplementation), checkoutOpts)
 	if err != nil {
 		// Do not return err as recovery without changes is impossible.
@@ -752,10 +755,6 @@ func (r *GitRepositoryReconciler) gitCheckout(ctx context.Context,
 			return nil, e
 		}
 	}
-
-	// Checkout HEAD of reference in object
-	gitCtx, cancel := context.WithTimeout(ctx, obj.Spec.Timeout.Duration)
-	defer cancel()
 
 	commit, err := checkoutStrategy.Checkout(gitCtx, dir, obj.Spec.URL, authOpts)
 	if err != nil {

--- a/pkg/git/libgit2/checkout.go
+++ b/pkg/git/libgit2/checkout.go
@@ -91,6 +91,7 @@ func (c *CheckoutBranch) Checkout(ctx context.Context, path, url string, opts *g
 			TargetURL:    url,
 			AuthOpts:     opts,
 			ProxyOptions: &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
+			Context:      ctx,
 		})
 		url = opts.TransportOptionsURL
 		remoteCallBacks := managed.RemoteCallbacks()

--- a/pkg/git/libgit2/managed/options.go
+++ b/pkg/git/libgit2/managed/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package managed
 
 import (
+	"context"
 	"sync"
 
 	"github.com/fluxcd/source-controller/pkg/git"
@@ -29,6 +30,7 @@ type TransportOptions struct {
 	TargetURL    string
 	AuthOpts     *git.AuthOptions
 	ProxyOptions *git2go.ProxyOptions
+	Context      context.Context
 }
 
 var (

--- a/pkg/git/strategy/proxy/strategy_proxy_test.go
+++ b/pkg/git/strategy/proxy/strategy_proxy_test.go
@@ -292,7 +292,7 @@ func TestCheckoutStrategyForImplementation_Proxied(t *testing.T) {
 
 				return nil, func() {}
 			},
-			shortTimeout:  false,
+			shortTimeout:  true,
 			wantUsedProxy: false,
 			wantError:     true,
 		},


### PR DESCRIPTION
Some scenarios could lead a goroutine to be running indefinetely within managed ssh.
Previously between the two git operations, the reconciliation could take twice the timeout set for the Flux object.

After the changes were introduced (after 10pm), the reconciliations became more stable:
![image](https://user-images.githubusercontent.com/5452977/170674142-a8dacd04-935e-427b-a490-ddb0ff0ff07e.png)
