### PR TITLE
Upgrade to Go 1.18

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Restore Go cache
         uses: actions/cache@v3
         with:
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Enable integration tests
         # Only run integration tests for main branch
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Restore Go cache
         uses: actions/cache@v3
         with:
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Run tests
         env:
           TEST_AZURE_ACCOUNT_NAME: ${{ secrets.TEST_AZURE_ACCOUNT_NAME }}
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Restore Go cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Restore Go cache
         uses: actions/cache@v3
         with:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,7 +45,7 @@ If any of the above dependencies are not present on your system, the first invoc
 ## How to run the test suite
 
 Prerequisites:
-* Go >= 1.17
+* Go >= 1.18
 
 You can run the test suite by simply doing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.17
+ARG GO_VERSION=1.18
 ARG XX_VERSION=1.1.2
 
 ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2-only

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,8 @@ api-docs: gen-crd-api-reference-docs  ## Generate API reference documentation
 	$(GEN_CRD_API_REFERENCE_DOCS) -api-dir=./api/v1beta2 -config=./hack/api-docs/config.json -template-dir=./hack/api-docs/template -out-file=./docs/api/source.md
 
 tidy:  ## Run go mod tidy
-	cd api; rm -f go.sum; go mod tidy -compat=1.17
-	rm -f go.sum; go mod tidy -compat=1.17
+	cd api; rm -f go.sum; go mod tidy -compat=1.18
+	rm -f go.sum; go mod tidy -compat=1.18
 
 fmt:  ## Run go fmt against code
 	go fmt ./...

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/source-controller/api
 
-go 1.17
+go 1.18
 
 require (
 	github.com/fluxcd/pkg/apis/acl v0.0.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/source-controller
 
-go 1.17
+go 1.18
 
 replace github.com/fluxcd/source-controller/api => ./api
 

--- a/tests/fuzz/go.mod
+++ b/tests/fuzz/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/source-controller/tests/fuzz
 
-go 1.17
+go 1.18
 
 replace github.com/fluxcd/kustomize-controller/api => ../../api
 


### PR DESCRIPTION
Upgrade to use Go 1.18. This is required to unblock #786.

The major issues which seem like they could affect end users are security and crypto related. This information should be published even if it may not affect many users.

* TLS now defaults to 1.2 for client connections
* crypto/x509 rejects SHA-1 hash functions

This PR requires pkg to be updated first.