### PR TITLE
fuzz: Ensure Go 1.18 for fuzz image

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -17,6 +17,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18.x
     - name: Restore Go cache
       uses: actions/cache@v3
       with:

--- a/tests/fuzz/Dockerfile.builder
+++ b/tests/fuzz/Dockerfile.builder
@@ -1,4 +1,9 @@
+FROM golang:1.18 AS go
+
 FROM gcr.io/oss-fuzz-base/base-builder-go
+
+# ensures golang 1.18 to enable go native fuzzing.
+COPY --from=go /usr/local/go /usr/local/
 
 COPY ./ $GOPATH/src/github.com/fluxcd/source-controller/
 COPY ./tests/fuzz/oss_fuzz_build.sh $SRC/build.sh

--- a/tests/fuzz/go.mod
+++ b/tests/fuzz/go.mod
@@ -2,6 +2,6 @@ module github.com/fluxcd/source-controller/tests/fuzz
 
 go 1.18
 
-replace github.com/fluxcd/kustomize-controller/api => ../../api
+replace github.com/fluxcd/source-controller/api => ../../api
 
-replace github.com/fluxcd/kustomize-controller => ../../
+replace github.com/fluxcd/source-controller => ../../


### PR DESCRIPTION
Changes:
- Upgrade fuzz container to Go 1.18.
- Upgrade worker to Go 1.18.
- The mod replace in tests/fuzz was pointing to the wrong controller.

Fixes issue on running Fuzz tests:
```
go: downloading github.com/PaesslerAG/gval v1.0.0
go: downloading github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb
# sigs.k8s.io/release-utils/version
/home/runner/go/pkg/mod/sigs.k8s.io/release-utils@v0.7.3/version/version.go:122:25: bi.Settings undefined (type *debug.BuildInfo has no field or method Settings)
note: module requires Go 1.18
make: *** [Makefile:183: /home/runner/work/source-controller/source-controller/build/libgit2/v0.2.0/lib/libgit2.a] Error 2
Error: Process completed with exit code 2.
```
https://github.com/fluxcd/source-controller/runs/7952919815?check_suite_focus=true#step:4:223