### PR TITLE
Don't fetch tags when exact version is specified in `HelmChart`

### DIFF
--- a/internal/helm/chart/dependency_manager_test.go
+++ b/internal/helm/chart/dependency_manager_test.go
@@ -604,6 +604,8 @@ func TestDependencyManager_addRemoteOCIDependency(t *testing.T) {
 			},
 			wantFunc: func(g *WithT, c *helmchart.Chart) {
 				g.Expect(c.Dependencies()).To(HaveLen(1))
+				dep := c.Dependencies()[0]
+				g.Expect(dep).NotTo(BeNil())
 			},
 		},
 		{
@@ -633,9 +635,7 @@ func TestDependencyManager_addRemoteOCIDependency(t *testing.T) {
 						Scheme: "oci",
 						Host:   "example.com",
 					},
-					Client: &mockGetter{
-						Response: chartB,
-					},
+					Client: &mockGetter{},
 					RegistryClient: &mockTagsGetter{
 						tags: map[string][]string{
 							"helmchart": {"0.1.0"},
@@ -648,7 +648,7 @@ func TestDependencyManager_addRemoteOCIDependency(t *testing.T) {
 				Version:    "0.2.0",
 				Repository: "oci://example.com",
 			},
-			wantErr: "could not locate a version matching provided version string 0.2.0",
+			wantErr: "failed to load downloaded archive of version '0.2.0'",
 		},
 		{
 			name: "chart load error",

--- a/internal/helm/repository/oci_chart_repository_test.go
+++ b/internal/helm/repository/oci_chart_repository_test.go
@@ -118,59 +118,68 @@ func TestOCIChartRepository_Get(t *testing.T) {
 	testURL := "oci://localhost:5000/my_repo"
 
 	testCases := []struct {
-		name        string
-		url         string
-		version     string
-		expected    string
-		expectedErr string
+		name           string
+		registryClient RegistryClient
+		url            string
+		version        string
+		expected       string
+		expectedErr    string
 	}{
 		{
-			name:     "should return latest stable version",
-			version:  "",
-			url:      testURL,
-			expected: "1.0.0",
+			name:           "should return latest stable version",
+			registryClient: registryClient,
+			version:        "",
+			url:            testURL,
+			expected:       "1.0.0",
 		},
 		{
-			name:     "should return latest stable version (asterisk)",
-			version:  "*",
-			url:      testURL,
-			expected: "1.0.0",
+			name:           "should return latest stable version (asterisk)",
+			registryClient: registryClient,
+			version:        "*",
+			url:            testURL,
+			expected:       "1.0.0",
 		},
 		{
-			name:     "should return latest stable version (semver range)",
-			version:  ">=0.1.5",
-			url:      testURL,
-			expected: "1.0.0",
+			name:           "should return latest stable version (semver range)",
+			registryClient: registryClient,
+			version:        ">=0.1.5",
+			url:            testURL,
+			expected:       "1.0.0",
 		},
 		{
-			name:     "should return 0.2.0 (semver range)",
-			version:  "0.2.x",
-			url:      testURL,
-			expected: "0.2.0",
+			name:           "should return 0.2.0 (semver range)",
+			registryClient: registryClient,
+			version:        "0.2.x",
+			url:            testURL,
+			expected:       "0.2.0",
 		},
 		{
-			name:     "should return a perfect match",
-			version:  "0.1.0",
-			url:      testURL,
-			expected: "0.1.0",
+			name:           "should return a perfect match",
+			registryClient: nil,
+			version:        "0.1.0",
+			url:            testURL,
+			expected:       "0.1.0",
 		},
 		{
-			name:     "should return 0.10.0",
-			version:  "0.*",
-			url:      testURL,
-			expected: "0.10.0",
+			name:           "should return 0.10.0",
+			registryClient: registryClient,
+			version:        "0.*",
+			url:            testURL,
+			expected:       "0.10.0",
 		},
 		{
-			name:        "should an error for unfunfilled range",
-			version:     ">2.0.0",
-			url:         testURL,
-			expectedErr: "could not locate a version matching provided version string >2.0.0",
+			name:           "should an error for unfulfilled range",
+			registryClient: registryClient,
+			version:        ">2.0.0",
+			url:            testURL,
+			expectedErr:    "could not locate a version matching provided version string >2.0.0",
 		},
 		{
-			name:     "shouldn't error out with trailing slash",
-			version:  "",
-			url:      "oci://localhost:5000/my_repo/",
-			expected: "1.0.0",
+			name:           "shouldn't error out with trailing slash",
+			registryClient: registryClient,
+			version:        "",
+			url:            "oci://localhost:5000/my_repo/",
+			expected:       "1.0.0",
 		},
 	}
 
@@ -178,7 +187,7 @@ func TestOCIChartRepository_Get(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			r, err := NewOCIChartRepository(tc.url, WithOCIRegistryClient(registryClient), WithOCIGetter(providers))
+			r, err := NewOCIChartRepository(tc.url, WithOCIRegistryClient(tc.registryClient), WithOCIGetter(providers))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(r).ToNot(BeNil())
 


### PR DESCRIPTION
Taking this shortcut has two benefits:

1. It allows charts to be fetched from AWS's public container registry
   at public.ecr.aws
2. It makes reconciling a HelmChart faster by skipping one or more
   potentially expensive API calls to the registry.

refs #845
