### PR TITLE
OCI HelmRepo: handle status conditions in-line

### DIFF
--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -577,8 +577,8 @@ func (r *HelmRepositoryReconciler) garbageCollect(ctx context.Context, obj *sour
 		// Clean status sub-resource
 		obj.Status.Artifact = nil
 		obj.Status.URL = ""
-		// Remove the condition as the artifact doesn't exist.
-		conditions.Delete(obj, sourcev1.ArtifactInStorageCondition)
+		// Remove any stale conditions.
+		obj.Status.Conditions = nil
 		return nil
 	}
 	if obj.GetArtifact() != nil {

--- a/controllers/helmrepository_controller_test.go
+++ b/controllers/helmrepository_controller_test.go
@@ -1179,13 +1179,16 @@ func TestHelmRepositoryReconciler_ReconcileTypeUpdatePredicateFilter(t *testing.
 			return false
 		}
 		readyCondition := conditions.Get(obj, meta.ReadyCondition)
+		if readyCondition == nil {
+			return false
+		}
 		return readyCondition.Status == metav1.ConditionTrue &&
 			newGen == readyCondition.ObservedGeneration &&
 			newGen == obj.Status.ObservedGeneration
 	}, timeout).Should(BeTrue())
 
 	// Check if the object status is valid.
-	condns = &status.Conditions{NegativePolarity: helmRepositoryOCIReadyCondition.NegativePolarity}
+	condns = &status.Conditions{NegativePolarity: helmRepositoryOCINegativeConditions}
 	checker = status.NewChecker(testEnv.Client, condns)
 	checker.CheckErr(ctx, obj)
 


### PR DESCRIPTION
Refactor the OCI HelmRepo reconciler to remove extra custom status
conditions and manage Ready, Reconciling and Stalled conditions within
the reconciler, in-line.
Since OCI HelmRepository is a simple reconciler, it'd be better
to not introduce extra conditions and utilize the three base conditions
to represent the status. In order to have consistent status conditions,
a new summarization code is written within the reconciler based
on the context. It takes into consideration a lot of the details from
the internal/reconcile/summarize package and handles certain scenarios
in context specific manner. All the result and error abstractions are
removed since they are only needed when using internal/reconcile
package.

Some of the code patterns introduced in this can be moved into separate
functions and tested individually, similar to the helpers in the internal/reconcile/
package. It can also be integrated into the summarize and patch helpers.
It can be done separately as a follow-up.

Refer https://gist.github.com/darkowlzz/c5c86afb148ad06dc7c4cc8c6afcdaef
for examples of how the status conditions appear in various scenarios.

Examples of the events:
![oci-helmrepo-events](https://user-images.githubusercontent.com/614105/171064981-2c880a94-8d21-419c-a3df-53c9c922394f.png)
NOTE: Some of the strings may be different in the code. This snapshot was taken during development.

Supersedes #733 