### PR TITLE
remove MacOS 10.15 from testing matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,7 +63,7 @@ jobs:
   darwin-amd64:
     strategy:
       matrix:
-        os: [macos-10.15, macos-11, macos-12]
+        os: [macos-11, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This version is not supported, anymore. More info at
https://github.com/actions/virtual-environments/issues/5583

Fixes https://github.com/fluxcd/source-controller/issues/843