### PR TITLE
build: run darwin tests on macos 10.15, 11 and 12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,10 +58,13 @@ jobs:
           GO_TEST_ARGS: ''
         run: make test
 
-  # Runs 'make test' on macos-10.15 to assure development environment for 
-  # contributors using MacOS.
+  # Runs 'make test' on MacOS to ensure the continuous support for contributors
+  # using it as a development environment.
   darwin-amd64:
-    runs-on: macos-10.15
+    strategy:
+      matrix:
+        os: [macos-10.15, macos-11, macos-12]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Some issues building source-controller seem to be talking place when running `make test` with `Go 1.18`.
By expanding the current tests to macOS 11-12, we ensure they won't break once we migrate over.