### PR TITLE
Fix repository cache regression

### DIFF
--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -159,6 +159,14 @@ func TestHelmChartReconciler_Reconcile(t *testing.T) {
 		return obj.Status.LastHandledReconcileAt == "now"
 	}, timeout).Should(BeTrue())
 
+	// Check if the cache contains the index.
+	repoKey := client.ObjectKey{Name: repository.Name, Namespace: repository.Namespace}
+	err = testEnv.Get(ctx, repoKey, repository)
+	g.Expect(err).ToNot(HaveOccurred())
+	localPath := testStorage.LocalPath(*repository.GetArtifact())
+	_, found := testCache.Get(localPath)
+	g.Expect(found).To(BeTrue())
+
 	g.Expect(testEnv.Delete(ctx, obj)).To(Succeed())
 
 	// Wait for HelmChart to be deleted

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -103,6 +103,7 @@ var (
 
 var (
 	testRegistryServer *registryClientTestServer
+	testCache          *cache.Cache
 )
 
 func init() {
@@ -246,7 +247,7 @@ func TestMain(m *testing.M) {
 		panic(fmt.Sprintf("Failed to start HelmRepositoryOCIReconciler: %v", err))
 	}
 
-	c := cache.New(5, 1*time.Second)
+	testCache = cache.New(5, 1*time.Second)
 	cacheRecorder := cache.MustMakeMetrics()
 	if err := (&HelmChartReconciler{
 		Client:        testEnv,
@@ -254,7 +255,7 @@ func TestMain(m *testing.M) {
 		Metrics:       testMetricsH,
 		Getters:       testGetters,
 		Storage:       testStorage,
-		Cache:         c,
+		Cache:         testCache,
 		TTL:           1 * time.Second,
 		CacheRecorder: cacheRecorder,
 	}).SetupWithManager(testEnv); err != nil {

--- a/internal/helm/chart/builder_remote.go
+++ b/internal/helm/chart/builder_remote.go
@@ -186,7 +186,6 @@ func (b *remoteChartBuilder) downloadFromRepository(remote *repository.ChartRepo
 		err = fmt.Errorf("could not load repository index for remote chart reference: %w", err)
 		return nil, &BuildError{Reason: ErrChartPull, Err: err}
 	}
-	defer remote.Unload()
 
 	// Get the current version for the RemoteReference
 	cv, err := remote.Get(remoteRef.Name, remoteRef.Version)


### PR DESCRIPTION
This fixes a regression introduce in #690. We no longer cache Helm repository indexes when cache is enabled because of a defer function in the `remote builder` which unload the index.

If implemented this make sure we don't unload an index before caching it during a chart build phase. The index is unloaded downstream after successfully caching it.

Signed-off-by: Soule BA <soule@weave.works>