### PR TITLE
set request auth if both username and password are non empty

### DIFF
--- a/pkg/git/libgit2/managed/http.go
+++ b/pkg/git/libgit2/managed/http.go
@@ -279,7 +279,7 @@ func createClientRequest(targetURL string, action git2go.SmartServiceAction,
 
 	// Apply authentication and TLS settings to the HTTP transport.
 	if authOpts != nil {
-		if len(authOpts.Username) > 0 {
+		if authOpts.Username != "" && authOpts.Password != "" {
 			req.SetBasicAuth(authOpts.Username, authOpts.Password)
 		}
 		if len(authOpts.CAFile) > 0 {


### PR DESCRIPTION
BitBucket servers don't accept a username with an empty password, so a
secret with no http auth creds will result in a 401, since we
fall back to "git" for the username and used to set basic auth with that
username without a password.

Fixes: #793 