### PR TITLE
Fix Panic when no artifact in source

### DIFF
--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -392,7 +392,8 @@ func (r *HelmChartReconciler) reconcileSource(ctx context.Context, obj *sourcev1
 
 	// Assert source has an artifact
 	if s.GetArtifact() == nil || !r.Storage.ArtifactExist(*s.GetArtifact()) {
-		if helmRepo, ok := s.(*sourcev1.HelmRepository); !ok || !helmreg.IsOCI(helmRepo.Spec.URL) {
+		// Set the condition to indicate that the source has no artifact for all types except OCI HelmRepository
+		if helmRepo, ok := s.(*sourcev1.HelmRepository); !ok || helmRepo.Spec.Type != sourcev1.HelmRepositoryTypeOCI {
 			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, "NoSourceArtifact",
 				"no artifact available for %s source '%s'", obj.Spec.SourceRef.Kind, obj.Spec.SourceRef.Name)
 			r.eventLogf(ctx, obj, events.EventTypeTrace, "NoSourceArtifact",


### PR DESCRIPTION
fixes #830 

If implemented, the helmrepository type will be used to decide whether a reconciliation can continue in the absence of source `artifact`, instead of url.

This solve the edge case where we have an https `helmrepository` with an `oci` url.

Signed-off-by: Soule BA <soule@weave.works>