### PR TITLE
Update libgit2 to v1.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.17
 ARG XX_VERSION=1.1.0
 
 ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2-all
-ARG LIBGIT2_TAG=v0.1.1
+ARG LIBGIT2_TAG=v0.1.2
 
 FROM ${LIBGIT2_IMG}:${LIBGIT2_TAG} AS libgit2-libs
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG ?= latest
 
 # Base image used to build the Go binary
 LIBGIT2_IMG ?= ghcr.io/fluxcd/golang-with-libgit2-all
-LIBGIT2_TAG ?= v0.1.1
+LIBGIT2_TAG ?= v0.1.2
 
 # Allows for defining additional Go test args, e.g. '-tags integration'.
 GO_TEST_ARGS ?= -race

--- a/controllers/gitrepository_controller_test.go
+++ b/controllers/gitrepository_controller_test.go
@@ -337,7 +337,12 @@ func TestGitRepositoryReconciler_reconcileSource_authStrategy(t *testing.T) {
 			},
 			wantErr: true,
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.GitOperationFailedReason, "x509: certificate signed by unknown authority"),
+				// The expected error messages may differ when in darwin. In some cases it will match the
+				// error message expected in linux: "x509: certificate signed by unknown authority". In
+				// other cases it may get "x509: “example.com” certificate is not standards compliant" instead.
+				//
+				// Trimming the expected error message for consistent results.
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.GitOperationFailedReason, "x509: "),
 			},
 		},
 		{

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -16,7 +16,7 @@
 
 set -euxo pipefail
 
-LIBGIT2_TAG="${LIBGIT2_TAG:-v0.1.1}"
+LIBGIT2_TAG="${LIBGIT2_TAG:-v0.1.2}"
 GOPATH="${GOPATH:-/root/go}"
 GO_SRC="${GOPATH}/src"
 PROJECT_PATH="github.com/fluxcd/source-controller"


### PR DESCRIPTION
Updates `golang-with-libgit2-all` to `v0.1.2` which contains `libgit2-1.3.2`.

Relates to https://github.com/fluxcd/golang-with-libgit2/pull/33.

Testing image: `ghcr.io/fluxcd/source-controller:rc-b4345783`.