### PR TITLE
fix(openapi): full regex for url to prevent error

### DIFF
--- a/api/v1beta1/gitrepository_types.go
+++ b/api/v1beta1/gitrepository_types.go
@@ -37,7 +37,7 @@ const (
 // GitRepositorySpec defines the desired state of a Git repository.
 type GitRepositorySpec struct {
 	// The repository URL, can be a HTTP/S or SSH address.
-	// +kubebuilder:validation:Pattern="^(http|https|ssh)://"
+	// +kubebuilder:validation:Pattern="^(http|https|ssh)://.*$"
 	// +required
 	URL string `json:"url"`
 

--- a/api/v1beta2/gitrepository_types.go
+++ b/api/v1beta2/gitrepository_types.go
@@ -48,7 +48,7 @@ const (
 // Artifact for a Git repository.
 type GitRepositorySpec struct {
 	// URL specifies the Git repository URL, it can be an HTTP/S or SSH address.
-	// +kubebuilder:validation:Pattern="^(http|https|ssh)://"
+	// +kubebuilder:validation:Pattern="^(http|https|ssh)://.*$"
 	// +required
 	URL string `json:"url"`
 

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -169,7 +169,7 @@ spec:
                 type: string
               url:
                 description: The repository URL, can be a HTTP/S or SSH address.
-                pattern: ^(http|https|ssh)://
+                pattern: ^(http|https|ssh)://.*$
                 type: string
               verify:
                 description: Verify OpenPGP signature for the Git commit HEAD points
@@ -513,7 +513,7 @@ spec:
               url:
                 description: URL specifies the Git repository URL, it can be an HTTP/S
                   or SSH address.
-                pattern: ^(http|https|ssh)://
+                pattern: ^(http|https|ssh)://.*$
                 type: string
               verify:
                 description: Verification specifies the configuration to verify the


### PR DESCRIPTION
In IDEA, the previous pattern led to an error because the regex wasn't complete. 

<img width="851" alt="image" src="https://user-images.githubusercontent.com/1970922/179714084-4494f075-966a-4143-981d-d8d17318b2fb.png">

If there is some extra work to do, let me know. 

Signed-off-by: Davin Kevin <davin.kevin@gmail.com>