### PR TITLE
Fix SIGSEGV when resolving charts dependencies

### DIFF
--- a/internal/helm/chart/dependency_manager.go
+++ b/internal/helm/chart/dependency_manager.go
@@ -98,7 +98,9 @@ func NewDependencyManager(opts ...DependencyManagerOption) *DependencyManager {
 func (dm *DependencyManager) Clear() error {
 	var errs []error
 	for _, v := range dm.downloaders {
-		errs = append(errs, v.Clear())
+		if v != nil {
+			errs = append(errs, v.Clear())
+		}
 	}
 	return errors.NewAggregate(errs)
 }
@@ -257,6 +259,10 @@ func (dm *DependencyManager) resolveRepository(url string) (repo repository.Down
 	defer dm.mu.Unlock()
 
 	nUrl := repository.NormalizeURL(url)
+	err = repository.ValidateDepURL(nUrl)
+	if err != nil {
+		return
+	}
 	if _, ok := dm.downloaders[nUrl]; !ok {
 		if dm.getChartDownloaderCallback == nil {
 			err = fmt.Errorf("no chart repository for URL '%s'", nUrl)

--- a/internal/helm/chart/dependency_manager_test.go
+++ b/internal/helm/chart/dependency_manager_test.go
@@ -93,6 +93,7 @@ func TestDependencyManager_Clear(t *testing.T) {
 		},
 		"with credentials":    ociRepoWithCreds,
 		"without credentials": &repository.OCIChartRepository{},
+		"nil downloader":      nil,
 	}
 
 	dm := NewDependencyManager(WithRepositories(downloaders))
@@ -427,6 +428,14 @@ func TestDependencyManager_addRemoteDependency(t *testing.T) {
 				Repository: "https://example.com",
 			},
 			wantErr: "no chart repository for URL",
+		},
+		{
+			name:        "resolve aliased repository error",
+			downloaders: map[string]repository.Downloader{},
+			dep: &helmchart.Dependency{
+				Repository: "@fantastic-charts",
+			},
+			wantErr: "aliased repository dependency is not supported",
 		},
 		{
 			name: "strategic load error",


### PR DESCRIPTION
fixes #815 

If implemented, this make sure that we clear only referenced downloaders.

It is also checked if the repository url is supported.

Signed-off-by: Soule BA <soule@weave.works>