### PR TITLE
support plain HTTP OCI registries in HelmRepositories

### DIFF
--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -89,6 +89,10 @@ type HelmRepositorySpec struct {
 	// +kubebuilder:validation:Enum=default;oci
 	// +optional
 	Type string `json:"type,omitempty"`
+
+	// Insecure allows connecting to a non-TLS/plain HTTP OCI endpoint.
+	// +optional
+	Insecure bool `json:"insecure,omitempty"`
 }
 
 // HelmRepositoryStatus records the observed state of the HelmRepository.

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -299,6 +299,10 @@ spec:
                 required:
                 - namespaceSelectors
                 type: object
+              insecure:
+                description: Insecure allows connecting to a non-TLS/plain HTTP OCI
+                  endpoint.
+                type: boolean
               interval:
                 description: Interval at which to check the URL for updates.
                 type: string

--- a/internal/helm/registry/client.go
+++ b/internal/helm/registry/client.go
@@ -27,7 +27,7 @@ import (
 // ClientGenerator generates a registry client and a temporary credential file.
 // The client is meant to be used for a single reconciliation.
 // The file is meant to be used for a single reconciliation and deleted after.
-func ClientGenerator(isLogin bool) (*registry.Client, string, error) {
+func ClientGenerator(isLogin, plainHTTP bool) (*registry.Client, string, error) {
 	if isLogin {
 		// create a temporary file to store the credentials
 		// this is needed because otherwise the credentials are stored in ~/.docker/config.json.
@@ -37,7 +37,14 @@ func ClientGenerator(isLogin bool) (*registry.Client, string, error) {
 		}
 
 		var errs []error
-		rClient, err := registry.NewClient(registry.ClientOptWriter(io.Discard), registry.ClientOptCredentialsFile(credentialsFile.Name()))
+		opts := []registry.ClientOption{
+			registry.ClientOptWriter(io.Discard),
+			registry.ClientOptCredentialsFile(credentialsFile.Name()),
+		}
+		if plainHTTP {
+			opts = append(opts, registry.ClientOptPlainHTTP())
+		}
+		rClient, err := registry.NewClient(opts...)
 		if err != nil {
 			errs = append(errs, err)
 			// attempt to delete the temporary file


### PR DESCRIPTION
The new field `.spec.insecure` in the HelmRepository CRD signals to
the controllers that the registry is served via HTTP and not HTTPS.

closes #807 

**NOTE**: This PR depends on a change in the Helm SDK to support configuring the registry client accordingly: https://github.com/helm/helm/pull/11139