### PR TITLE
build: disable matrix fail-fast

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,6 +64,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-10.15, macos-11, macos-12]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Intermittent issues are causing the test matrix to fail and whenever that happens, all other matrix options are automatically cancelled. This increases the amount of retries needed in order to get all tests to pass.

This decreases the impact of https://github.com/fluxcd/source-controller/issues/841.