### PR TITLE
Enable Umbrella Chart with dependencies from OCI repositories

### DIFF
--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -461,9 +462,10 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 		loginOpts []helmreg.LoginOption
 	)
 
+	normalizedURL := repository.NormalizeURL(repo.Spec.URL)
 	// Construct the Getter options from the HelmRepository data
 	clientOpts := []helmgetter.Option{
-		helmgetter.WithURL(repo.Spec.URL),
+		helmgetter.WithURL(normalizedURL),
 		helmgetter.WithTimeout(repo.Spec.Timeout.Duration),
 		helmgetter.WithPassCredentialsAll(repo.Spec.PassCredentials),
 	}
@@ -491,7 +493,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 		}
 		clientOpts = append(clientOpts, opts...)
 
-		tlsConfig, err = getter.TLSClientConfigFromSecret(*secret, repo.Spec.URL)
+		tlsConfig, err = getter.TLSClientConfigFromSecret(*secret, normalizedURL)
 		if err != nil {
 			e := &serror.Event{
 				Err:    fmt.Errorf("failed to create TLS client config with secret data: %w", err),
@@ -503,7 +505,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 		}
 
 		// Build registryClient options from secret
-		loginOpt, err := registry.LoginOptionFromSecret(repo.Spec.URL, *secret)
+		loginOpt, err := registry.LoginOptionFromSecret(normalizedURL, *secret)
 		if err != nil {
 			e := &serror.Event{
 				Err:    fmt.Errorf("failed to configure Helm client with secret data: %w", err),
@@ -518,11 +520,11 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 	}
 
 	// Initialize the chart repository
-	var chartRepo chart.Repository
+	var chartRepo repository.Downloader
 	switch repo.Spec.Type {
 	case sourcev1.HelmRepositoryTypeOCI:
-		if !helmreg.IsOCI(repo.Spec.URL) {
-			err := fmt.Errorf("invalid OCI registry URL: %s", repo.Spec.URL)
+		if !helmreg.IsOCI(normalizedURL) {
+			err := fmt.Errorf("invalid OCI registry URL: %s", normalizedURL)
 			return chartRepoConfigErrorReturn(err, obj)
 		}
 
@@ -530,7 +532,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 		// this is needed because otherwise the credentials are stored in ~/.docker/config.json.
 		// TODO@souleb: remove this once the registry move to Oras v2
 		// or rework to enable reusing credentials to avoid the unneccessary handshake operations
-		registryClient, file, err := r.RegistryClientGenerator(loginOpts != nil)
+		registryClient, credentialsFile, err := r.RegistryClientGenerator(loginOpts != nil)
 		if err != nil {
 			e := &serror.Event{
 				Err:    fmt.Errorf("failed to construct Helm client: %w", err),
@@ -540,9 +542,9 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 			return sreconcile.ResultEmpty, e
 		}
 
-		if file != "" {
+		if credentialsFile != "" {
 			defer func() {
-				if err := os.Remove(file); err != nil {
+				if err := os.Remove(credentialsFile); err != nil {
 					r.eventLogf(ctx, obj, corev1.EventTypeWarning, meta.FailedReason,
 						"failed to delete temporary credentials file: %s", err)
 				}
@@ -551,7 +553,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 
 		// Tell the chart repository to use the OCI client with the configured getter
 		clientOpts = append(clientOpts, helmgetter.WithRegistryClient(registryClient))
-		ociChartRepo, err := repository.NewOCIChartRepository(repo.Spec.URL, repository.WithOCIGetter(r.Getters), repository.WithOCIGetterOptions(clientOpts), repository.WithOCIRegistryClient(registryClient))
+		ociChartRepo, err := repository.NewOCIChartRepository(normalizedURL, repository.WithOCIGetter(r.Getters), repository.WithOCIGetterOptions(clientOpts), repository.WithOCIRegistryClient(registryClient))
 		if err != nil {
 			return chartRepoConfigErrorReturn(err, obj)
 		}
@@ -571,7 +573,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 			}
 		}
 	default:
-		httpChartRepo, err := repository.NewChartRepository(repo.Spec.URL, r.Storage.LocalPath(*repo.GetArtifact()), r.Getters, tlsConfig, clientOpts,
+		httpChartRepo, err := repository.NewChartRepository(normalizedURL, r.Storage.LocalPath(*repo.GetArtifact()), r.Getters, tlsConfig, clientOpts,
 			repository.WithMemoryCache(r.Storage.LocalPath(*repo.GetArtifact()), r.Cache, r.TTL, func(event string) {
 				r.IncCacheEvents(event, obj.Name, obj.Namespace)
 			}))
@@ -684,9 +686,15 @@ func (r *HelmChartReconciler) buildFromTarballArtifact(ctx context.Context, obj 
 
 	// Setup dependency manager
 	dm := chart.NewDependencyManager(
-		chart.WithRepositoryCallback(r.namespacedChartRepositoryCallback(ctx, obj.GetName(), obj.GetNamespace())),
+		chart.WithDownloaderCallback(r.namespacedChartRepositoryCallback(ctx, obj.GetName(), obj.GetNamespace())),
 	)
-	defer dm.Clear()
+	defer func() {
+		err := dm.Clear()
+		if err != nil {
+			r.eventLogf(ctx, obj, corev1.EventTypeWarning, meta.FailedReason,
+				"dependency manager cleanup error: %s", err)
+		}
+	}()
 
 	// Configure builder options, including any previously cached chart
 	opts := chart.BuildOptions{
@@ -913,12 +921,17 @@ func (r *HelmChartReconciler) garbageCollect(ctx context.Context, obj *sourcev1.
 	return nil
 }
 
-// namespacedChartRepositoryCallback returns a chart.GetChartRepositoryCallback scoped to the given namespace.
-// The returned callback returns a repository.ChartRepository configured with the retrieved v1beta1.HelmRepository,
+// namespacedChartRepositoryCallback returns a chart.GetChartDownloaderCallback scoped to the given namespace.
+// The returned callback returns a repository.Downloader configured with the retrieved v1beta1.HelmRepository,
 // or a shim with defaults if no object could be found.
-func (r *HelmChartReconciler) namespacedChartRepositoryCallback(ctx context.Context, name, namespace string) chart.GetChartRepositoryCallback {
-	return func(url string) (*repository.ChartRepository, error) {
-		var tlsConfig *tls.Config
+// The callback returns an object with a state, so the caller has to do the necessary cleanup.
+func (r *HelmChartReconciler) namespacedChartRepositoryCallback(ctx context.Context, name, namespace string) chart.GetChartDownloaderCallback {
+	return func(url string) (repository.Downloader, error) {
+		var (
+			tlsConfig *tls.Config
+			loginOpts []helmreg.LoginOption
+		)
+		normalizedURL := repository.NormalizeURL(url)
 		repo, err := r.resolveDependencyRepository(ctx, url, namespace)
 		if err != nil {
 			// Return Kubernetes client errors, but ignore others
@@ -933,7 +946,7 @@ func (r *HelmChartReconciler) namespacedChartRepositoryCallback(ctx context.Cont
 			}
 		}
 		clientOpts := []helmgetter.Option{
-			helmgetter.WithURL(repo.Spec.URL),
+			helmgetter.WithURL(normalizedURL),
 			helmgetter.WithTimeout(repo.Spec.Timeout.Duration),
 			helmgetter.WithPassCredentialsAll(repo.Spec.PassCredentials),
 		}
@@ -947,26 +960,77 @@ func (r *HelmChartReconciler) namespacedChartRepositoryCallback(ctx context.Cont
 			}
 			clientOpts = append(clientOpts, opts...)
 
-			tlsConfig, err = getter.TLSClientConfigFromSecret(*secret, repo.Spec.URL)
+			tlsConfig, err = getter.TLSClientConfigFromSecret(*secret, normalizedURL)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create TLS client config for HelmRepository '%s': %w", repo.Name, err)
 			}
+
+			// Build registryClient options from secret
+			loginOpt, err := registry.LoginOptionFromSecret(normalizedURL, *secret)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create login options for HelmRepository '%s': %w", repo.Name, err)
+			}
+
+			loginOpts = append([]helmreg.LoginOption{}, loginOpt)
 		}
 
-		chartRepo, err := repository.NewChartRepository(repo.Spec.URL, "", r.Getters, tlsConfig, clientOpts)
-		if err != nil {
-			return nil, err
+		var chartRepo repository.Downloader
+		if helmreg.IsOCI(normalizedURL) {
+			registryClient, credentialsFile, err := r.RegistryClientGenerator(loginOpts != nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create registry client for HelmRepository '%s': %w", repo.Name, err)
+			}
+
+			var errs []error
+			// Tell the chart repository to use the OCI client with the configured getter
+			clientOpts = append(clientOpts, helmgetter.WithRegistryClient(registryClient))
+			ociChartRepo, err := repository.NewOCIChartRepository(normalizedURL, repository.WithOCIGetter(r.Getters),
+				repository.WithOCIGetterOptions(clientOpts),
+				repository.WithOCIRegistryClient(registryClient),
+				repository.WithCredentialsFile(credentialsFile))
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to create OCI chart repository for HelmRepository '%s': %w", repo.Name, err))
+				// clean up the credentialsFile
+				if credentialsFile != "" {
+					if err := os.Remove(credentialsFile); err != nil {
+						errs = append(errs, err)
+					}
+				}
+				return nil, kerrors.NewAggregate(errs)
+			}
+
+			// If login options are configured, use them to login to the registry
+			// The OCIGetter will later retrieve the stored credentials to pull the chart
+			if loginOpts != nil {
+				err = ociChartRepo.Login(loginOpts...)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("failed to login to OCI chart repository for HelmRepository '%s': %w", repo.Name, err))
+					// clean up the credentialsFile
+					errs = append(errs, ociChartRepo.Clear())
+					return nil, kerrors.NewAggregate(errs)
+				}
+			}
+
+			chartRepo = ociChartRepo
+		} else {
+			httpChartRepo, err := repository.NewChartRepository(normalizedURL, "", r.Getters, tlsConfig, clientOpts)
+			if err != nil {
+				return nil, err
+			}
+
+			// Ensure that the cache key is the same as the artifact path
+			// otherwise don't enable caching. We don't want to cache indexes
+			// for repositories that are not reconciled by the source controller.
+			if repo.Status.Artifact != nil {
+				httpChartRepo.CachePath = r.Storage.LocalPath(*repo.GetArtifact())
+				httpChartRepo.SetMemCache(r.Storage.LocalPath(*repo.GetArtifact()), r.Cache, r.TTL, func(event string) {
+					r.IncCacheEvents(event, name, namespace)
+				})
+			}
+
+			chartRepo = httpChartRepo
 		}
 
-		// Ensure that the cache key is the same as the artifact path
-		// otherwise don't enable caching. We don't want to cache indexes
-		// for repositories that are not reconciled by the source controller.
-		if repo.Status.Artifact != nil {
-			chartRepo.CachePath = r.Storage.LocalPath(*repo.GetArtifact())
-			chartRepo.SetMemCache(r.Storage.LocalPath(*repo.GetArtifact()), r.Cache, r.TTL, func(event string) {
-				r.IncCacheEvents(event, name, namespace)
-			})
-		}
 		return chartRepo, nil
 	}
 }

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -518,7 +518,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 	}
 
 	// Initialize the chart repository
-	var chartRepo chart.Remote
+	var chartRepo chart.Repository
 	switch repo.Spec.Type {
 	case sourcev1.HelmRepositoryTypeOCI:
 		if !helmreg.IsOCI(repo.Spec.URL) {

--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -411,9 +411,6 @@ func TestHelmChartReconciler_reconcileSource(t *testing.T) {
 				}))
 			},
 		},
-		//{
-		//	name: "Error on transient build error",
-		//},
 		{
 			name: "Stalling on persistent build error",
 			source: &sourcev1.GitRepository{
@@ -1070,7 +1067,7 @@ func TestHelmChartReconciler_buildFromTarballArtifact(t *testing.T) {
 			assertFunc: func(g *WithT, build chart.Build) {
 				g.Expect(build.Name).To(Equal("helmchartwithdeps"))
 				g.Expect(build.Version).To(Equal("0.1.0"))
-				g.Expect(build.ResolvedDependencies).To(Equal(3))
+				g.Expect(build.ResolvedDependencies).To(Equal(4))
 				g.Expect(build.Path).To(BeARegularFile())
 			},
 			cleanFunc: func(g *WithT, build *chart.Build) {
@@ -1178,10 +1175,11 @@ func TestHelmChartReconciler_buildFromTarballArtifact(t *testing.T) {
 			g := NewWithT(t)
 
 			r := &HelmChartReconciler{
-				Client:        fake.NewClientBuilder().Build(),
-				EventRecorder: record.NewFakeRecorder(32),
-				Storage:       storage,
-				Getters:       testGetters,
+				Client:                  fake.NewClientBuilder().Build(),
+				EventRecorder:           record.NewFakeRecorder(32),
+				Storage:                 storage,
+				Getters:                 testGetters,
+				RegistryClientGenerator: registry.ClientGenerator,
 			}
 
 			obj := &sourcev1.HelmChart{

--- a/controllers/helmrepository_controller_oci.go
+++ b/controllers/helmrepository_controller_oci.go
@@ -326,7 +326,7 @@ func (r *HelmRepositoryOCIReconciler) reconcile(ctx context.Context, obj *v1beta
 	if loginOpts != nil {
 		err = chartRepo.Login(loginOpts...)
 		if err != nil {
-			e := fmt.Errorf("failed to log into registry '%s': %w", obj.Spec.URL, err)
+			e := fmt.Errorf("failed to login to registry '%s': %w", obj.Spec.URL, err)
 			conditions.MarkFalse(obj, meta.ReadyCondition, sourcev1.AuthenticationFailedReason, e.Error())
 			result, retErr = ctrl.Result{}, e
 			return

--- a/controllers/testdata/charts/helmchartwithdeps/Chart.yaml
+++ b/controllers/testdata/charts/helmchartwithdeps/Chart.yaml
@@ -31,3 +31,6 @@ dependencies:
   - name: grafana
     version: ">=5.7.0"
     repository: "https://grafana.github.io/helm-charts"
+  - name: podinfo
+    version: ">=6.1.*"
+    repository: "oci://ghcr.io/stefanprodan/charts"

--- a/internal/helm/chart/builder_local_test.go
+++ b/internal/helm/chart/builder_local_test.go
@@ -67,7 +67,7 @@ func TestLocalBuilder_Build(t *testing.T) {
 		reference           Reference
 		buildOpts           BuildOptions
 		valuesFiles         []helmchart.File
-		repositories        map[string]*repository.ChartRepository
+		repositories        map[string]repository.Downloader
 		dependentChartPaths []string
 		wantValues          chartutil.Values
 		wantVersion         string
@@ -146,7 +146,7 @@ fullnameOverride: "full-foo-name-override"`),
 		{
 			name:      "chart with dependencies",
 			reference: LocalReference{Path: "../testdata/charts/helmchartwithdeps"},
-			repositories: map[string]*repository.ChartRepository{
+			repositories: map[string]repository.Downloader{
 				"https://grafana.github.io/helm-charts/": mockRepo(),
 			},
 			dependentChartPaths: []string{"./../testdata/charts/helmchart"},
@@ -165,7 +165,7 @@ fullnameOverride: "full-foo-name-override"`),
 		{
 			name:      "v1 chart with dependencies",
 			reference: LocalReference{Path: "../testdata/charts/helmchartwithdeps-v1"},
-			repositories: map[string]*repository.ChartRepository{
+			repositories: map[string]repository.Downloader{
 				"https://grafana.github.io/helm-charts/": mockRepo(),
 			},
 			dependentChartPaths: []string{"../testdata/charts/helmchart-v1"},

--- a/internal/helm/chart/builder_remote.go
+++ b/internal/helm/chart/builder_remote.go
@@ -34,24 +34,16 @@ import (
 
 	"github.com/fluxcd/source-controller/internal/fs"
 	"github.com/fluxcd/source-controller/internal/helm/chart/secureloader"
+	"github.com/fluxcd/source-controller/internal/helm/repository"
 )
 
-// Repository is a repository.ChartRepository or a repository.OCIChartRepository.
-// It is used to download a chart from a remote Helm repository or OCI registry.
-type Repository interface {
-	// GetChartVersion returns the repo.ChartVersion for the given name and version.
-	GetChartVersion(name, version string) (*repo.ChartVersion, error)
-	// GetChartVersion returns a chart.ChartVersion from the remote repository.
-	DownloadChart(chart *repo.ChartVersion) (*bytes.Buffer, error)
-}
-
 type remoteChartBuilder struct {
-	remote Repository
+	remote repository.Downloader
 }
 
 // NewRemoteBuilder returns a Builder capable of building a Helm
-// chart with a RemoteReference in the given repository.ChartRepository.
-func NewRemoteBuilder(repository Repository) Builder {
+// chart with a RemoteReference in the given repository.Downloader.
+func NewRemoteBuilder(repository repository.Downloader) Builder {
 	return &remoteChartBuilder{
 		remote: repository,
 	}
@@ -132,7 +124,7 @@ func (b *remoteChartBuilder) Build(_ context.Context, ref Reference, p string, o
 	return result, nil
 }
 
-func (b *remoteChartBuilder) downloadFromRepository(remote Repository, remoteRef RemoteReference, opts BuildOptions) (*bytes.Buffer, *Build, error) {
+func (b *remoteChartBuilder) downloadFromRepository(remote repository.Downloader, remoteRef RemoteReference, opts BuildOptions) (*bytes.Buffer, *Build, error) {
 	// Get the current version for the RemoteReference
 	cv, err := remote.GetChartVersion(remoteRef.Name, remoteRef.Version)
 	if err != nil {

--- a/internal/helm/chart/builder_remote.go
+++ b/internal/helm/chart/builder_remote.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/fluxcd/source-controller/internal/helm/repository"
 	helmchart "helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/repo"
@@ -37,22 +36,22 @@ import (
 	"github.com/fluxcd/source-controller/internal/helm/chart/secureloader"
 )
 
-// Remote is a repository.ChartRepository or a repository.OCIChartRepository.
+// Repository is a repository.ChartRepository or a repository.OCIChartRepository.
 // It is used to download a chart from a remote Helm repository or OCI registry.
-type Remote interface {
-	// GetChart returns a chart.Chart from the remote repository.
-	Get(name, version string) (*repo.ChartVersion, error)
+type Repository interface {
+	// GetChartVersion returns the repo.ChartVersion for the given name and version.
+	GetChartVersion(name, version string) (*repo.ChartVersion, error)
 	// GetChartVersion returns a chart.ChartVersion from the remote repository.
 	DownloadChart(chart *repo.ChartVersion) (*bytes.Buffer, error)
 }
 
 type remoteChartBuilder struct {
-	remote Remote
+	remote Repository
 }
 
 // NewRemoteBuilder returns a Builder capable of building a Helm
 // chart with a RemoteReference in the given repository.ChartRepository.
-func NewRemoteBuilder(repository Remote) Builder {
+func NewRemoteBuilder(repository Repository) Builder {
 	return &remoteChartBuilder{
 		remote: repository,
 	}
@@ -83,31 +82,12 @@ func (b *remoteChartBuilder) Build(_ context.Context, ref Reference, p string, o
 		return nil, &BuildError{Reason: ErrChartReference, Err: err}
 	}
 
-	var (
-		res *bytes.Buffer
-		err error
-	)
-
-	result := &Build{}
-	switch b.remote.(type) {
-	case *repository.ChartRepository:
-		res, err = b.downloadFromRepository(b.remote.(*repository.ChartRepository), remoteRef, result, opts)
-		if err != nil {
-			return nil, &BuildError{Reason: ErrChartPull, Err: err}
-		}
-		if res == nil {
-			return result, nil
-		}
-	case *repository.OCIChartRepository:
-		res, err = b.downloadFromOCIRepository(b.remote.(*repository.OCIChartRepository), remoteRef, result, opts)
-		if err != nil {
-			return nil, &BuildError{Reason: ErrChartPull, Err: err}
-		}
-		if res == nil {
-			return result, nil
-		}
-	default:
-		return nil, &BuildError{Reason: ErrChartReference, Err: fmt.Errorf("unsupported remote type %T", b.remote)}
+	res, result, err := b.downloadFromRepository(b.remote, remoteRef, opts)
+	if err != nil {
+		return nil, &BuildError{Reason: ErrChartPull, Err: err}
+	}
+	if res == nil {
+		return result, nil
 	}
 
 	requiresPackaging := len(opts.GetValuesFiles()) != 0 || opts.VersionMetadata != ""
@@ -152,66 +132,31 @@ func (b *remoteChartBuilder) Build(_ context.Context, ref Reference, p string, o
 	return result, nil
 }
 
-func (b *remoteChartBuilder) downloadFromOCIRepository(remote *repository.OCIChartRepository, remoteRef RemoteReference, buildResult *Build, opts BuildOptions) (*bytes.Buffer, error) {
-	cv, err := remote.Get(remoteRef.Name, remoteRef.Version)
-	if err != nil {
-		err = fmt.Errorf("failed to get chart version for remote reference: %w", err)
-		return nil, &BuildError{Reason: ErrChartPull, Err: err}
-	}
-
-	result, shouldReturn, err := generateBuildResult(cv, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	if shouldReturn {
-		*buildResult = *result
-		return nil, nil
-	}
-
-	// Download the package for the resolved version
-	res, err := remote.DownloadChart(cv)
-	if err != nil {
-		err = fmt.Errorf("failed to download chart for remote reference: %w", err)
-		return nil, &BuildError{Reason: ErrChartPull, Err: err}
-	}
-
-	*buildResult = *result
-
-	return res, nil
-}
-
-func (b *remoteChartBuilder) downloadFromRepository(remote *repository.ChartRepository, remoteRef RemoteReference, buildResult *Build, opts BuildOptions) (*bytes.Buffer, error) {
-	if err := remote.StrategicallyLoadIndex(); err != nil {
-		err = fmt.Errorf("could not load repository index for remote chart reference: %w", err)
-		return nil, &BuildError{Reason: ErrChartPull, Err: err}
-	}
-
+func (b *remoteChartBuilder) downloadFromRepository(remote Repository, remoteRef RemoteReference, opts BuildOptions) (*bytes.Buffer, *Build, error) {
 	// Get the current version for the RemoteReference
-	cv, err := remote.Get(remoteRef.Name, remoteRef.Version)
+	cv, err := remote.GetChartVersion(remoteRef.Name, remoteRef.Version)
 	if err != nil {
 		err = fmt.Errorf("failed to get chart version for remote reference: %w", err)
-		return nil, &BuildError{Reason: ErrChartReference, Err: err}
+		return nil, nil, &BuildError{Reason: ErrChartReference, Err: err}
 	}
 
 	result, shouldReturn, err := generateBuildResult(cv, opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	*buildResult = *result
 
 	if shouldReturn {
-		return nil, nil
+		return nil, result, nil
 	}
 
 	// Download the package for the resolved version
 	res, err := remote.DownloadChart(cv)
 	if err != nil {
 		err = fmt.Errorf("failed to download chart for remote reference: %w", err)
-		return nil, &BuildError{Reason: ErrChartPull, Err: err}
+		return nil, nil, &BuildError{Reason: ErrChartPull, Err: err}
 	}
 
-	return res, nil
+	return res, result, nil
 }
 
 // generateBuildResult returns a Build object generated from the given chart version and build options. It also returns

--- a/internal/helm/chart/dependency_manager.go
+++ b/internal/helm/chart/dependency_manager.go
@@ -240,7 +240,7 @@ func (dm *DependencyManager) addRemoteDependency(chart *chartWithLock, dep *helm
 		return fmt.Errorf("failed to load index for '%s': %w", dep.Name, err)
 	}
 
-	ver, err := repo.Get(dep.Name, dep.Version)
+	ver, err := repo.GetChartVersion(dep.Name, dep.Version)
 	if err != nil {
 		return err
 	}

--- a/internal/helm/registry/client.go
+++ b/internal/helm/registry/client.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"helm.sh/helm/v3/pkg/registry"
+	"k8s.io/apimachinery/pkg/util/errors"
 )
 
 // ClientGenerator generates a registry client and a temporary credential file.
@@ -30,16 +31,25 @@ func ClientGenerator(isLogin bool) (*registry.Client, string, error) {
 	if isLogin {
 		// create a temporary file to store the credentials
 		// this is needed because otherwise the credentials are stored in ~/.docker/config.json.
-		credentialFile, err := os.CreateTemp("", "credentials")
+		credentialsFile, err := os.CreateTemp("", "credentials")
 		if err != nil {
 			return nil, "", err
 		}
 
-		rClient, err := registry.NewClient(registry.ClientOptWriter(io.Discard), registry.ClientOptCredentialsFile(credentialFile.Name()))
+		var errs []error
+		rClient, err := registry.NewClient(registry.ClientOptWriter(io.Discard), registry.ClientOptCredentialsFile(credentialsFile.Name()))
 		if err != nil {
-			return nil, "", err
+			errs = append(errs, err)
+			// attempt to delete the temporary file
+			if credentialsFile != nil {
+				err := os.Remove(credentialsFile.Name())
+				if err != nil {
+					errs = append(errs, err)
+				}
+			}
+			return nil, "", errors.NewAggregate(errs)
 		}
-		return rClient, credentialFile.Name(), nil
+		return rClient, credentialsFile.Name(), nil
 	}
 
 	rClient, err := registry.NewClient(registry.ClientOptWriter(io.Discard))

--- a/internal/helm/repository/chart_repository.go
+++ b/internal/helm/repository/chart_repository.go
@@ -150,10 +150,15 @@ func newChartRepository() *ChartRepository {
 	}
 }
 
-// Get returns the repo.ChartVersion for the given name, the version is expected
+// GetChartVersion returns the repo.ChartVersion for the given name, the version is expected
 // to be a semver.Constraints compatible string. If version is empty, the latest
 // stable version will be returned and prerelease versions will be ignored.
-func (r *ChartRepository) Get(name, ver string) (*repo.ChartVersion, error) {
+func (r *ChartRepository) GetChartVersion(name, ver string) (*repo.ChartVersion, error) {
+	// See if we already have the index in cache or try to load it.
+	if err := r.StrategicallyLoadIndex(); err != nil {
+		return nil, err
+	}
+
 	r.RLock()
 	defer r.RUnlock()
 
@@ -469,6 +474,22 @@ func (r *ChartRepository) Unload() {
 	r.Lock()
 	defer r.Unlock()
 	r.Index = nil
+}
+
+// Clear cache the index in memory before unloading it.
+// It cleans up temporary files and directories created by the repository.
+func (r *ChartRepository) Clear() (errs []error) {
+	if err := r.CacheIndexInMemory(); err != nil {
+		errs = append(errs, err)
+	}
+
+	r.Unload()
+
+	if err := r.RemoveCache(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return
 }
 
 // SetMemCache sets the cache to use for this repository.

--- a/internal/helm/repository/chart_repository.go
+++ b/internal/helm/repository/chart_repository.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/repo"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/yaml"
 
 	"github.com/fluxcd/pkg/version"
@@ -476,9 +477,10 @@ func (r *ChartRepository) Unload() {
 	r.Index = nil
 }
 
-// Clear cache the index in memory before unloading it.
+// Clear caches the index in memory before unloading it.
 // It cleans up temporary files and directories created by the repository.
-func (r *ChartRepository) Clear() (errs []error) {
+func (r *ChartRepository) Clear() error {
+	var errs []error
 	if err := r.CacheIndexInMemory(); err != nil {
 		errs = append(errs, err)
 	}
@@ -489,7 +491,7 @@ func (r *ChartRepository) Clear() (errs []error) {
 		errs = append(errs, err)
 	}
 
-	return
+	return kerrors.NewAggregate(errs)
 }
 
 // SetMemCache sets the cache to use for this repository.

--- a/internal/helm/repository/chart_repository_test.go
+++ b/internal/helm/repository/chart_repository_test.go
@@ -181,7 +181,7 @@ func TestChartRepository_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			cv, err := r.Get(tt.chartName, tt.chartVersion)
+			cv, err := r.GetChartVersion(tt.chartName, tt.chartVersion)
 			if tt.wantErr != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tt.wantErr))

--- a/internal/helm/repository/oci_chart_repository.go
+++ b/internal/helm/repository/oci_chart_repository.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/url"
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -60,6 +61,8 @@ type OCIChartRepository struct {
 
 	// RegistryClient is a client to use while downloading tags or charts from a registry.
 	RegistryClient RegistryClient
+	// credentialsFile is a temporary credentials file to use while downloading tags or charts from a registry.
+	credentialsFile string
 }
 
 // OCIChartRepositoryOption is a function that can be passed to NewOCIChartRepository
@@ -90,6 +93,14 @@ func WithOCIGetter(providers getter.Providers) OCIChartRepositoryOption {
 func WithOCIGetterOptions(getterOpts []getter.Option) OCIChartRepositoryOption {
 	return func(r *OCIChartRepository) error {
 		r.Options = getterOpts
+		return nil
+	}
+}
+
+// WithCredentialsFile returns a ChartRepositoryOption that will set the credentials file
+func WithCredentialsFile(credentialsFile string) OCIChartRepositoryOption {
+	return func(r *OCIChartRepository) error {
+		r.credentialsFile = credentialsFile
 		return nil
 	}
 }
@@ -126,7 +137,7 @@ func (r *OCIChartRepository) GetChartVersion(name, ver string) (*repo.ChartVersi
 	cpURL.Path = path.Join(cpURL.Path, name)
 	cvs, err := r.getTags(cpURL.String())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not get tags for %q: %s", name, err)
 	}
 
 	if len(cvs) == 0 {
@@ -153,7 +164,7 @@ func (r *OCIChartRepository) getTags(ref string) ([]string, error) {
 	// Retrieve list of repository tags
 	tags, err := r.RegistryClient.Tags(strings.TrimPrefix(ref, fmt.Sprintf("%s://", registry.OCIScheme)))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not fetch tags for %q: %s", ref, err)
 	}
 	if len(tags) == 0 {
 		return nil, fmt.Errorf("unable to locate any tags in provided repository: %s", ref)
@@ -203,6 +214,23 @@ func (r *OCIChartRepository) Logout() error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// HasCredentials returns true if the OCIChartRepository has credentials.
+func (r *OCIChartRepository) HasCredentials() bool {
+	return r.credentialsFile != ""
+}
+
+// Clear deletes the OCI registry credentials file.
+func (r *OCIChartRepository) Clear() error {
+	// clean the credentials file if it exists
+	if r.credentialsFile != "" {
+		if err := os.Remove(r.credentialsFile); err != nil {
+			return err
+		}
+	}
+	r.credentialsFile = ""
 	return nil
 }
 

--- a/internal/helm/repository/oci_chart_repository.go
+++ b/internal/helm/repository/oci_chart_repository.go
@@ -115,11 +115,11 @@ func NewOCIChartRepository(repositoryURL string, chartRepoOpts ...OCIChartReposi
 	return r, nil
 }
 
-// Get returns the repo.ChartVersion for the given name, the version is expected
+// GetChartVersion returns the repo.ChartVersion for the given name, the version is expected
 // to be a semver.Constraints compatible string. If version is empty, the latest
 // stable version will be returned and prerelease versions will be ignored.
 // adapted from https://github.com/helm/helm/blob/49819b4ef782e80b0c7f78c30bd76b51ebb56dc8/pkg/downloader/chart_downloader.go#L162
-func (r *OCIChartRepository) Get(name, ver string) (*repo.ChartVersion, error) {
+func (r *OCIChartRepository) GetChartVersion(name, ver string) (*repo.ChartVersion, error) {
 	// Find chart versions matching the given name.
 	// Either in an index file or from a registry.
 	cpURL := r.URL

--- a/internal/helm/repository/oci_chart_repository_test.go
+++ b/internal/helm/repository/oci_chart_repository_test.go
@@ -183,7 +183,7 @@ func TestOCIChartRepository_Get(t *testing.T) {
 			g.Expect(r).ToNot(BeNil())
 
 			chart := "podinfo"
-			cv, err := r.Get(chart, tc.version)
+			cv, err := r.GetChartVersion(chart, tc.version)
 			if tc.expectedErr != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(Equal(tc.expectedErr))

--- a/internal/helm/repository/repository.go
+++ b/internal/helm/repository/repository.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repository
+
+import (
+	"bytes"
+
+	"helm.sh/helm/v3/pkg/repo"
+)
+
+// Downloader is used to download a chart from a remote Helm repository or OCI Helm repository.
+type Downloader interface {
+	// GetChartVersion returns the repo.ChartVersion for the given name and version
+	// from the remote Helm repository or OCI Helm repository.
+	GetChartVersion(name, version string) (*repo.ChartVersion, error)
+	// DownloadChart downloads a chart from the remote Helm repository or OCI Helm repository.
+	DownloadChart(chart *repo.ChartVersion) (*bytes.Buffer, error)
+	// Clear removes all temporary files created by the downloader, caching the files if the cache is configured,
+	// and calling garbage collector to remove unused files.
+	Clear() error
+}

--- a/internal/helm/repository/utils.go
+++ b/internal/helm/repository/utils.go
@@ -18,13 +18,20 @@ package repository
 
 import (
 	"strings"
+
+	helmreg "helm.sh/helm/v3/pkg/registry"
 )
 
-// NormalizeURL normalizes a ChartRepository URL by ensuring it ends with a
-// single "/".
-func NormalizeURL(url string) string {
-	if url != "" {
-		return strings.TrimRight(url, "/") + "/"
+// NormalizeURL normalizes a ChartRepository URL by its scheme.
+func NormalizeURL(repositoryURL string) string {
+	if repositoryURL == "" {
+		return ""
 	}
-	return url
+
+	if strings.Contains(repositoryURL, helmreg.OCIScheme) {
+		return strings.TrimRight(repositoryURL, "/")
+	}
+
+	return strings.TrimRight(repositoryURL, "/") + "/"
+
 }

--- a/internal/helm/repository/utils_test.go
+++ b/internal/helm/repository/utils_test.go
@@ -48,6 +48,16 @@ func TestNormalizeURL(t *testing.T) {
 			url:  "",
 			want: "",
 		},
+		{
+			name: "oci with slash",
+			url:  "oci://example.com/",
+			want: "oci://example.com",
+		},
+		{
+			name: "oci double slash",
+			url:  "oci://example.com//",
+			want: "oci://example.com",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
fixes #722 

### new feature
When using a `gitrepository` source, it is possible to declare Umbrella Charts with a `dependencies` section like:

```yaml
dependencies:
  - name: helmchart
    version: "0.1.0"
    repository: "file://../helmchart"
  - name: my-chart
    version: "1.1.0"
    repository: "https://my-helm-repository/helm-charts"
```

A depended helm chart can be resolved from a local path with `file://` prefix or from a `helm repository` with `https://` prefix in the repository field.

This pull request adds a new option for resolving depended helm chart, OCI helm repositories. If implemented, user will be able to declare three type of repositories like:

```yaml
dependencies:
  - name: helmchart
    version: "0.1.0"
    repository: "file://../helmchart"
  - name: my-chart
    version: "1.1.0"
    repository: "https://my-helm-repository/helm-charts"
  - name: my-oci-chart
    version: "1.1.0"
    repository: "oci://my-oci-helm-repository/helm-charts"
```

### code changes

Introduces a new interface that permits downloading Helm Charts from Helm HTTP/S repositories and Helm OCi repositories.

```go
// Downloader is used to download a chart from a remote Helm repository or OCI registry.
type Downloader interface {
	// GetChartVersion returns the repo.ChartVersion for the given name and version
	// from the remote repository.ChartRepository.
	GetChartVersion(name, version string) (*repo.ChartVersion, error)
	// DownloadChart downloads a chart from the remote Helm repository or OCI registry.
	DownloadChart(chart *repo.ChartVersion) (*bytes.Buffer, error)
	Clear() error
}
```

The dependency manager is refactored to accept those interfaces instead of a repository `struct`. It enables using both repository types to resolve chart dependencies.

The remote builder has been refactored as part of this work.