### PR TITLE
libgit2: add contextual logging to subtransports

### DIFF
--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -246,7 +247,13 @@ func (r *BucketReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, opts Buc
 
 func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	start := time.Now()
-	log := ctrl.LoggerFrom(ctx)
+	log := ctrl.LoggerFrom(ctx).
+		// Sets a reconcile ID to correlate logs from all suboperations.
+		WithValues("reconcileID", uuid.NewUUID())
+
+	// logger will be associated to the new context that is
+	// returned from ctrl.LoggerInto.
+	ctx = ctrl.LoggerInto(ctx, log)
 
 	// Fetch the Bucket
 	obj := &sourcev1.Bucket{}

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -29,6 +29,7 @@ import (
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/fluxcd/pkg/runtime/logger"
+	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -159,7 +160,13 @@ func (r *GitRepositoryReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, o
 
 func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	start := time.Now()
-	log := ctrl.LoggerFrom(ctx)
+	log := ctrl.LoggerFrom(ctx).
+		// Sets a correlation ID for all transport level logs.
+		WithValues("cid", uuid.New())
+
+	// logger will be associated to the new context that is
+	// returned from ctrl.LoggerInto.
+	ctx = ctrl.LoggerInto(ctx, log)
 
 	// Fetch the GitRepository
 	obj := &sourcev1.GitRepository{}

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -29,10 +29,10 @@ import (
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/fluxcd/pkg/runtime/logger"
-	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -161,8 +161,8 @@ func (r *GitRepositoryReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, o
 func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	start := time.Now()
 	log := ctrl.LoggerFrom(ctx).
-		// Sets a correlation ID for all transport level logs.
-		WithValues("cid", uuid.New())
+		// Sets a reconcile ID to correlate logs from all suboperations.
+		WithValues("reconcileID", uuid.NewUUID())
 
 	// logger will be associated to the new context that is
 	// returned from ctrl.LoggerInto.

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -180,7 +181,13 @@ func (r *HelmChartReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, opts 
 
 func (r *HelmChartReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	start := time.Now()
-	log := ctrl.LoggerFrom(ctx)
+	log := ctrl.LoggerFrom(ctx).
+		// Sets a reconcile ID to correlate logs from all suboperations.
+		WithValues("reconcileID", uuid.NewUUID())
+
+	// logger will be associated to the new context that is
+	// returned from ctrl.LoggerInto.
+	ctx = ctrl.LoggerInto(ctx, log)
 
 	// Fetch the HelmChart
 	obj := &sourcev1.HelmChart{}

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -142,7 +143,13 @@ func (r *HelmRepositoryReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, 
 
 func (r *HelmRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	start := time.Now()
-	log := ctrl.LoggerFrom(ctx)
+	log := ctrl.LoggerFrom(ctx).
+		// Sets a reconcile ID to correlate logs from all suboperations.
+		WithValues("reconcileID", uuid.NewUUID())
+
+	// logger will be associated to the new context that is
+	// returned from ctrl.LoggerInto.
+	ctx = ctrl.LoggerInto(ctx, log)
 
 	// Fetch the HelmRepository
 	obj := &sourcev1.HelmRepository{}

--- a/controllers/helmrepository_controller_oci.go
+++ b/controllers/helmrepository_controller_oci.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -107,7 +108,13 @@ func (r *HelmRepositoryOCIReconciler) SetupWithManagerAndOptions(mgr ctrl.Manage
 
 func (r *HelmRepositoryOCIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	start := time.Now()
-	log := ctrl.LoggerFrom(ctx)
+	log := ctrl.LoggerFrom(ctx).
+		// Sets a reconcile ID to correlate logs from all suboperations.
+		WithValues("reconcileID", uuid.NewUUID())
+
+	// logger will be associated to the new context that is
+	// returned from ctrl.LoggerInto.
+	ctx = ctrl.LoggerInto(ctx, log)
 
 	// Fetch the HelmRepository
 	obj := &sourcev1.HelmRepository{}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -40,7 +40,6 @@ import (
 	feathelper "github.com/fluxcd/pkg/runtime/features"
 	"github.com/fluxcd/pkg/runtime/testenv"
 	"github.com/fluxcd/pkg/testserver"
-	"github.com/go-logr/logr"
 	"github.com/phayes/freeport"
 
 	"github.com/distribution/distribution/v3/configuration"
@@ -209,7 +208,7 @@ func TestMain(m *testing.M) {
 
 	fg := feathelper.FeatureGates{}
 	fg.SupportedFeatures(features.FeatureGates())
-	managed.InitManagedTransport(logr.Discard())
+	managed.InitManagedTransport()
 
 	if err := (&GitRepositoryReconciler{
 		Client:        testEnv,

--- a/main.go
+++ b/main.go
@@ -311,7 +311,7 @@ func main() {
 	}()
 
 	if enabled, _ := features.Enabled(features.GitManagedTransport); enabled {
-		managed.InitManagedTransport(ctrl.Log.WithName("managed-transport"))
+		managed.InitManagedTransport()
 	} else {
 		if optimize, _ := feathelper.Enabled(features.OptimizedGitClones); optimize {
 			features.Disable(features.OptimizedGitClones)

--- a/pkg/git/libgit2/managed/http_test.go
+++ b/pkg/git/libgit2/managed/http_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/fluxcd/pkg/gittestserver"
 	"github.com/fluxcd/source-controller/pkg/git"
-	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 
 	git2go "github.com/libgit2/git2go/v33"
@@ -170,7 +169,7 @@ func TestHTTPManagedTransport_E2E(t *testing.T) {
 	defer server.StopHTTP()
 
 	// Force managed transport to be enabled
-	InitManagedTransport(logr.Discard())
+	InitManagedTransport()
 
 	repoPath := "test.git"
 	err = server.InitRepo("../../testdata/git/repo", git.DefaultBranch, repoPath)
@@ -253,7 +252,7 @@ func TestHTTPManagedTransport_HandleRedirect(t *testing.T) {
 	}
 
 	// Force managed transport to be enabled
-	InitManagedTransport(logr.Discard())
+	InitManagedTransport()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/git/libgit2/managed/init.go
+++ b/pkg/git/libgit2/managed/init.go
@@ -19,9 +19,6 @@ package managed
 import (
 	"sync"
 	"time"
-
-	"github.com/fluxcd/pkg/runtime/logger"
-	"github.com/go-logr/logr"
 )
 
 var (
@@ -38,9 +35,7 @@ var (
 	// handshake, put/get).
 	fullHttpClientTimeOut time.Duration = 10 * time.Minute
 
-	debugLog logr.Logger
-	traceLog logr.Logger
-	enabled  bool
+	enabled bool
 )
 
 // Enabled defines whether the use of Managed Transport is enabled which
@@ -63,14 +58,10 @@ func Enabled() bool {
 //
 // This function will only register managed transports once, subsequent calls
 // leads to no-op.
-func InitManagedTransport(log logr.Logger) error {
+func InitManagedTransport() error {
 	var err error
 
 	once.Do(func() {
-		log.Info("Initializing managed transport")
-		debugLog = log.V(logger.DebugLevel)
-		traceLog = log.V(logger.TraceLevel)
-
 		if err = registerManagedHTTP(); err != nil {
 			return
 		}

--- a/pkg/git/libgit2/managed/ssh_test.go
+++ b/pkg/git/libgit2/managed/ssh_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/fluxcd/pkg/ssh"
 	"github.com/fluxcd/source-controller/pkg/git"
-	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 
 	"github.com/fluxcd/pkg/gittestserver"
@@ -89,7 +88,7 @@ func TestSSHManagedTransport_E2E(t *testing.T) {
 		server.StartSSH()
 	}()
 	defer server.StopSSH()
-	InitManagedTransport(logr.Discard())
+	InitManagedTransport()
 
 	kp, err := ssh.NewEd25519Generator().Generate()
 	g.Expect(err).ToNot(HaveOccurred())

--- a/pkg/git/libgit2/managed_test.go
+++ b/pkg/git/libgit2/managed_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/fluxcd/gitkit"
 	"github.com/fluxcd/pkg/gittestserver"
 	"github.com/fluxcd/pkg/ssh"
-	"github.com/go-logr/logr"
 
 	feathelper "github.com/fluxcd/pkg/runtime/features"
 	. "github.com/onsi/gomega"
@@ -471,5 +470,5 @@ func getTransportOptionsURL(transport git.TransportType) string {
 func enableManagedTransport() {
 	fg := feathelper.FeatureGates{}
 	fg.SupportedFeatures(features.FeatureGates())
-	managed.InitManagedTransport(logr.Discard())
+	managed.InitManagedTransport()
 }

--- a/pkg/git/strategy/proxy/strategy_proxy_test.go
+++ b/pkg/git/strategy/proxy/strategy_proxy_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/elazarl/goproxy"
 	"github.com/fluxcd/pkg/gittestserver"
 	feathelper "github.com/fluxcd/pkg/runtime/features"
-	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 
 	"github.com/fluxcd/source-controller/internal/features"
@@ -50,7 +49,7 @@ func TestCheckoutStrategyForImplementation_Proxied(t *testing.T) {
 	fg := feathelper.FeatureGates{}
 	fg.SupportedFeatures(features.FeatureGates())
 
-	managed.InitManagedTransport(logr.Discard())
+	managed.InitManagedTransport()
 
 	type cleanupFunc func()
 


### PR DESCRIPTION
Debugging connection issues can be extremely difficult, even more so at scale or when concurrent connections are required to trigger specific issues.

Changes:
- Add a correlation identifier (`reconcileID`) for each reconciliation, which allows for greater traceability when going through all the reconciliation operations - including at transport level.
- Add transportType to segregate HTTP and SSH transport logging.
- SSH operations are now enriched with `addr` containing server address, and HTTP `url`.

Example of stdout output when grepping by a specific TransportID:
```
{"level":"Level(-2)","ts":"2022-06-13T07:27:09.781+0100","logger":"controller.gitrepository","msg":"creating new ssh session","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"ssh-ed25519-bitbucket","namespace":"flux-system","cid":"a44976a7-9461-4af7-88f4-b3d481fa5ca7","transportType":"ssh","addr":"bitbucket.org:22"}
{"level":"Level(-2)","ts":"2022-06-13T07:27:09.863+0100","logger":"controller.gitrepository","msg":"run on remote","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"ssh-ed25519-bitbucket","namespace":"flux-system","cid":"a44976a7-9461-4af7-88f4-b3d481fa5ca7","transportType":"ssh","addr":"bitbucket.org:22","cmd":"git-upload-pack '/pjbgf/flux-testing.git'"}
{"level":"Level(-2)","ts":"2022-06-13T07:27:10.074+0100","logger":"controller.gitrepository","msg":"sshSmartSubtransport.Close()","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"ssh-ed25519-bitbucket","namespace":"flux-system","cid":"a44976a7-9461-4af7-88f4-b3d481fa5ca7","transportType":"ssh","addr":"bitbucket.org:22"}
{"level":"Level(-2)","ts":"2022-06-13T07:27:10.074+0100","logger":"controller.gitrepository","msg":"session.Close()","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"ssh-ed25519-bitbucket","namespace":"flux-system","cid":"a44976a7-9461-4af7-88f4-b3d481fa5ca7","transportType":"ssh","addr":"bitbucket.org:22"}
{"level":"Level(-2)","ts":"2022-06-13T07:27:10.074+0100","logger":"controller.gitrepository","msg":"close client","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"ssh-ed25519-bitbucket","namespace":"flux-system","cid":"a44976a7-9461-4af7-88f4-b3d481fa5ca7","transportType":"ssh","addr":"bitbucket.org:22"}
{"level":"Level(-2)","ts":"2022-06-13T07:27:10.074+0100","logger":"controller.gitrepository","msg":"sshSmartSubtransport.Close()","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"ssh-ed25519-bitbucket","namespace":"flux-system","cid":"a44976a7-9461-4af7-88f4-b3d481fa5ca7","transportType":"ssh","addr":"bitbucket.org:22"}
{"level":"Level(-2)","ts":"2022-06-13T07:27:10.074+0100","logger":"controller.gitrepository","msg":"close client","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"ssh-ed25519-bitbucket","namespace":"flux-system","cid":"a44976a7-9461-4af7-88f4-b3d481fa5ca7","transportType":"ssh","addr":"bitbucket.org:22"}
{"level":"info","ts":"2022-06-13T07:27:10.075+0100","logger":"controller.gitrepository","msg":"no changes since last reconcilation: observed revision 'main/d35781accf1ea8078de18e154622486042bca4cc'","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"ssh-ed25519-bitbucket","namespace":"flux-system","cid":"a44976a7-9461-4af7-88f4-b3d481fa5ca7"}
{"level":"info","ts":"2022-06-13T07:27:10.075+0100","msg":"no changes since last reconcilation: observed revision 'main/d35781accf1ea8078de18e154622486042bca4cc'","name":"ssh-ed25519-bitbucket","namespace":"flux-system","reconciler kind":"GitRepository","reason":"GitOperationSucceeded","annotations":null}
{"level":"Level(-2)","ts":"2022-06-13T07:27:10.080+0100","logger":"controller.gitrepository","msg":"sshSmartSubtransport.Close()","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"ssh-ed25519-bitbucket","namespace":"flux-system","cid":"a44976a7-9461-4af7-88f4-b3d481fa5ca7","transportType":"ssh","addr":"bitbucket.org:22"}
{"level":"Level(-2)","ts":"2022-06-13T07:27:10.080+0100","logger":"controller.gitrepository","msg":"close client","reconciler group":"source.toolkit.fluxcd.io","reconciler kind":"GitRepository","name":"ssh-ed25519-bitbucket","namespace":"flux-system","cid":"a44976a7-9461-4af7-88f4-b3d481fa5ca7","transportType":"ssh","addr":"bitbucket.org:22"}
```
