### PR TITLE
Split GitHub workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,18 +27,11 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Verify
-        run: make verify
       - name: Enable integration tests
         # Only run integration tests for main branch
         if: github.ref == 'refs/heads/main'
         run: |
           echo 'GO_TAGS=integration' >> $GITHUB_ENV
-      - name: Run tests
-        env:
-          TEST_AZURE_ACCOUNT_NAME: ${{ secrets.TEST_AZURE_ACCOUNT_NAME }}
-          TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
-        run: make test
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
         with:
@@ -69,19 +62,6 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo 'GO_TAGS=integration' >> $GITHUB_ENV
-      - name: Run tests
-        env:
-          TEST_AZURE_ACCOUNT_NAME: ${{ secrets.TEST_AZURE_ACCOUNT_NAME }}
-          TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
-          
-          # Temporarily disabling -race for arm64 as our GitHub action
-          # runners don't seem to like it. The race detection was tested
-          # on both Apple M1 and Linux arm64 with successful results.
-          #
-          # We should reenable go test -race for arm64 runners once the
-          # current issue is resolved.
-          GO_TEST_ARGS: ''
-        run: make test
       - name: Prepare
         id: prep
         run: |
@@ -103,24 +83,3 @@ jobs:
         run: |
           kind delete cluster --name ${{ steps.prep.outputs.CLUSTER }}
           rm /tmp/${{ steps.prep.outputs.CLUSTER }}
-
-  # Runs 'make test' on macos-10.15 to assure development environment for 
-  # contributors using MacOS.
-  darwin-amd64:
-    runs-on: macos-10.15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17.x
-      - name: Restore Go cache
-        uses: actions/cache@v3
-        with:
-          path: /home/runner/work/_temp/_github_home/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Run tests
-        run: make test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,80 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read # for actions/checkout to fetch code
+
+jobs:
+
+  test-linux-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.x
+      - name: Restore Go cache
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/work/_temp/_github_home/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run tests
+        env:
+          TEST_AZURE_ACCOUNT_NAME: ${{ secrets.TEST_AZURE_ACCOUNT_NAME }}
+          TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
+        run: make test
+
+  test-linux-arm64:
+    # Hosted on Equinix
+    # Docs: https://github.com/fluxcd/flux2/tree/main/.github/runners
+    runs-on: [self-hosted, Linux, ARM64, equinix]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.x
+      - name: Run tests
+        env:
+          TEST_AZURE_ACCOUNT_NAME: ${{ secrets.TEST_AZURE_ACCOUNT_NAME }}
+          TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
+          
+          # Temporarily disabling -race for arm64 as our GitHub action
+          # runners don't seem to like it. The race detection was tested
+          # on both Apple M1 and Linux arm64 with successful results.
+          #
+          # We should reenable go test -race for arm64 runners once the
+          # current issue is resolved.
+          GO_TEST_ARGS: ''
+        run: make test
+
+  # Runs 'make test' on macos-10.15 to assure development environment for 
+  # contributors using MacOS.
+  darwin-amd64:
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.x
+      - name: Restore Go cache
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/work/_temp/_github_home/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run tests
+        run: make test

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,31 @@
+name: verify
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read # for actions/checkout to fetch code
+
+jobs:
+
+  verify-linux-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.x
+      - name: Restore Go cache
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/work/_temp/_github_home/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Verify
+        run: make verify


### PR DESCRIPTION
The main `e2e` workflow is taking around 16 minutes to finish. By splitting it into different workflows, the overall "time to merge" is reduced to around 10ish minutes.