### PR TITLE
libgit2: Pass ctx to all the transport opts

### DIFF
--- a/pkg/git/libgit2/checkout.go
+++ b/pkg/git/libgit2/checkout.go
@@ -238,6 +238,7 @@ func (c *CheckoutTag) Checkout(ctx context.Context, path, url string, opts *git.
 			TargetURL:    url,
 			AuthOpts:     opts,
 			ProxyOptions: &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
+			Context:      ctx,
 		})
 		url = opts.TransportOptionsURL
 		remoteCallBacks := managed.RemoteCallbacks()
@@ -351,6 +352,7 @@ func (c *CheckoutCommit) Checkout(ctx context.Context, path, url string, opts *g
 			TargetURL:    url,
 			AuthOpts:     opts,
 			ProxyOptions: &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
+			Context:      ctx,
 		})
 		url = opts.TransportOptionsURL
 		remoteCallBacks = managed.RemoteCallbacks()
@@ -395,6 +397,7 @@ func (c *CheckoutSemVer) Checkout(ctx context.Context, path, url string, opts *g
 			TargetURL:    url,
 			AuthOpts:     opts,
 			ProxyOptions: &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
+			Context:      ctx,
 		})
 		url = opts.TransportOptionsURL
 		remoteCallBacks = managed.RemoteCallbacks()


### PR DESCRIPTION
The context passed to Checkout() has a timeout. Pass it forward to
the transport in the option for all the checkouts.

Missed in #740 