### PR TITLE
libgit2: upgrade to golang-with-libgit2 v0.1.4

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -5,61 +5,6 @@ code of their open source projects along with license information below.
 We acknowledge and are grateful to these developers for their contributions
 to open source.
 
-## libssh2
-
-Libssh2 was obtained in source-code form from its github repository: 
-https://github.com/libssh2/libssh2/
-
-No changes were made to its original source code. 
-
-Copyright notice (https://raw.githubusercontent.com/libssh2/libssh2/master/COPYING):
-
-/* Copyright (c) 2004-2007 Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2005,2006 Mikhail Gusarov <dottedmag@dottedmag.net>
- * Copyright (c) 2006-2007 The Written Word, Inc.
- * Copyright (c) 2007 Eli Fant <elifantu@mail.ru>
- * Copyright (c) 2009-2021 Daniel Stenberg
- * Copyright (C) 2008, 2009 Simon Josefsson
- * Copyright (c) 2000 Markus Friedl
- * Copyright (c) 2015 Microsoft Corp.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms,
- * with or without modification, are permitted provided
- * that the following conditions are met:
- *
- *   Redistributions of source code must retain the above
- *   copyright notice, this list of conditions and the
- *   following disclaimer.
- *
- *   Redistributions in binary form must reproduce the above
- *   copyright notice, this list of conditions and the following
- *   disclaimer in the documentation and/or other materials
- *   provided with the distribution.
- *
- *   Neither the name of the copyright holder nor the names
- *   of any other contributors may be used to endorse or
- *   promote products derived from this software without
- *   specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
- * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
- * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
- * OF SUCH DAMAGE.
- */
-
-***
-
 ## libgit2
 
 Libgit2 was obtained in source-code form from its github repository: 
@@ -1254,38 +1199,3 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-***
-
-## zlib
-
-Zlib was obtained in binary form via official distribution channels.
-No changes were made to its original source code. 
-
-Copyright notice (https://zlib.net/zlib_license.html):
-
- /* zlib.h -- interface of the 'zlib' general purpose compression library
-  version 1.2.11, January 15th, 2017
-
-  Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
-
-  This software is provided 'as-is', without any express or implied
-  warranty.  In no event will the authors be held liable for any damages
-  arising from the use of this software.
-
-  Permission is granted to anyone to use this software for any purpose,
-  including commercial applications, and to alter it and redistribute it
-  freely, subject to the following restrictions:
-
-  1. The origin of this software must not be misrepresented; you must not
-     claim that you wrote the original software. If you use this software
-     in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required.
-  2. Altered source versions must be plainly marked as such, and must not be
-     misrepresented as being the original software.
-  3. This notice may not be removed or altered from any source distribution.
-
-  Jean-loup Gailly        Mark Adler
-  jloup@gzip.org          madler@alumni.caltech.edu
-
-*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ ARG BASE_VARIANT=alpine
 ARG GO_VERSION=1.17
 ARG XX_VERSION=1.1.0
 
-ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2-all
-ARG LIBGIT2_TAG=v0.1.2
+ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2-only
+ARG LIBGIT2_TAG=v0.1.4
 
 FROM ${LIBGIT2_IMG}:${LIBGIT2_TAG} AS libgit2-libs
 
@@ -82,9 +82,8 @@ ENV CGO_ENABLED=1
 
 # Instead of using xx-go, (cross) compile with vanilla go leveraging musl tool chain.
 RUN export $(cat build/musl/$(xx-info alpine-arch).env | xargs) && \
-    export LIBRARY_PATH="/usr/local/$(xx-info triple):/usr/local/$(xx-info triple)/lib64" && \
-    export PKG_CONFIG_PATH="/usr/local/$(xx-info triple)/lib/pkgconfig:/usr/local/$(xx-info triple)/lib64/pkgconfig" && \
-    export CGO_LDFLAGS="$(pkg-config --static --libs --cflags libssh2 openssl libgit2) -static" && \
+    export PKG_CONFIG_PATH="/usr/local/$(xx-info triple)/lib/pkgconfig" && \
+    export CGO_LDFLAGS="$(pkg-config --static --libs --cflags libgit2) -static" && \
     GOARCH=$TARGETARCH go build  \
         -ldflags "-s -w" \
         -tags 'netgo,osusergo,static_build' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_VARIANT=alpine
 ARG GO_VERSION=1.17
-ARG XX_VERSION=1.1.0
+ARG XX_VERSION=1.1.2
 
 ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2-only
 ARG LIBGIT2_TAG=v0.1.4

--- a/hack/install-libraries.sh
+++ b/hack/install-libraries.sh
@@ -74,12 +74,12 @@ extract_libraries(){
 }
 
 fix_pkgconfigs(){
-    DIR="$1"
     NEW_DIR="$(/bin/pwd)/build/libgit2/${TAG}"
 
     # Update the prefix paths included in the .pc files.
     if [[ $OSTYPE == 'darwin'* ]]; then
-        INSTALLED_DIR="/Users/runner/work/golang-with-libgit2/golang-with-libgit2/build/${DIR}"
+        # https://github.com/fluxcd/golang-with-libgit2/blob/v0.1.4/.github/workflows/release.yaml#L158
+        INSTALLED_DIR="/Users/runner/work/golang-with-libgit2/golang-with-libgit2/build/libgit2-darwin-amd64"
 
         # This will make it easier to update to the location in which they will be used.
         # sed has a sight different behaviour in MacOS
@@ -90,7 +90,8 @@ fix_pkgconfigs(){
             find "${NEW_DIR}" -type f -name "*.pc" | xargs -I {} sed -i "" "s;${INSTALLED_DIR};${NEW_DIR};g" {}
         fi
     else
-        INSTALLED_DIR="/home/runner/work/golang-with-libgit2/golang-with-libgit2/build/${DIR}"
+        # https://github.com/fluxcd/golang-with-libgit2/blob/v0.1.4/.github/workflows/release.yaml#L52
+        INSTALLED_DIR="/home/runner/work/golang-with-libgit2/golang-with-libgit2/build/build_libgit2_only"
     
         find "${NEW_DIR}" -type f -name "*.pc" | xargs -I {} sed -i "s;${INSTALLED_DIR};${NEW_DIR};g" {}
     fi
@@ -136,17 +137,17 @@ install_libraries(){
         fi
     fi
 
-    FILE_NAME="linux-$(uname -m)-all-libs.tar.gz"
-    DIR="libgit2-linux-all-libs"
+    FILE_NAME="linux-x86_64-libgit2-only.tar.gz"
+    DIR="linux-libgit2-only"
     if [[ $OSTYPE == 'darwin'* ]]; then
-        FILE_NAME="darwin-all-libs.tar.gz"
-        DIR="darwin-all-libs"
+        FILE_NAME="darwin-libgit2-only.tar.gz"
+        DIR="darwin-libgit2-only"
     fi
 
     download_files "${FILE_NAME}"
     assure_provenance "${FILE_NAME}"
     extract_libraries "${FILE_NAME}" "${DIR}"
-    fix_pkgconfigs "${DIR}"
+    fix_pkgconfigs
 }
 
 install_libraries

--- a/hack/update-attributions.sh
+++ b/hack/update-attributions.sh
@@ -12,19 +12,6 @@ code of their open source projects along with license information below.
 We acknowledge and are grateful to these developers for their contributions
 to open source.
 
-## libssh2
-
-Libssh2 was obtained in source-code form from its github repository: 
-https://github.com/libssh2/libssh2/
-
-No changes were made to its original source code. 
-
-Copyright notice (https://raw.githubusercontent.com/libssh2/libssh2/master/COPYING):
-
-$(curl --max-time 5 -L https://raw.githubusercontent.com/libssh2/libssh2/master/COPYING)
-
-${SPLIT}
-
 ## libgit2
 
 Libgit2 was obtained in source-code form from its github repository: 
@@ -35,39 +22,4 @@ No changes were made to its original source code.
 Copyright notice (https://raw.githubusercontent.com/libgit2/libgit2/main/COPYING):
 
 $(curl --max-time 5 -L https://raw.githubusercontent.com/libgit2/libgit2/main/COPYING)
-
-${SPLIT}
-
-## zlib
-
-Zlib was obtained in binary form via official distribution channels.
-No changes were made to its original source code. 
-
-Copyright notice (https://zlib.net/zlib_license.html):
-
- /* zlib.h -- interface of the 'zlib' general purpose compression library
-  version 1.2.11, January 15th, 2017
-
-  Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
-
-  This software is provided 'as-is', without any express or implied
-  warranty.  In no event will the authors be held liable for any damages
-  arising from the use of this software.
-
-  Permission is granted to anyone to use this software for any purpose,
-  including commercial applications, and to alter it and redistribute it
-  freely, subject to the following restrictions:
-
-  1. The origin of this software must not be misrepresented; you must not
-     claim that you wrote the original software. If you use this software
-     in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required.
-  2. Altered source versions must be plainly marked as such, and must not be
-     misrepresented as being the original software.
-  3. This notice may not be removed or altered from any source distribution.
-
-  Jean-loup Gailly        Mark Adler
-  jloup@gzip.org          madler@alumni.caltech.edu
-
-*/
 EOF


### PR DESCRIPTION
Upgrade to golang-with-libgit2 v0.1.4 and use libgit2 which is compiled
without being linked to libssh2 and openssl.

Relates to: #782
Fixes: #762 

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>
