### PR TITLE
Fix sorting semver from OCI repository tags

### DIFF
--- a/internal/helm/repository/oci_chart_repository.go
+++ b/internal/helm/repository/oci_chart_repository.go
@@ -228,7 +228,7 @@ func getLastMatchingVersionOrConstraint(cvs []string, ver string) (string, error
 		}
 	}
 
-	matchingVersions := make([]string, 0, len(cvs))
+	matchingVersions := make([]*semver.Version, 0, len(cvs))
 	for _, cv := range cvs {
 		v, err := version.ParseVersion(cv)
 		if err != nil {
@@ -239,14 +239,14 @@ func getLastMatchingVersionOrConstraint(cvs []string, ver string) (string, error
 			continue
 		}
 
-		matchingVersions = append(matchingVersions, cv)
+		matchingVersions = append(matchingVersions, v)
 	}
 	if len(matchingVersions) == 0 {
 		return "", fmt.Errorf("could not locate a version matching provided version string %s", ver)
 	}
 
 	// Sort versions
-	sort.Sort(sort.Reverse(sort.StringSlice(matchingVersions)))
+	sort.Sort(sort.Reverse(semver.Collection(matchingVersions)))
 
-	return matchingVersions[0], nil
+	return matchingVersions[0].Original(), nil
 }

--- a/internal/helm/repository/oci_chart_repository_test.go
+++ b/internal/helm/repository/oci_chart_repository_test.go
@@ -101,6 +101,8 @@ func TestOCIChartRepoisitory_Get(t *testing.T) {
 			"0.1.5+a.min.hour",
 			"0.1.5+c.now",
 			"0.2.0",
+			"0.9.0",
+			"0.10.0",
 			"1.0.0",
 			"1.1.0-rc.1",
 		},
@@ -143,6 +145,11 @@ func TestOCIChartRepoisitory_Get(t *testing.T) {
 			name:     "should return a perfect match",
 			version:  "0.1.0",
 			expected: "0.1.0",
+		},
+		{
+			name:     "should return 0.10.0",
+			version:  "0.*",
+			expected: "0.10.0",
 		},
 		{
 			name:        "should an error for unfunfilled range",


### PR DESCRIPTION
If implemented this fix the issue where we previously did a string
ordering of matching semver versions when retrieving a list of tags from
an OCI registry.

fixes #768

Signed-off-by: Soule BA <soule@weave.works>