### PR TITLE
build: Ignore CI workflows for markdown files

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'MAINTAINERS'
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,6 +2,10 @@ name: e2e
 
 on:
   pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'MAINTAINERS'
   push:
     branches:
       - main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,11 @@ name: tests
 
 on:
   pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'MAINTAINERS'
+
   push:
     branches:
       - main

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,6 +2,11 @@ name: verify
 
 on:
   pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'MAINTAINERS'
+
   push:
     branches:
       - main


### PR DESCRIPTION
Running all CI tests at pull requests for some files is sub-optimal, when a PR contain changes to a single file not checked by the tests.