### PR TITLE
libgit2: refactor feature managed transport usage

### DIFF
--- a/api/v1beta2/condition_types.go
+++ b/api/v1beta2/condition_types.go
@@ -100,4 +100,8 @@ const (
 
 	// CacheOperationFailedReason signals a failure in cache operation.
 	CacheOperationFailedReason string = "CacheOperationFailed"
+
+	// ControllerMisbehaviorReason signals a failure caused by misbehavior/
+	// UB of the controller.
+	ControllerMisbehaviorReason string = "ControllerMisbehavior"
 )

--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -499,10 +499,11 @@ func TestGitRepositoryReconciler_reconcileSource_authStrategy(t *testing.T) {
 			}
 
 			r := &GitRepositoryReconciler{
-				Client:        builder.Build(),
-				EventRecorder: record.NewFakeRecorder(32),
-				Storage:       testStorage,
-				features:      features.FeatureGates(),
+				Client:                     builder.Build(),
+				EventRecorder:              record.NewFakeRecorder(32),
+				Storage:                    testStorage,
+				ManagedTransportRegistered: true,
+				features:                   features.FeatureGates(),
 			}
 
 			for _, i := range testGitImplementations {
@@ -697,10 +698,11 @@ func TestGitRepositoryReconciler_reconcileSource_checkoutStrategy(t *testing.T) 
 	}
 
 	r := &GitRepositoryReconciler{
-		Client:        fakeclient.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
-		EventRecorder: record.NewFakeRecorder(32),
-		Storage:       testStorage,
-		features:      features.FeatureGates(),
+		Client:                     fakeclient.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
+		EventRecorder:              record.NewFakeRecorder(32),
+		Storage:                    testStorage,
+		ManagedTransportRegistered: true,
+		features:                   features.FeatureGates(),
 	}
 
 	for _, tt := range tests {
@@ -922,9 +924,10 @@ func TestGitRepositoryReconciler_reconcileArtifact(t *testing.T) {
 			resetChmod(tt.dir, 0o755, 0o644)
 
 			r := &GitRepositoryReconciler{
-				EventRecorder: record.NewFakeRecorder(32),
-				Storage:       testStorage,
-				features:      features.FeatureGates(),
+				EventRecorder:              record.NewFakeRecorder(32),
+				Storage:                    testStorage,
+				ManagedTransportRegistered: true,
+				features:                   features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1065,11 +1068,12 @@ func TestGitRepositoryReconciler_reconcileInclude(t *testing.T) {
 			}
 
 			r := &GitRepositoryReconciler{
-				Client:            builder.Build(),
-				EventRecorder:     record.NewFakeRecorder(32),
-				Storage:           storage,
-				requeueDependency: dependencyInterval,
-				features:          features.FeatureGates(),
+				Client:                     builder.Build(),
+				EventRecorder:              record.NewFakeRecorder(32),
+				Storage:                    storage,
+				ManagedTransportRegistered: true,
+				requeueDependency:          dependencyInterval,
+				features:                   features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1237,9 +1241,10 @@ func TestGitRepositoryReconciler_reconcileStorage(t *testing.T) {
 			}()
 
 			r := &GitRepositoryReconciler{
-				EventRecorder: record.NewFakeRecorder(32),
-				Storage:       testStorage,
-				features:      features.FeatureGates(),
+				EventRecorder:              record.NewFakeRecorder(32),
+				Storage:                    testStorage,
+				ManagedTransportRegistered: true,
+				features:                   features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1279,9 +1284,10 @@ func TestGitRepositoryReconciler_reconcileDelete(t *testing.T) {
 	g := NewWithT(t)
 
 	r := &GitRepositoryReconciler{
-		EventRecorder: record.NewFakeRecorder(32),
-		Storage:       testStorage,
-		features:      features.FeatureGates(),
+		EventRecorder:              record.NewFakeRecorder(32),
+		Storage:                    testStorage,
+		ManagedTransportRegistered: true,
+		features:                   features.FeatureGates(),
 	}
 
 	obj := &sourcev1.GitRepository{
@@ -1417,9 +1423,10 @@ func TestGitRepositoryReconciler_verifyCommitSignature(t *testing.T) {
 			}
 
 			r := &GitRepositoryReconciler{
-				EventRecorder: record.NewFakeRecorder(32),
-				Client:        builder.Build(),
-				features:      features.FeatureGates(),
+				EventRecorder:              record.NewFakeRecorder(32),
+				Client:                     builder.Build(),
+				ManagedTransportRegistered: true,
+				features:                   features.FeatureGates(),
 			}
 
 			obj := &sourcev1.GitRepository{
@@ -1558,10 +1565,11 @@ func TestGitRepositoryReconciler_ConditionsUpdate(t *testing.T) {
 			builder := fakeclient.NewClientBuilder().WithScheme(testEnv.GetScheme()).WithObjects(obj)
 
 			r := &GitRepositoryReconciler{
-				Client:        builder.Build(),
-				EventRecorder: record.NewFakeRecorder(32),
-				Storage:       testStorage,
-				features:      features.FeatureGates(),
+				Client:                     builder.Build(),
+				EventRecorder:              record.NewFakeRecorder(32),
+				Storage:                    testStorage,
+				ManagedTransportRegistered: true,
+				features:                   features.FeatureGates(),
 			}
 
 			key := client.ObjectKeyFromObject(obj)
@@ -1925,8 +1933,9 @@ func TestGitRepositoryReconciler_notify(t *testing.T) {
 			}
 
 			reconciler := &GitRepositoryReconciler{
-				EventRecorder: recorder,
-				features:      features.FeatureGates(),
+				EventRecorder:              recorder,
+				ManagedTransportRegistered: true,
+				features:                   features.FeatureGates(),
 			}
 			reconciler.notify(ctx, oldObj, newObj, tt.commit, tt.res, tt.resErr)
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -190,21 +190,21 @@ func TestMain(m *testing.M) {
 	var err error
 	testServer, err = testserver.NewTempArtifactServer()
 	if err != nil {
-		panic(fmt.Sprintf("Failed to create a temporary storage server: %v", err))
+		panic(fmt.Sprintf("failed to create a temporary storage server: %v", err))
 	}
 	fmt.Println("Starting the test storage server")
 	testServer.Start()
 
 	testStorage, err = newTestStorage(testServer.HTTPServer)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to create a test storage: %v", err))
+		panic(fmt.Sprintf("failed to create a test storage: %v", err))
 	}
 
 	testMetricsH = controller.MustMakeMetrics(testEnv)
 
 	testRegistryServer, err = setupRegistryServer(ctx)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to create a test registry server: %v", err))
+		panic(fmt.Sprintf("failed to create a test registry server: %v", err))
 	}
 
 	fg := feathelper.FeatureGates{}
@@ -212,13 +212,14 @@ func TestMain(m *testing.M) {
 	managed.InitManagedTransport(logr.Discard())
 
 	if err := (&GitRepositoryReconciler{
-		Client:        testEnv,
-		EventRecorder: record.NewFakeRecorder(32),
-		Metrics:       testMetricsH,
-		Storage:       testStorage,
-		features:      features.FeatureGates(),
+		Client:                     testEnv,
+		EventRecorder:              record.NewFakeRecorder(32),
+		Metrics:                    testMetricsH,
+		Storage:                    testStorage,
+		ManagedTransportRegistered: true,
+		features:                   features.FeatureGates(),
 	}).SetupWithManager(testEnv); err != nil {
-		panic(fmt.Sprintf("Failed to start GitRepositoryReconciler: %v", err))
+		panic(fmt.Sprintf("failed to start GitRepositoryReconciler: %v", err))
 	}
 
 	if err := (&BucketReconciler{
@@ -227,7 +228,7 @@ func TestMain(m *testing.M) {
 		Metrics:       testMetricsH,
 		Storage:       testStorage,
 	}).SetupWithManager(testEnv); err != nil {
-		panic(fmt.Sprintf("Failed to start BucketReconciler: %v", err))
+		panic(fmt.Sprintf("failed to start BucketReconciler: %v", err))
 	}
 
 	if err := (&HelmRepositoryReconciler{
@@ -237,7 +238,7 @@ func TestMain(m *testing.M) {
 		Getters:       testGetters,
 		Storage:       testStorage,
 	}).SetupWithManager(testEnv); err != nil {
-		panic(fmt.Sprintf("Failed to start HelmRepositoryReconciler: %v", err))
+		panic(fmt.Sprintf("failed to start HelmRepositoryReconciler: %v", err))
 	}
 
 	if err = (&HelmRepositoryOCIReconciler{
@@ -247,7 +248,7 @@ func TestMain(m *testing.M) {
 		Getters:                 testGetters,
 		RegistryClientGenerator: registry.ClientGenerator,
 	}).SetupWithManager(testEnv); err != nil {
-		panic(fmt.Sprintf("Failed to start HelmRepositoryOCIReconciler: %v", err))
+		panic(fmt.Sprintf("failed to start HelmRepositoryOCIReconciler: %v", err))
 	}
 
 	testCache = cache.New(5, 1*time.Second)
@@ -262,13 +263,13 @@ func TestMain(m *testing.M) {
 		TTL:           1 * time.Second,
 		CacheRecorder: cacheRecorder,
 	}).SetupWithManager(testEnv); err != nil {
-		panic(fmt.Sprintf("Failed to start HelmRepositoryReconciler: %v", err))
+		panic(fmt.Sprintf("failed to start HelmRepositoryReconciler: %v", err))
 	}
 
 	go func() {
 		fmt.Println("Starting the test environment")
 		if err := testEnv.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the test environment manager: %v", err))
+			panic(fmt.Sprintf("failed to start the test environment manager: %v", err))
 		}
 	}()
 	<-testEnv.Manager.Elected()
@@ -277,17 +278,17 @@ func TestMain(m *testing.M) {
 
 	fmt.Println("Stopping the test environment")
 	if err := testEnv.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop the test environment: %v", err))
+		panic(fmt.Sprintf("failed to stop the test environment: %v", err))
 	}
 
 	fmt.Println("Stopping the storage server")
 	testServer.Stop()
 	if err := os.RemoveAll(testServer.Root()); err != nil {
-		panic(fmt.Sprintf("Failed to remove storage server dir: %v", err))
+		panic(fmt.Sprintf("failed to remove storage server dir: %v", err))
 	}
 
 	if err := os.RemoveAll(testRegistryServer.workspaceDir); err != nil {
-		panic(fmt.Sprintf("Failed to remove registry workspace dir: %v", err))
+		panic(fmt.Sprintf("failed to remove registry workspace dir: %v", err))
 	}
 
 	os.Exit(code)

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -65,11 +65,3 @@ func FeatureGates() map[string]bool {
 func Enabled(feature string) (bool, error) {
 	return feathelper.Enabled(feature)
 }
-
-// Disable disables the specified feature. If the feature is not
-// present, it's a no-op.
-func Disable(feature string) {
-	if _, ok := features[feature]; ok {
-		features[feature] = false
-	}
-}

--- a/pkg/git/libgit2/checkout.go
+++ b/pkg/git/libgit2/checkout.go
@@ -18,6 +18,7 @@ package libgit2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -44,13 +45,20 @@ func CheckoutStrategyForOptions(ctx context.Context, opt git.CheckoutOptions) gi
 	}
 	switch {
 	case opt.Commit != "":
-		return &CheckoutCommit{Commit: opt.Commit}
+		return &CheckoutCommit{
+			Commit:  opt.Commit,
+			Managed: opt.Managed,
+		}
 	case opt.SemVer != "":
-		return &CheckoutSemVer{SemVer: opt.SemVer}
+		return &CheckoutSemVer{
+			SemVer:  opt.SemVer,
+			Managed: opt.Managed,
+		}
 	case opt.Tag != "":
 		return &CheckoutTag{
 			Tag:          opt.Tag,
 			LastRevision: opt.LastRevision,
+			Managed:      opt.Managed,
 		}
 	default:
 		branch := opt.Branch
@@ -60,6 +68,7 @@ func CheckoutStrategyForOptions(ctx context.Context, opt git.CheckoutOptions) gi
 		return &CheckoutBranch{
 			Branch:       branch,
 			LastRevision: opt.LastRevision,
+			Managed:      opt.Managed,
 		}
 	}
 }
@@ -67,6 +76,7 @@ func CheckoutStrategyForOptions(ctx context.Context, opt git.CheckoutOptions) gi
 type CheckoutBranch struct {
 	Branch       string
 	LastRevision string
+	Managed      bool
 }
 
 func (c *CheckoutBranch) Checkout(ctx context.Context, path, url string, opts *git.AuthOptions) (_ *git.Commit, err error) {
@@ -75,146 +85,141 @@ func (c *CheckoutBranch) Checkout(ctx context.Context, path, url string, opts *g
 	// This branching is temporary, to address the transient panics observed when using unmanaged transport.
 	// The panics probably happen because we perform multiple fetch ops (introduced as a part of optimizing git clones).
 	// The branching lets us establish a clear code path to help us be certain of the expected behaviour.
-	// When we get rid of unmanaged transports, we can get rid of this branching as well.
-	if managed.Enabled() {
-		// We store the target URL and auth options mapped to a unique ID. We overwrite the target URL
-		// with the TransportOptionsURL, because managed transports don't provide a way for any kind of
-		// dependency injection. This lets us have a way of doing interop between application level code
-		// and transport level code.
-		// Performing all fetch operations with the TransportOptionsURL as the URL, lets the managed
-		// transport action use it to fetch the registered transport options which contains the
-		// _actual_ target URL and the correct credentials to use.
-		if opts == nil {
-			return nil, fmt.Errorf("can't use managed transport with an empty set of auth options")
-		}
-		if opts.TransportOptionsURL == "" {
-			return nil, fmt.Errorf("can't use managed transport without a valid transport auth id.")
-		}
-		managed.AddTransportOptions(opts.TransportOptionsURL, managed.TransportOptions{
-			TargetURL:    url,
-			AuthOpts:     opts,
-			ProxyOptions: &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
-			Context:      ctx,
-		})
-		url = opts.TransportOptionsURL
-		remoteCallBacks := managed.RemoteCallbacks()
-		defer managed.RemoveTransportOptions(opts.TransportOptionsURL)
-
-		repo, remote, err := initializeRepoWithRemote(ctx, path, url, opts)
-		if err != nil {
-			return nil, err
-		}
-		// Open remote connection.
-		err = remote.ConnectFetch(&remoteCallBacks, nil, nil)
-		if err != nil {
-			remote.Free()
-			repo.Free()
-			return nil, fmt.Errorf("unable to fetch-connect to remote '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
-		}
-		defer func() {
-			remote.Disconnect()
-			remote.Free()
-			repo.Free()
-		}()
-
-		// When the last observed revision is set, check whether it is still the
-		// same at the remote branch. If so, short-circuit the clone operation here.
-		if c.LastRevision != "" {
-			heads, err := remote.Ls(c.Branch)
-			if err != nil {
-				return nil, fmt.Errorf("unable to remote ls for '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
-			}
-			if len(heads) > 0 {
-				hash := heads[0].Id.String()
-				currentRevision := fmt.Sprintf("%s/%s", c.Branch, hash)
-				if currentRevision == c.LastRevision {
-					// Construct a partial commit with the existing information.
-					c := &git.Commit{
-						Hash:      git.Hash(hash),
-						Reference: "refs/heads/" + c.Branch,
-					}
-					return c, nil
-				}
-			}
-		}
-
-		// Limit the fetch operation to the specific branch, to decrease network usage.
-		err = remote.Fetch([]string{c.Branch},
-			&git2go.FetchOptions{
-				DownloadTags:    git2go.DownloadTagsNone,
-				RemoteCallbacks: remoteCallBacks,
-			},
-			"")
-		if err != nil {
-			return nil, fmt.Errorf("unable to fetch remote '%s': %w",
-				managed.EffectiveURL(url), gitutil.LibGit2Error(err))
-		}
-
-		branch, err := repo.References.Lookup(fmt.Sprintf("refs/remotes/origin/%s", c.Branch))
-		if err != nil {
-			return nil, fmt.Errorf("unable to lookup branch '%s' for '%s': %w",
-				c.Branch, managed.EffectiveURL(url), gitutil.LibGit2Error(err))
-		}
-		defer branch.Free()
-
-		upstreamCommit, err := repo.LookupCommit(branch.Target())
-		if err != nil {
-			return nil, fmt.Errorf("unable to lookup commit '%s' for '%s': %w",
-				c.Branch, managed.EffectiveURL(url), gitutil.LibGit2Error(err))
-		}
-		defer upstreamCommit.Free()
-
-		// We try to lookup the branch (and create it if it doesn't exist), so that we can
-		// switch the repo to the specified branch. This is done so that users of this api
-		// can expect the repo to be at the desired branch, when cloned.
-		localBranch, err := repo.LookupBranch(c.Branch, git2go.BranchLocal)
-		if git2go.IsErrorCode(err, git2go.ErrorCodeNotFound) {
-			localBranch, err = repo.CreateBranch(c.Branch, upstreamCommit, false)
-			if err != nil {
-				return nil, fmt.Errorf("unable to create local branch '%s': %w", c.Branch, err)
-			}
-		} else if err != nil {
-			return nil, fmt.Errorf("unable to lookup branch '%s': %w", c.Branch, err)
-		}
-		defer localBranch.Free()
-
-		tree, err := repo.LookupTree(upstreamCommit.TreeId())
-		if err != nil {
-			return nil, fmt.Errorf("unable to lookup tree for branch '%s': %w", c.Branch, err)
-		}
-		defer tree.Free()
-
-		err = repo.CheckoutTree(tree, &git2go.CheckoutOpts{
-			// the remote branch should take precedence if it exists at this point in time.
-			Strategy: git2go.CheckoutForce,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("unable to checkout tree for branch '%s': %w", c.Branch, err)
-		}
-
-		// Set the current head to point to the requested branch.
-		err = repo.SetHead("refs/heads/" + c.Branch)
-		if err != nil {
-			return nil, fmt.Errorf("unable to set HEAD to branch '%s':%w", c.Branch, err)
-		}
-
-		// Use the current worktree's head as reference for the commit to be returned.
-		head, err := repo.Head()
-		if err != nil {
-			return nil, fmt.Errorf("unable to resolve HEAD: %w", err)
-		}
-		defer head.Free()
-
-		cc, err := repo.LookupCommit(head.Target())
-		if err != nil {
-			return nil, fmt.Errorf("unable to lookup HEAD commit '%s' for branch '%s': %w", head.Target(), c.Branch, err)
-		}
-		defer cc.Free()
-
-		return buildCommit(cc, "refs/heads/"+c.Branch), nil
+	// When we get rid of unmanaged transport, we can get rid of this branching as well.
+	if c.Managed {
+		return c.checkoutManaged(ctx, path, url, opts)
 	} else {
 		return c.checkoutUnmanaged(ctx, path, url, opts)
 	}
+}
+
+func (c *CheckoutBranch) checkoutManaged(ctx context.Context, path, url string, opts *git.AuthOptions) (_ *git.Commit, err error) {
+	// We store the target URL and auth options mapped to a unique ID. We use the TransportOptionsURL
+	// for fetch operations, because managed transport doesn't provide a way for any kind of
+	// dependency injection. This lets us have a way of doing interop between application level code
+	// and transport level code.
+	// Performing all fetch operations with the TransportOptionsURL as the URL, lets the managed
+	// transport action use it to fetch the registered transport options which contains the
+	// _actual_ target URL and the correct credentials to use.
+	err = registerManagedTransportOptions(ctx, url, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer managed.RemoveTransportOptions(opts.TransportOptionsURL)
+
+	repo, remote, err := initializeRepoWithRemote(ctx, path, opts.TransportOptionsURL, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Open remote connection.
+	remoteCallBacks := managed.RemoteCallbacks()
+	err = remote.ConnectFetch(&remoteCallBacks, nil, nil)
+	if err != nil {
+		remote.Free()
+		repo.Free()
+		return nil, fmt.Errorf("unable to fetch-connect to remote '%s': %w", url, gitutil.LibGit2Error(err))
+	}
+	defer func() {
+		remote.Disconnect()
+		remote.Free()
+		repo.Free()
+	}()
+
+	// When the last observed revision is set, check whether it is still the
+	// same at the remote branch. If so, short-circuit the clone operation here.
+	if c.LastRevision != "" {
+		heads, err := remote.Ls(c.Branch)
+		if err != nil {
+			return nil, fmt.Errorf("unable to remote ls for '%s': %w", url, gitutil.LibGit2Error(err))
+		}
+		if len(heads) > 0 {
+			hash := heads[0].Id.String()
+			currentRevision := fmt.Sprintf("%s/%s", c.Branch, hash)
+			if currentRevision == c.LastRevision {
+				// Construct a partial commit with the existing information.
+				c := &git.Commit{
+					Hash:      git.Hash(hash),
+					Reference: "refs/heads/" + c.Branch,
+				}
+				return c, nil
+			}
+		}
+	}
+
+	// Limit the fetch operation to the specific branch, to decrease network usage.
+	err = remote.Fetch([]string{c.Branch},
+		&git2go.FetchOptions{
+			DownloadTags:    git2go.DownloadTagsNone,
+			RemoteCallbacks: remoteCallBacks,
+		},
+		"")
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch remote '%s': %w", url, gitutil.LibGit2Error(err))
+	}
+
+	branch, err := repo.References.Lookup(fmt.Sprintf("refs/remotes/origin/%s", c.Branch))
+	if err != nil {
+		return nil, fmt.Errorf("unable to lookup branch '%s' for '%s': %w",
+			c.Branch, url, gitutil.LibGit2Error(err))
+	}
+	defer branch.Free()
+
+	upstreamCommit, err := repo.LookupCommit(branch.Target())
+	if err != nil {
+		return nil, fmt.Errorf("unable to lookup commit '%s' for '%s': %w",
+			c.Branch, url, gitutil.LibGit2Error(err))
+	}
+	defer upstreamCommit.Free()
+
+	// We try to lookup the branch (and create it if it doesn't exist), so that we can
+	// switch the repo to the specified branch. This is done so that users of this api
+	// can expect the repo to be at the desired branch, when cloned.
+	localBranch, err := repo.LookupBranch(c.Branch, git2go.BranchLocal)
+	if git2go.IsErrorCode(err, git2go.ErrorCodeNotFound) {
+		localBranch, err = repo.CreateBranch(c.Branch, upstreamCommit, false)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create local branch '%s': %w", c.Branch, err)
+		}
+	} else if err != nil {
+		return nil, fmt.Errorf("unable to lookup branch '%s': %w", c.Branch, err)
+	}
+	defer localBranch.Free()
+
+	tree, err := repo.LookupTree(upstreamCommit.TreeId())
+	if err != nil {
+		return nil, fmt.Errorf("unable to lookup tree for branch '%s': %w", c.Branch, err)
+	}
+	defer tree.Free()
+
+	err = repo.CheckoutTree(tree, &git2go.CheckoutOpts{
+		// the remote branch should take precedence if it exists at this point in time.
+		Strategy: git2go.CheckoutForce,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to checkout tree for branch '%s': %w", c.Branch, err)
+	}
+
+	// Set the current head to point to the requested branch.
+	err = repo.SetHead("refs/heads/" + c.Branch)
+	if err != nil {
+		return nil, fmt.Errorf("unable to set HEAD to branch '%s':%w", c.Branch, err)
+	}
+
+	// Use the current worktree's head as reference for the commit to be returned.
+	head, err := repo.Head()
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve HEAD: %w", err)
+	}
+	defer head.Free()
+
+	cc, err := repo.LookupCommit(head.Target())
+	if err != nil {
+		return nil, fmt.Errorf("unable to lookup HEAD commit '%s' for branch '%s': %w", head.Target(), c.Branch, err)
+	}
+	defer cc.Free()
+
+	return buildCommit(cc, "refs/heads/"+c.Branch), nil
 }
 
 func (c *CheckoutBranch) checkoutUnmanaged(ctx context.Context, path, url string, opts *git.AuthOptions) (_ *git.Commit, err error) {
@@ -230,7 +235,7 @@ func (c *CheckoutBranch) checkoutUnmanaged(ctx context.Context, path, url string
 		CheckoutBranch: c.Branch,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to clone '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
+		return nil, fmt.Errorf("unable to clone '%s': %w", url, gitutil.LibGit2Error(err))
 	}
 	defer repo.Free()
 	head, err := repo.Head()
@@ -249,6 +254,7 @@ func (c *CheckoutBranch) checkoutUnmanaged(ctx context.Context, path, url string
 type CheckoutTag struct {
 	Tag          string
 	LastRevision string
+	Managed      bool
 }
 
 func (c *CheckoutTag) Checkout(ctx context.Context, path, url string, opts *git.AuthOptions) (_ *git.Commit, err error) {
@@ -257,90 +263,88 @@ func (c *CheckoutTag) Checkout(ctx context.Context, path, url string, opts *git.
 	// This branching is temporary, to address the transient panics observed when using unmanaged transport.
 	// The panics probably happen because we perform multiple fetch ops (introduced as a part of optimizing git clones).
 	// The branching lets us establish a clear code path to help us be certain of the expected behaviour.
-	// When we get rid of unmanaged transports, we can get rid of this branching as well.
-	if managed.Enabled() {
-		if opts.TransportOptionsURL == "" {
-			return nil, fmt.Errorf("can't use managed transport without a valid transport auth id.")
-		}
-		managed.AddTransportOptions(opts.TransportOptionsURL, managed.TransportOptions{
-			TargetURL:    url,
-			AuthOpts:     opts,
-			ProxyOptions: &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
-			Context:      ctx,
-		})
-		url = opts.TransportOptionsURL
-		remoteCallBacks := managed.RemoteCallbacks()
-		defer managed.RemoveTransportOptions(opts.TransportOptionsURL)
-
-		repo, remote, err := initializeRepoWithRemote(ctx, path, url, opts)
-		if err != nil {
-			return nil, err
-		}
-		// Open remote connection.
-		err = remote.ConnectFetch(&remoteCallBacks, nil, nil)
-		if err != nil {
-			remote.Free()
-			repo.Free()
-			return nil, fmt.Errorf("unable to fetch-connect to remote '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
-		}
-		defer func() {
-			remote.Disconnect()
-			remote.Free()
-			repo.Free()
-		}()
-
-		// When the last observed revision is set, check whether it is still the
-		// same at the remote branch. If so, short-circuit the clone operation here.
-		if c.LastRevision != "" {
-			heads, err := remote.Ls(c.Tag)
-			if err != nil {
-				return nil, fmt.Errorf("unable to remote ls for '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
-			}
-			if len(heads) > 0 {
-				hash := heads[0].Id.String()
-				currentRevision := fmt.Sprintf("%s/%s", c.Tag, hash)
-				var same bool
-				if currentRevision == c.LastRevision {
-					same = true
-				} else if len(heads) > 1 {
-					hash = heads[1].Id.String()
-					currentAnnotatedRevision := fmt.Sprintf("%s/%s", c.Tag, hash)
-					if currentAnnotatedRevision == c.LastRevision {
-						same = true
-					}
-				}
-				if same {
-					// Construct a partial commit with the existing information.
-					c := &git.Commit{
-						Hash:      git.Hash(hash),
-						Reference: "refs/tags/" + c.Tag,
-					}
-					return c, nil
-				}
-			}
-		}
-
-		err = remote.Fetch([]string{c.Tag},
-			&git2go.FetchOptions{
-				DownloadTags:    git2go.DownloadTagsAuto,
-				RemoteCallbacks: remoteCallBacks,
-			},
-			"")
-
-		if err != nil {
-			return nil, fmt.Errorf("unable to fetch remote '%s': %w",
-				managed.EffectiveURL(url), gitutil.LibGit2Error(err))
-		}
-
-		cc, err := checkoutDetachedDwim(repo, c.Tag)
-		if err != nil {
-			return nil, err
-		}
-		defer cc.Free()
-		return buildCommit(cc, "refs/tags/"+c.Tag), nil
+	// When we get rid of unmanaged transport, we can get rid of this branching as well.
+	if c.Managed {
+		return c.checkoutManaged(ctx, path, url, opts)
 	} else {
 		return c.checkoutUnmanaged(ctx, path, url, opts)
 	}
+}
+
+func (c *CheckoutTag) checkoutManaged(ctx context.Context, path, url string, opts *git.AuthOptions) (_ *git.Commit, err error) {
+	err = registerManagedTransportOptions(ctx, url, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer managed.RemoveTransportOptions(opts.TransportOptionsURL)
+
+	repo, remote, err := initializeRepoWithRemote(ctx, path, opts.TransportOptionsURL, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Open remote connection.
+	remoteCallBacks := managed.RemoteCallbacks()
+	err = remote.ConnectFetch(&remoteCallBacks, nil, nil)
+	if err != nil {
+		remote.Free()
+		repo.Free()
+		return nil, fmt.Errorf("unable to fetch-connect to remote '%s': %w", url, gitutil.LibGit2Error(err))
+	}
+	defer func() {
+		remote.Disconnect()
+		remote.Free()
+		repo.Free()
+	}()
+
+	// When the last observed revision is set, check whether it is still the
+	// same at the remote branch. If so, short-circuit the clone operation here.
+	if c.LastRevision != "" {
+		heads, err := remote.Ls(c.Tag)
+		if err != nil {
+			return nil, fmt.Errorf("unable to remote ls for '%s': %w", url, gitutil.LibGit2Error(err))
+		}
+		if len(heads) > 0 {
+			hash := heads[0].Id.String()
+			currentRevision := fmt.Sprintf("%s/%s", c.Tag, hash)
+			var same bool
+			if currentRevision == c.LastRevision {
+				same = true
+			} else if len(heads) > 1 {
+				hash = heads[1].Id.String()
+				currentAnnotatedRevision := fmt.Sprintf("%s/%s", c.Tag, hash)
+				if currentAnnotatedRevision == c.LastRevision {
+					same = true
+				}
+			}
+			if same {
+				// Construct a partial commit with the existing information.
+				c := &git.Commit{
+					Hash:      git.Hash(hash),
+					Reference: "refs/tags/" + c.Tag,
+				}
+				return c, nil
+			}
+		}
+	}
+
+	err = remote.Fetch([]string{c.Tag},
+		&git2go.FetchOptions{
+			DownloadTags:    git2go.DownloadTagsAuto,
+			RemoteCallbacks: remoteCallBacks,
+		},
+		"")
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch remote '%s': %w", url, gitutil.LibGit2Error(err))
+	}
+
+	cc, err := checkoutDetachedDwim(repo, c.Tag)
+	if err != nil {
+		return nil, err
+	}
+	defer cc.Free()
+	return buildCommit(cc, "refs/tags/"+c.Tag), nil
 }
 
 func (c *CheckoutTag) checkoutUnmanaged(ctx context.Context, path, url string, opts *git.AuthOptions) (_ *git.Commit, err error) {
@@ -352,7 +356,7 @@ func (c *CheckoutTag) checkoutUnmanaged(ctx context.Context, path, url string, o
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to clone '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
+		return nil, fmt.Errorf("unable to clone '%s': %w", url, gitutil.LibGit2Error(err))
 	}
 	defer repo.Free()
 	cc, err := checkoutDetachedDwim(repo, c.Tag)
@@ -364,37 +368,34 @@ func (c *CheckoutTag) checkoutUnmanaged(ctx context.Context, path, url string, o
 }
 
 type CheckoutCommit struct {
-	Commit string
+	Commit  string
+	Managed bool
 }
 
 func (c *CheckoutCommit) Checkout(ctx context.Context, path, url string, opts *git.AuthOptions) (_ *git.Commit, err error) {
 	defer recoverPanic(&err)
 
 	remoteCallBacks := RemoteCallbacks(ctx, opts)
+	targetURL := url
 
-	if managed.Enabled() {
-		if opts.TransportOptionsURL == "" {
-			return nil, fmt.Errorf("can't use managed transport without a valid transport auth id.")
+	if c.Managed {
+		err = registerManagedTransportOptions(ctx, url, opts)
+		if err != nil {
+			return nil, err
 		}
-		managed.AddTransportOptions(opts.TransportOptionsURL, managed.TransportOptions{
-			TargetURL:    url,
-			AuthOpts:     opts,
-			ProxyOptions: &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
-			Context:      ctx,
-		})
-		url = opts.TransportOptionsURL
-		remoteCallBacks = managed.RemoteCallbacks()
 		defer managed.RemoveTransportOptions(opts.TransportOptionsURL)
+		remoteCallBacks = managed.RemoteCallbacks()
+		targetURL = opts.TransportOptionsURL
 	}
 
-	repo, err := git2go.Clone(url, path, &git2go.CloneOptions{
+	repo, err := git2go.Clone(targetURL, path, &git2go.CloneOptions{
 		FetchOptions: git2go.FetchOptions{
 			DownloadTags:    git2go.DownloadTagsNone,
 			RemoteCallbacks: remoteCallBacks,
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to clone '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
+		return nil, fmt.Errorf("unable to clone '%s': %w", url, gitutil.LibGit2Error(err))
 	}
 	defer repo.Free()
 	oid, err := git2go.NewOid(c.Commit)
@@ -409,27 +410,24 @@ func (c *CheckoutCommit) Checkout(ctx context.Context, path, url string, opts *g
 }
 
 type CheckoutSemVer struct {
-	SemVer string
+	SemVer  string
+	Managed bool
 }
 
 func (c *CheckoutSemVer) Checkout(ctx context.Context, path, url string, opts *git.AuthOptions) (_ *git.Commit, err error) {
 	defer recoverPanic(&err)
 
 	remoteCallBacks := RemoteCallbacks(ctx, opts)
+	targetURL := url
 
-	if managed.Enabled() {
-		if opts.TransportOptionsURL == "" {
-			return nil, fmt.Errorf("can't use managed transport without a valid transport auth id.")
+	if c.Managed {
+		err = registerManagedTransportOptions(ctx, url, opts)
+		if err != nil {
+			return nil, err
 		}
-		managed.AddTransportOptions(opts.TransportOptionsURL, managed.TransportOptions{
-			TargetURL:    url,
-			AuthOpts:     opts,
-			ProxyOptions: &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
-			Context:      ctx,
-		})
-		url = opts.TransportOptionsURL
-		remoteCallBacks = managed.RemoteCallbacks()
 		defer managed.RemoveTransportOptions(opts.TransportOptionsURL)
+		remoteCallBacks = managed.RemoteCallbacks()
+		targetURL = opts.TransportOptionsURL
 	}
 
 	verConstraint, err := semver.NewConstraint(c.SemVer)
@@ -437,14 +435,14 @@ func (c *CheckoutSemVer) Checkout(ctx context.Context, path, url string, opts *g
 		return nil, fmt.Errorf("semver parse error: %w", err)
 	}
 
-	repo, err := git2go.Clone(url, path, &git2go.CloneOptions{
+	repo, err := git2go.Clone(targetURL, path, &git2go.CloneOptions{
 		FetchOptions: git2go.FetchOptions{
 			DownloadTags:    git2go.DownloadTagsAll,
 			RemoteCallbacks: remoteCallBacks,
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to clone '%s': %w", managed.EffectiveURL(url), gitutil.LibGit2Error(err))
+		return nil, fmt.Errorf("unable to clone '%s': %w", url, gitutil.LibGit2Error(err))
 	}
 	defer repo.Free()
 
@@ -628,6 +626,25 @@ func initializeRepoWithRemote(ctx context.Context, path, url string, opts *git.A
 		}
 	}
 	return repo, remote, nil
+}
+
+// registerManagedTransportOptions registers the given url and it's transport options.
+// Callers must make sure to call `managed.RemoveTransportOptions()` to avoid increase in
+// memory consumption.
+func registerManagedTransportOptions(ctx context.Context, url string, authOpts *git.AuthOptions) error {
+	if authOpts == nil {
+		return errors.New("can't use managed transport with an empty set of auth options")
+	}
+	if authOpts.TransportOptionsURL == "" {
+		return errors.New("can't use managed transport without a valid transport auth id")
+	}
+	managed.AddTransportOptions(authOpts.TransportOptionsURL, managed.TransportOptions{
+		TargetURL:    url,
+		AuthOpts:     authOpts,
+		ProxyOptions: &git2go.ProxyOptions{Type: git2go.ProxyTypeAuto},
+		Context:      ctx,
+	})
+	return nil
 }
 
 func recoverPanic(err *error) {

--- a/pkg/git/libgit2/checkout_test.go
+++ b/pkg/git/libgit2/checkout_test.go
@@ -30,8 +30,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/fluxcd/source-controller/pkg/git"
-
-	mt "github.com/fluxcd/source-controller/pkg/git/libgit2/managed"
 )
 
 func TestCheckoutBranch_unmanaged(t *testing.T) {
@@ -138,7 +136,6 @@ func checkoutBranch(t *testing.T, managed bool) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(mt.Enabled()).To(Equal(managed))
 
 			branch := CheckoutBranch{
 				Branch:       tt.branch,
@@ -229,7 +226,6 @@ func checkoutTag(t *testing.T, managed bool) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(mt.Enabled()).To(Equal(managed))
 
 			server, err := gittestserver.NewTempGitServer()
 			g.Expect(err).ToNot(HaveOccurred())
@@ -319,7 +315,6 @@ func TestCheckoutCommit_unmanaged(t *testing.T) {
 // via CheckoutCommit.
 func checkoutCommit(t *testing.T, managed bool) {
 	g := NewWithT(t)
-	g.Expect(mt.Enabled()).To(Equal(managed))
 
 	server, err := gittestserver.NewTempGitServer()
 	if err != nil {
@@ -498,7 +493,6 @@ func checkoutSemVer(t *testing.T, managed bool) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(mt.Enabled()).To(Equal(managed))
 
 			semVer := CheckoutSemVer{
 				SemVer: tt.constraint,
@@ -618,7 +612,6 @@ func mockSignature(time time.Time) *git2go.Signature {
 func TestInitializeRepoWithRemote(t *testing.T) {
 	g := NewWithT(t)
 
-	g.Expect(mt.Enabled()).To(BeFalse())
 	tmp := t.TempDir()
 	ctx := context.TODO()
 	testRepoURL := "https://example.com/foo/bar"

--- a/pkg/git/libgit2/managed/http_test.go
+++ b/pkg/git/libgit2/managed/http_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/fluxcd/pkg/gittestserver"
 	"github.com/fluxcd/source-controller/pkg/git"
-	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 
 	git2go "github.com/libgit2/git2go/v33"
@@ -169,9 +168,6 @@ func TestHTTPManagedTransport_E2E(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	defer server.StopHTTP()
 
-	// Force managed transport to be enabled
-	InitManagedTransport(logr.Discard())
-
 	repoPath := "test.git"
 	err = server.InitRepo("../../testdata/git/repo", git.DefaultBranch, repoPath)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -251,9 +247,6 @@ func TestHTTPManagedTransport_HandleRedirect(t *testing.T) {
 		{name: "http to https", repoURL: "http://github.com/stefanprodan/podinfo"},
 		{name: "handle gitlab redirect", repoURL: "https://gitlab.com/stefanprodan/podinfo"},
 	}
-
-	// Force managed transport to be enabled
-	InitManagedTransport(logr.Discard())
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/git/libgit2/managed/init.go
+++ b/pkg/git/libgit2/managed/init.go
@@ -40,17 +40,7 @@ var (
 
 	debugLog logr.Logger
 	traceLog logr.Logger
-	enabled  bool
 )
-
-// Enabled defines whether the use of Managed Transport is enabled which
-// is only true if InitManagedTransport was called successfully at least
-// once.
-//
-// This is only affects git operations that uses libgit2 implementation.
-func Enabled() bool {
-	return enabled
-}
 
 // InitManagedTransport initialises HTTP(S) and SSH managed transport
 // for git2go, and therefore only impact git operations using the
@@ -76,7 +66,6 @@ func InitManagedTransport(log logr.Logger) error {
 		}
 
 		err = registerManagedSSH()
-		enabled = true
 	})
 
 	return err

--- a/pkg/git/libgit2/managed/managed_test.go
+++ b/pkg/git/libgit2/managed/managed_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The Flux authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managed
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestMain(m *testing.M) {
+	InitManagedTransport(logr.Discard())
+	code := m.Run()
+	os.Exit(code)
+}

--- a/pkg/git/libgit2/managed/options.go
+++ b/pkg/git/libgit2/managed/options.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/fluxcd/source-controller/internal/features"
 	"github.com/fluxcd/source-controller/pkg/git"
 	git2go "github.com/libgit2/git2go/v33"
 )
@@ -41,9 +42,8 @@ var (
 
 // AddTransportOptions registers a TransportOptions object mapped to the
 // provided transportOptsURL, which must be a valid URL, i.e. prefixed with "http://"
-// or "ssh://", as it is used as a dummy URL for all git operations and the managed
-// transports will only be invoked for the protocols that they have been
-// registered for.
+// or "ssh://", as it is used as a dummy URL for all libgit2 operations which use
+// managed transport.
 func AddTransportOptions(transportOptsURL string, opts TransportOptions) {
 	m.Lock()
 	transportOpts[transportOptsURL] = opts
@@ -75,7 +75,7 @@ func getTransportOptions(transportOptsURL string) (*TransportOptions, bool) {
 // this returns the same input if Managed Transport is disabled or if no TargetURL
 // is set on TransportOptions.
 func EffectiveURL(transporOptsURL string) string {
-	if !Enabled() {
+	if enabled, _ := features.Enabled(features.GitManagedTransport); enabled {
 		return transporOptsURL
 	}
 

--- a/pkg/git/libgit2/managed/ssh_test.go
+++ b/pkg/git/libgit2/managed/ssh_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/fluxcd/pkg/ssh"
 	"github.com/fluxcd/source-controller/pkg/git"
-	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 
 	"github.com/fluxcd/pkg/gittestserver"
@@ -89,7 +88,6 @@ func TestSSHManagedTransport_E2E(t *testing.T) {
 		server.StartSSH()
 	}()
 	defer server.StopSSH()
-	InitManagedTransport(logr.Discard())
 
 	kp, err := ssh.NewEd25519Generator().Generate()
 	g.Expect(err).ToNot(HaveOccurred())

--- a/pkg/git/libgit2/managed/transport.go
+++ b/pkg/git/libgit2/managed/transport.go
@@ -11,7 +11,7 @@ import (
 
 // knownHostCallback returns a CertificateCheckCallback that verifies
 // the key of Git server against the given host and known_hosts for
-// git.SSH Transports.
+// git.SSH transport.
 func KnownHostsCallback(host string, knownHosts []byte) git2go.CertificateCheckCallback {
 	return func(cert *git2go.Certificate, valid bool, hostname string) error {
 		kh, err := pkgkh.ParseKnownHosts(string(knownHosts))

--- a/pkg/git/libgit2/managed_checkout_test.go
+++ b/pkg/git/libgit2/managed_checkout_test.go
@@ -15,32 +15,35 @@ limitations under the License.
 */
 
 // This file is named `managed_checkout_test.go` on purpose to make sure that
-// tests needing to use unmanaged transports run before the tests that use managed
-// transports do, since the the former are present in `checkout_test.go`. `checkout_test.go`
+// tests needing to use unmanaged transport run before the tests that use managed
+// transport do, since the the former are present in `checkout_test.go`. `checkout_test.go`
 // comes first in this package (alphabetically speaking), which makes golang run the tests
 // in that file first.
 package libgit2
 
 import (
 	"testing"
+
+	"github.com/fluxcd/source-controller/pkg/git/libgit2/managed"
+	"github.com/go-logr/logr"
 )
 
 func TestCheckoutBranch_CheckoutManaged(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 	checkoutBranch(t, true)
 }
 
 func TestCheckoutTag_CheckoutManaged(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 	checkoutTag(t, true)
 }
 
 func TestCheckoutCommit_CheckoutManaged(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 	checkoutCommit(t, true)
 }
 
 func TestCheckoutTagSemVer_CheckoutManaged(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 	checkoutSemVer(t, true)
 }

--- a/pkg/git/libgit2/managed_test.go
+++ b/pkg/git/libgit2/managed_test.go
@@ -32,11 +32,9 @@ import (
 	"github.com/fluxcd/pkg/ssh"
 	"github.com/go-logr/logr"
 
-	feathelper "github.com/fluxcd/pkg/runtime/features"
 	. "github.com/onsi/gomega"
 	cryptossh "golang.org/x/crypto/ssh"
 
-	"github.com/fluxcd/source-controller/internal/features"
 	"github.com/fluxcd/source-controller/pkg/git"
 	"github.com/fluxcd/source-controller/pkg/git/libgit2/managed"
 )
@@ -46,7 +44,7 @@ const testRepositoryPath = "../testdata/git/repo"
 // Test_managedSSH_KeyTypes assures support for the different
 // types of keys for SSH Authentication supported by Flux.
 func Test_managedSSH_KeyTypes(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 
 	tests := []struct {
 		name       string
@@ -147,7 +145,10 @@ func Test_managedSSH_KeyTypes(t *testing.T) {
 			authOpts.TransportOptionsURL = getTransportOptionsURL(git.SSH)
 
 			// Prepare for checkout.
-			branchCheckoutStrat := &CheckoutBranch{Branch: git.DefaultBranch}
+			branchCheckoutStrat := &CheckoutBranch{
+				Branch:  git.DefaultBranch,
+				Managed: true,
+			}
 			tmpDir := t.TempDir()
 
 			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
@@ -175,7 +176,7 @@ func Test_managedSSH_KeyTypes(t *testing.T) {
 // Test_managedSSH_KeyExchangeAlgos assures support for the different
 // types of SSH key exchange algorithms supported by Flux.
 func Test_managedSSH_KeyExchangeAlgos(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 
 	tests := []struct {
 		name      string
@@ -277,7 +278,10 @@ func Test_managedSSH_KeyExchangeAlgos(t *testing.T) {
 			authOpts.TransportOptionsURL = getTransportOptionsURL(git.SSH)
 
 			// Prepare for checkout.
-			branchCheckoutStrat := &CheckoutBranch{Branch: git.DefaultBranch}
+			branchCheckoutStrat := &CheckoutBranch{
+				Branch:  git.DefaultBranch,
+				Managed: true,
+			}
 			tmpDir := t.TempDir()
 
 			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
@@ -298,7 +302,7 @@ func Test_managedSSH_KeyExchangeAlgos(t *testing.T) {
 // Test_managedSSH_HostKeyAlgos assures support for the different
 // types of SSH Host Key algorithms supported by Flux.
 func Test_managedSSH_HostKeyAlgos(t *testing.T) {
-	enableManagedTransport()
+	managed.InitManagedTransport(logr.Discard())
 
 	tests := []struct {
 		name               string
@@ -446,7 +450,10 @@ func Test_managedSSH_HostKeyAlgos(t *testing.T) {
 			authOpts.TransportOptionsURL = getTransportOptionsURL(git.SSH)
 
 			// Prepare for checkout.
-			branchCheckoutStrat := &CheckoutBranch{Branch: git.DefaultBranch}
+			branchCheckoutStrat := &CheckoutBranch{
+				Branch:  git.DefaultBranch,
+				Managed: true,
+			}
 			tmpDir := t.TempDir()
 
 			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
@@ -466,10 +473,4 @@ func getTransportOptionsURL(transport git.TransportType) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(transport) + "://" + string(b)
-}
-
-func enableManagedTransport() {
-	fg := feathelper.FeatureGates{}
-	fg.SupportedFeatures(features.FeatureGates())
-	managed.InitManagedTransport(logr.Discard())
 }

--- a/pkg/git/options.go
+++ b/pkg/git/options.go
@@ -52,6 +52,9 @@ type CheckoutOptions struct {
 	// LastRevision holds the last observed revision of the local repository.
 	// It is used to skip clone operations when no changes were detected.
 	LastRevision string
+
+	// Managed defines if the checkout should be done using managed transport.
+	Managed bool
 }
 
 type TransportType string
@@ -73,11 +76,11 @@ type AuthOptions struct {
 	KnownHosts []byte
 	CAFile     []byte
 	// TransportOptionsURL is a unique identifier for this set of authentication
-	// options. It's used by managed libgit2 transports to uniquely identify
+	// options. It's used by managed libgit2 transport to uniquely identify
 	// which credentials to use for a particular Git operation, and avoid misuse
 	// of credentials in a multi-tenant environment.
 	// It must be prefixed with a valid transport protocol ("ssh:// "or "http://") because
-	// of the way managed transports are registered and invoked.
+	// of the way managed transport is registered and invoked.
 	// It's a field of AuthOptions despite not providing any kind of authentication
 	// info, as it's the only way to sneak it into git.Checkout, without polluting
 	// it's args and keeping it generic.

--- a/pkg/git/strategy/proxy/strategy_proxy_test.go
+++ b/pkg/git/strategy/proxy/strategy_proxy_test.go
@@ -29,11 +29,9 @@ import (
 
 	"github.com/elazarl/goproxy"
 	"github.com/fluxcd/pkg/gittestserver"
-	feathelper "github.com/fluxcd/pkg/runtime/features"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 
-	"github.com/fluxcd/source-controller/internal/features"
 	"github.com/fluxcd/source-controller/pkg/git"
 	"github.com/fluxcd/source-controller/pkg/git/gogit"
 	"github.com/fluxcd/source-controller/pkg/git/libgit2"
@@ -46,10 +44,6 @@ import (
 func TestCheckoutStrategyForImplementation_Proxied(t *testing.T) {
 	// for libgit2 we are only testing for managed transport,
 	// as unmanaged is sunsetting.
-	// Unmanaged transport does not support HTTP_PROXY.
-	fg := feathelper.FeatureGates{}
-	fg.SupportedFeatures(features.FeatureGates())
-
 	managed.InitManagedTransport(logr.Discard())
 
 	type cleanupFunc func()
@@ -336,7 +330,8 @@ func TestCheckoutStrategyForImplementation_Proxied(t *testing.T) {
 
 			// Checkout the repo.
 			checkoutStrategy, err := strategy.CheckoutStrategyForImplementation(context.TODO(), tt.gitImpl, git.CheckoutOptions{
-				Branch: tt.branch,
+				Branch:  tt.branch,
+				Managed: true,
 			})
 			g.Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
This PR adds a new field `Managed` to `CheckoutOpts` to let checkout impls
figure out when to use managed transport. Adds a new field to the
reconciler which stores the state of managed transport registration and
uses the same to return a stalling error when managed transports are not
registered but the feature is enabled.

Follow up to #727 and branched off from #746