### PR TITLE
gitrepo: Refactor feature usage and fix tests

### DIFF
--- a/api/v1beta2/condition_types.go
+++ b/api/v1beta2/condition_types.go
@@ -100,4 +100,8 @@ const (
 
 	// CacheOperationFailedReason signals a failure in cache operation.
 	CacheOperationFailedReason string = "CacheOperationFailed"
+
+	// ControllerMisbehaviorReason signals a failure caused by misbehavior/
+	// UB of the controller.
+	ControllerMisbehaviorReason string = "ControllerMisbehavior"
 )

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -112,8 +112,9 @@ type GitRepositoryReconciler struct {
 	kuberecorder.EventRecorder
 	helper.Metrics
 
-	Storage        *Storage
-	ControllerName string
+	Storage                     *Storage
+	ControllerName              string
+	ManagedTransportsRegistered bool
 
 	requeueDependency time.Duration
 	features          map[string]bool
@@ -718,6 +719,40 @@ func (r *GitRepositoryReconciler) gitCheckout(ctx context.Context,
 		checkoutOpts.SemVer = ref.SemVer
 	}
 
+	// managed GIT transport only affects the libgit2 implementation
+	if enabled, ok := r.features[features.GitManagedTransport]; ok && enabled &&
+		obj.Spec.GitImplementation == sourcev1.LibGit2Implementation {
+		// We return a stalling error if managed transports aren't registered and the related
+		// feature is enabled, since the controller can't recover from this.
+		if !r.ManagedTransportsRegistered {
+			e := &serror.Stalling{
+				Err:    errors.New("can't use managed transports because they are not registered"),
+				Reason: sourcev1.ControllerMisbehaviorReason,
+			}
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			return nil, e
+		}
+
+		// We set the TransportOptionsURL of this set of authentication options here by constructing
+		// a unique URL that won't clash in a multi tenant environment. This unique URL is used by
+		// libgit2 managed transports. This enables us to bypass the inbuilt credentials callback in
+		// libgit2, which is inflexible and unstable.
+		if strings.HasPrefix(obj.Spec.URL, "http") {
+			authOpts.TransportOptionsURL = fmt.Sprintf("http://%s/%s/%d", obj.Name, obj.UID, obj.Generation)
+		} else if strings.HasPrefix(obj.Spec.URL, "ssh") {
+			authOpts.TransportOptionsURL = fmt.Sprintf("ssh://%s/%s/%d", obj.Name, obj.UID, obj.Generation)
+		} else {
+			e := &serror.Stalling{
+				Err:    fmt.Errorf("git repository URL '%s' has invalid transport type, supported types are: http, https, ssh", obj.Spec.URL),
+				Reason: sourcev1.URLInvalidReason,
+			}
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			return nil, e
+		}
+
+		checkoutOpts.Managed = true
+	}
+
 	// Only if the object has an existing artifact in storage, attempt to
 	// short-circuit clone operation. reconcileStorage has already verified
 	// that the artifact exists.
@@ -740,27 +775,6 @@ func (r *GitRepositoryReconciler) gitCheckout(ctx context.Context,
 		}
 		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
 		return nil, e
-	}
-
-	// managed GIT transport only affects the libgit2 implementation
-	if enabled, ok := r.features[features.GitManagedTransport]; ok && enabled &&
-		obj.Spec.GitImplementation == sourcev1.LibGit2Implementation {
-		// We set the TransportOptionsURL of this set of authentication options here by constructing
-		// a unique URL that won't clash in a multi tenant environment. This unique URL is used by
-		// libgit2 managed transports. This enables us to bypass the inbuilt credentials callback in
-		// libgit2, which is inflexible and unstable.
-		if strings.HasPrefix(obj.Spec.URL, "http") {
-			authOpts.TransportOptionsURL = fmt.Sprintf("http://%s/%s/%d", obj.Name, obj.UID, obj.Generation)
-		} else if strings.HasPrefix(obj.Spec.URL, "ssh") {
-			authOpts.TransportOptionsURL = fmt.Sprintf("ssh://%s/%s/%d", obj.Name, obj.UID, obj.Generation)
-		} else {
-			e := &serror.Stalling{
-				Err:    fmt.Errorf("git repository URL '%s' has invalid transport type, supported types are: http, https, ssh", obj.Spec.URL),
-				Reason: sourcev1.URLInvalidReason,
-			}
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
-			return nil, e
-		}
 	}
 
 	commit, err := checkoutStrategy.Checkout(gitCtx, dir, obj.Spec.URL, authOpts)

--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -499,10 +499,11 @@ func TestGitRepositoryReconciler_reconcileSource_authStrategy(t *testing.T) {
 			}
 
 			r := &GitRepositoryReconciler{
-				Client:        builder.Build(),
-				EventRecorder: record.NewFakeRecorder(32),
-				Storage:       testStorage,
-				features:      features.FeatureGates(),
+				Client:                      builder.Build(),
+				EventRecorder:               record.NewFakeRecorder(32),
+				Storage:                     testStorage,
+				ManagedTransportsRegistered: true,
+				features:                    features.FeatureGates(),
 			}
 
 			for _, i := range testGitImplementations {
@@ -697,10 +698,11 @@ func TestGitRepositoryReconciler_reconcileSource_checkoutStrategy(t *testing.T) 
 	}
 
 	r := &GitRepositoryReconciler{
-		Client:        fakeclient.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
-		EventRecorder: record.NewFakeRecorder(32),
-		Storage:       testStorage,
-		features:      features.FeatureGates(),
+		Client:                      fakeclient.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
+		EventRecorder:               record.NewFakeRecorder(32),
+		Storage:                     testStorage,
+		ManagedTransportsRegistered: true,
+		features:                    features.FeatureGates(),
 	}
 
 	for _, tt := range tests {
@@ -922,9 +924,10 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			resetChmod(tt.dir, 0o755, 0o644)
 
 			r := &GitRepositoryReconciler{
-				EventRecorder: record.NewFakeRecorder(32),
-				Storage:       testStorage,
-				features:      features.FeatureGates(),
+				EventRecorder:               record.NewFakeRecorder(32),
+				Storage:                     testStorage,
+				ManagedTransportsRegistered: true,
+				features:                    features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1065,11 +1068,12 @@ func TestGitRepositoryReconciler_reconcileInclude(t *testing.T) {
 			}
 
 			r := &GitRepositoryReconciler{
-				Client:            builder.Build(),
-				EventRecorder:     record.NewFakeRecorder(32),
-				Storage:           storage,
-				requeueDependency: dependencyInterval,
-				features:          features.FeatureGates(),
+				Client:                      builder.Build(),
+				EventRecorder:               record.NewFakeRecorder(32),
+				Storage:                     storage,
+				ManagedTransportsRegistered: true,
+				requeueDependency:           dependencyInterval,
+				features:                    features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1237,9 +1241,10 @@ func TestGitRepositoryReconciler_reconcileStorage(t *testing.T) {
 			}()
 
 			r := &GitRepositoryReconciler{
-				EventRecorder: record.NewFakeRecorder(32),
-				Storage:       testStorage,
-				features:      features.FeatureGates(),
+				EventRecorder:               record.NewFakeRecorder(32),
+				Storage:                     testStorage,
+				ManagedTransportsRegistered: true,
+				features:                    features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1279,9 +1284,10 @@ func TestGitRepositoryReconciler_reconcileDelete(t *testing.T) {
 	g := NewWithT(t)
 
 	r := &GitRepositoryReconciler{
-		EventRecorder: record.NewFakeRecorder(32),
-		Storage:       testStorage,
-		features:      features.FeatureGates(),
+		EventRecorder:               record.NewFakeRecorder(32),
+		Storage:                     testStorage,
+		ManagedTransportsRegistered: true,
+		features:                    features.FeatureGates(),
 	}
 
 	obj := &sourcev1.GitRepository{
@@ -1417,9 +1423,10 @@ func TestGitRepositoryReconciler_verifyCommitSignature(t *testing.T) {
 			}
 
 			r := &GitRepositoryReconciler{
-				EventRecorder: record.NewFakeRecorder(32),
-				Client:        builder.Build(),
-				features:      features.FeatureGates(),
+				EventRecorder:               record.NewFakeRecorder(32),
+				Client:                      builder.Build(),
+				ManagedTransportsRegistered: true,
+				features:                    features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1558,10 +1565,11 @@ func TestGitRepositoryReconciler_ConditionsUpdate(t *testing.T) {
 			builder := fakeclient.NewClientBuilder().WithScheme(testEnv.GetScheme()).WithObjects(obj)
 
 			r := &GitRepositoryReconciler{
-				Client:        builder.Build(),
-				EventRecorder: record.NewFakeRecorder(32),
-				Storage:       testStorage,
-				features:      features.FeatureGates(),
+				Client:                      builder.Build(),
+				EventRecorder:               record.NewFakeRecorder(32),
+				Storage:                     testStorage,
+				ManagedTransportsRegistered: true,
+				features:                    features.FeatureGates(),
 			}
 
 			key := client.ObjectKeyFromObject(obj)
@@ -1925,8 +1933,9 @@ func TestGitRepositoryReconciler_notify(t *testing.T) {
 			}
 
 			reconciler := &GitRepositoryReconciler{
-				EventRecorder: recorder,
-				features:      features.FeatureGates(),
+				EventRecorder:               recorder,
+				ManagedTransportsRegistered: true,
+				features:                    features.FeatureGates(),
 			}
 			reconciler.notify(ctx, oldObj, newObj, tt.commit, tt.res, tt.resErr)
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -209,14 +209,19 @@ func TestMain(m *testing.M) {
 
 	fg := feathelper.FeatureGates{}
 	fg.SupportedFeatures(features.FeatureGates())
-	managed.InitManagedTransport(logr.Discard())
+
+	err = managed.InitManagedTransport(logr.Discard())
+	if err != nil {
+		panic(fmt.Sprintf("Failed to register managed transports; %v", err))
+	}
 
 	if err := (&GitRepositoryReconciler{
-		Client:        testEnv,
-		EventRecorder: record.NewFakeRecorder(32),
-		Metrics:       testMetricsH,
-		Storage:       testStorage,
-		features:      features.FeatureGates(),
+		Client:                      testEnv,
+		EventRecorder:               record.NewFakeRecorder(32),
+		Metrics:                     testMetricsH,
+		Storage:                     testStorage,
+		ManagedTransportsRegistered: true,
+		features:                    features.FeatureGates(),
 	}).SetupWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Failed to start GitRepositoryReconciler: %v", err))
 	}

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -65,11 +65,3 @@ func FeatureGates() map[string]bool {
 func Enabled(feature string) (bool, error) {
 	return feathelper.Enabled(feature)
 }
-
-// Disable disables the specified feature. If the feature is not
-// present, it's a no-op.
-func Disable(feature string) {
-	if _, ok := features[feature]; ok {
-		features[feature] = false
-	}
-}

--- a/main.go
+++ b/main.go
@@ -312,13 +312,6 @@ func main() {
 
 	if enabled, _ := features.Enabled(features.GitManagedTransport); enabled {
 		managed.InitManagedTransport(ctrl.Log.WithName("managed-transport"))
-	} else {
-		if optimize, _ := feathelper.Enabled(features.OptimizedGitClones); optimize {
-			features.Disable(features.OptimizedGitClones)
-			setupLog.Info(
-				"disabling optimized git clones; git clones can only be optimized when using managed transport",
-			)
-		}
 	}
 
 	setupLog.Info("starting manager")

--- a/main.go
+++ b/main.go
@@ -204,12 +204,22 @@ func main() {
 	}
 	storage := mustInitStorage(storagePath, storageAdvAddr, artifactRetentionTTL, artifactRetentionRecords, setupLog)
 
+	var registered bool
+	if enabled, _ := features.Enabled(features.GitManagedTransport); enabled {
+		if err = managed.InitManagedTransport(ctrl.Log.WithName("managed-transport")); err != nil {
+			setupLog.Error(err, "could not register managed transports")
+		} else {
+			registered = true
+		}
+	}
+
 	if err = (&controllers.GitRepositoryReconciler{
-		Client:         mgr.GetClient(),
-		EventRecorder:  eventRecorder,
-		Metrics:        metricsH,
-		Storage:        storage,
-		ControllerName: controllerName,
+		Client:                      mgr.GetClient(),
+		EventRecorder:               eventRecorder,
+		Metrics:                     metricsH,
+		Storage:                     storage,
+		ControllerName:              controllerName,
+		ManagedTransportsRegistered: registered,
 	}).SetupWithManagerAndOptions(mgr, controllers.GitRepositoryReconcilerOptions{
 		MaxConcurrentReconciles:   concurrent,
 		DependencyRequeueInterval: requeueDependency,
@@ -309,10 +319,6 @@ func main() {
 
 		startFileServer(storage.BasePath, storageAddr, setupLog)
 	}()
-
-	if enabled, _ := features.Enabled(features.GitManagedTransport); enabled {
-		managed.InitManagedTransport(ctrl.Log.WithName("managed-transport"))
-	}
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/pkg/git/libgit2/managed/init.go
+++ b/pkg/git/libgit2/managed/init.go
@@ -40,17 +40,7 @@ var (
 
 	debugLog logr.Logger
 	traceLog logr.Logger
-	enabled  bool
 )
-
-// Enabled defines whether the use of Managed Transport is enabled which
-// is only true if InitManagedTransport was called successfully at least
-// once.
-//
-// This is only affects git operations that uses libgit2 implementation.
-func Enabled() bool {
-	return enabled
-}
 
 // InitManagedTransport initialises HTTP(S) and SSH managed transport
 // for git2go, and therefore only impact git operations using the
@@ -76,7 +66,6 @@ func InitManagedTransport(log logr.Logger) error {
 		}
 
 		err = registerManagedSSH()
-		enabled = true
 	})
 
 	return err

--- a/pkg/git/libgit2/managed/managed_test.go
+++ b/pkg/git/libgit2/managed/managed_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managed
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestMain(m *testing.M) {
+	InitManagedTransport(logr.Discard())
+	code := m.Run()
+	os.Exit(code)
+}

--- a/pkg/git/libgit2/managed/options.go
+++ b/pkg/git/libgit2/managed/options.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/fluxcd/source-controller/internal/features"
 	"github.com/fluxcd/source-controller/pkg/git"
 	git2go "github.com/libgit2/git2go/v33"
 )
@@ -75,7 +76,8 @@ func getTransportOptions(transportOptsURL string) (*TransportOptions, bool) {
 // this returns the same input if Managed Transport is disabled or if no TargetURL
 // is set on TransportOptions.
 func EffectiveURL(transporOptsURL string) string {
-	if !Enabled() {
+	if enabled, _ := features.Enabled(features.GitManagedTransport); enabled {
+
 		return transporOptsURL
 	}
 

--- a/pkg/git/libgit2/managed/ssh_test.go
+++ b/pkg/git/libgit2/managed/ssh_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/fluxcd/pkg/ssh"
 	"github.com/fluxcd/source-controller/pkg/git"
-	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 
 	"github.com/fluxcd/pkg/gittestserver"
@@ -89,7 +88,6 @@ func TestSSHManagedTransport_E2E(t *testing.T) {
 		server.StartSSH()
 	}()
 	defer server.StopSSH()
-	InitManagedTransport(logr.Discard())
 
 	kp, err := ssh.NewEd25519Generator().Generate()
 	g.Expect(err).ToNot(HaveOccurred())

--- a/pkg/git/libgit2/managed_checkout_test.go
+++ b/pkg/git/libgit2/managed_checkout_test.go
@@ -23,24 +23,27 @@ package libgit2
 
 import (
 	"testing"
+
+	"github.com/fluxcd/source-controller/pkg/git/libgit2/managed"
+	"github.com/go-logr/logr"
 )
 
 func TestCheckoutBranch_CheckoutManaged(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 	checkoutBranch(t, true)
 }
 
 func TestCheckoutTag_CheckoutManaged(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 	checkoutTag(t, true)
 }
 
 func TestCheckoutCommit_CheckoutManaged(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 	checkoutCommit(t, true)
 }
 
 func TestCheckoutTagSemVer_CheckoutManaged(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 	checkoutSemVer(t, true)
 }

--- a/pkg/git/libgit2/managed_test.go
+++ b/pkg/git/libgit2/managed_test.go
@@ -31,7 +31,10 @@ import (
 	"github.com/fluxcd/pkg/gittestserver"
 	feathelper "github.com/fluxcd/pkg/runtime/features"
 	"github.com/fluxcd/pkg/ssh"
+	"github.com/fluxcd/source-controller/pkg/git"
+	"github.com/fluxcd/source-controller/pkg/git/libgit2/managed"
 	"github.com/go-logr/logr"
+
 	. "github.com/onsi/gomega"
 	cryptossh "golang.org/x/crypto/ssh"
 
@@ -146,7 +149,10 @@ func Test_managedSSH_KeyTypes(t *testing.T) {
 			authOpts.TransportOptionsURL = getTransportOptionsURL(git.SSH)
 
 			// Prepare for checkout.
-			branchCheckoutStrat := &CheckoutBranch{Branch: git.DefaultBranch}
+			branchCheckoutStrat := &CheckoutBranch{
+				Branch:  git.DefaultBranch,
+				Managed: true,
+			}
 			tmpDir := t.TempDir()
 
 			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
@@ -276,7 +282,10 @@ func Test_managedSSH_KeyExchangeAlgos(t *testing.T) {
 			authOpts.TransportOptionsURL = getTransportOptionsURL(git.SSH)
 
 			// Prepare for checkout.
-			branchCheckoutStrat := &CheckoutBranch{Branch: git.DefaultBranch}
+			branchCheckoutStrat := &CheckoutBranch{
+				Branch:  git.DefaultBranch,
+				Managed: true,
+			}
 			tmpDir := t.TempDir()
 
 			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
@@ -445,7 +454,10 @@ func Test_managedSSH_HostKeyAlgos(t *testing.T) {
 			authOpts.TransportOptionsURL = getTransportOptionsURL(git.SSH)
 
 			// Prepare for checkout.
-			branchCheckoutStrat := &CheckoutBranch{Branch: git.DefaultBranch}
+			branchCheckoutStrat := &CheckoutBranch{
+				Branch:  git.DefaultBranch,
+				Managed: true,
+			}
 			tmpDir := t.TempDir()
 
 			ctx, cancel := context.WithTimeout(context.TODO(), timeout)

--- a/pkg/git/libgit2/managed_test.go
+++ b/pkg/git/libgit2/managed_test.go
@@ -29,10 +29,9 @@ import (
 
 	"github.com/fluxcd/gitkit"
 	"github.com/fluxcd/pkg/gittestserver"
+	feathelper "github.com/fluxcd/pkg/runtime/features"
 	"github.com/fluxcd/pkg/ssh"
 	"github.com/go-logr/logr"
-
-	feathelper "github.com/fluxcd/pkg/runtime/features"
 	. "github.com/onsi/gomega"
 	cryptossh "golang.org/x/crypto/ssh"
 
@@ -46,7 +45,7 @@ const testRepositoryPath = "../testdata/git/repo"
 // Test_managedSSH_KeyTypes assures support for the different
 // types of keys for SSH Authentication supported by Flux.
 func Test_managedSSH_KeyTypes(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 
 	tests := []struct {
 		name       string
@@ -175,7 +174,7 @@ func Test_managedSSH_KeyTypes(t *testing.T) {
 // Test_managedSSH_KeyExchangeAlgos assures support for the different
 // types of SSH key exchange algorithms supported by Flux.
 func Test_managedSSH_KeyExchangeAlgos(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 
 	tests := []struct {
 		name      string
@@ -298,7 +297,7 @@ func Test_managedSSH_KeyExchangeAlgos(t *testing.T) {
 // Test_managedSSH_HostKeyAlgos assures support for the different
 // types of SSH Host Key algorithms supported by Flux.
 func Test_managedSSH_HostKeyAlgos(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 
 	tests := []struct {
 		name               string

--- a/pkg/git/options.go
+++ b/pkg/git/options.go
@@ -52,6 +52,9 @@ type CheckoutOptions struct {
 	// LastRevision holds the last observed revision of the local repository.
 	// It is used to skip clone operations when no changes were detected.
 	LastRevision string
+
+	// Managed defines if the checkout should be done using managed transports.
+	Managed bool
 }
 
 type TransportType string

--- a/pkg/git/strategy/proxy/strategy_proxy_test.go
+++ b/pkg/git/strategy/proxy/strategy_proxy_test.go
@@ -44,7 +44,6 @@ import (
 func TestCheckoutStrategyForImplementation_Proxied(t *testing.T) {
 	// for libgit2 we are only testing for managed transport,
 	// as unmanaged is sunsetting.
-	// Unmanaged transport does not support HTTP_PROXY.
 	managed.InitManagedTransport(logr.Discard())
 
 	type cleanupFunc func()
@@ -331,7 +330,8 @@ func TestCheckoutStrategyForImplementation_Proxied(t *testing.T) {
 
 			// Checkout the repo.
 			checkoutStrategy, err := strategy.CheckoutStrategyForImplementation(context.TODO(), tt.gitImpl, git.CheckoutOptions{
-				Branch: tt.branch,
+				Branch:  tt.branch,
+				Managed: true,
 			})
 			g.Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/git/strategy/proxy/strategy_proxy_test.go
+++ b/pkg/git/strategy/proxy/strategy_proxy_test.go
@@ -29,11 +29,9 @@ import (
 
 	"github.com/elazarl/goproxy"
 	"github.com/fluxcd/pkg/gittestserver"
-	feathelper "github.com/fluxcd/pkg/runtime/features"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 
-	"github.com/fluxcd/source-controller/internal/features"
 	"github.com/fluxcd/source-controller/pkg/git"
 	"github.com/fluxcd/source-controller/pkg/git/gogit"
 	"github.com/fluxcd/source-controller/pkg/git/libgit2"
@@ -47,9 +45,6 @@ func TestCheckoutStrategyForImplementation_Proxied(t *testing.T) {
 	// for libgit2 we are only testing for managed transport,
 	// as unmanaged is sunsetting.
 	// Unmanaged transport does not support HTTP_PROXY.
-	fg := feathelper.FeatureGates{}
-	fg.SupportedFeatures(features.FeatureGates())
-
 	managed.InitManagedTransport(logr.Discard())
 
 	type cleanupFunc func()


### PR DESCRIPTION
This PR is a follow up to #727. It refactors feature usage in the reconciler alongside the checkout code, by getting rid of `managed.Enabled()`. Instead, a new field `Managed` in `CheckoutOpts` is added which is used to check for managed transport in `Checkout()` along with `features.Enabled()` in the reconciler, which lets us avoid having multiple global states for the same thing. If we can't register our managed transports before starting the reconciler, the reconciler will return a `Stalling` error.

It also addresses various shortcomings related to GitRepository (and libgit2) tests. It arranges the tests in different files carefully, to influence the order in which golang executes the tests. All the unmanaged tests go in `checkout_test.go`, which is the first file in it's package (alphabetically speaking), which means those tests always run prior to any other test in that package.
Related to #745. 

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>