### PR TITLE
Enable contextual login in OCI HelmRepository

### DIFF
--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -68,7 +68,9 @@ type HelmRepositorySpec struct {
 	// +required
 	Interval metav1.Duration `json:"interval"`
 
-	// Timeout of the index fetch operation, defaults to 60s.
+	// Timeout is used for the index fetch operation for an HTTPS helm repository,
+	// and for remote OCI Repository operations like pulling for an OCI helm repository.
+	// Its default value is 60s.
 	// +kubebuilder:default:="60s"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
@@ -89,6 +91,14 @@ type HelmRepositorySpec struct {
 	// +kubebuilder:validation:Enum=default;oci
 	// +optional
 	Type string `json:"type,omitempty"`
+
+	// Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+	// This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
+	// When not specified, defaults to 'generic'.
+	// +kubebuilder:validation:Enum=generic;aws;azure;gcp
+	// +kubebuilder:default:=generic
+	// +optional
+	Provider string `json:"provider,omitempty"`
 }
 
 // HelmRepositoryStatus records the observed state of the HelmRepository.

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -310,6 +310,18 @@ spec:
                   be done with caution, as it can potentially result in credentials
                   getting stolen in a MITM-attack.
                 type: boolean
+              provider:
+                default: generic
+                description: Provider used for authentication, can be 'aws', 'azure',
+                  'gcp' or 'generic'. This field is optional, and only taken into
+                  account if the .spec.type field is set to 'oci'. When not specified,
+                  defaults to 'generic'.
+                enum:
+                - generic
+                - aws
+                - azure
+                - gcp
+                type: string
               secretRef:
                 description: SecretRef specifies the Secret containing authentication
                   credentials for the HelmRepository. For HTTP/S basic auth the secret
@@ -328,7 +340,9 @@ spec:
                 type: boolean
               timeout:
                 default: 60s
-                description: Timeout of the index fetch operation, defaults to 60s.
+                description: Timeout is used for the index fetch operation for an
+                  HTTPS helm repository, and for remote OCI Repository operations
+                  like pulling for an OCI helm repository. Its default value is 60s.
                 type: string
               type:
                 description: Type of the HelmRepository. When this field is set to  "oci",

--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -1085,9 +1085,10 @@ func TestHelmChartReconciler_buildFromOCIHelmRepository(t *testing.T) {
 					GenerateName: "helmrepository-",
 				},
 				Spec: sourcev1.HelmRepositorySpec{
-					URL:     fmt.Sprintf("oci://%s/testrepo", testRegistryServer.registryHost),
-					Timeout: &metav1.Duration{Duration: timeout},
-					Type:    sourcev1.HelmRepositoryTypeOCI,
+					URL:      fmt.Sprintf("oci://%s/testrepo", testRegistryServer.registryHost),
+					Timeout:  &metav1.Duration{Duration: timeout},
+					Provider: sourcev1.GenericOCIProvider,
+					Type:     sourcev1.HelmRepositoryTypeOCI,
 				},
 			}
 			obj := &sourcev1.HelmChart{

--- a/controllers/helmrepository_controller_oci_test.go
+++ b/controllers/helmrepository_controller_oci_test.go
@@ -94,7 +94,8 @@ func TestHelmRepositoryOCIReconciler_Reconcile(t *testing.T) {
 					SecretRef: &meta.LocalObjectReference{
 						Name: secret.Name,
 					},
-					Type: sourcev1.HelmRepositoryTypeOCI,
+					Provider: sourcev1.GenericOCIProvider,
+					Type:     sourcev1.HelmRepositoryTypeOCI,
 				},
 			}
 			g.Expect(testEnv.Create(ctx, obj)).To(Succeed())

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -818,7 +818,9 @@ Kubernetes meta/v1.Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>Timeout of the index fetch operation, defaults to 60s.</p>
+<p>Timeout is used for the index fetch operation for an HTTPS helm repository,
+and for remote OCI Repository operations like pulling for an OCI helm repository.
+Its default value is 60s.</p>
 </td>
 </tr>
 <tr>
@@ -861,6 +863,20 @@ string
 <em>(Optional)</em>
 <p>Type of the HelmRepository.
 When this field is set to  &ldquo;oci&rdquo;, the URL field value must be prefixed with &ldquo;oci://&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provider</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Provider used for authentication, can be &lsquo;aws&rsquo;, &lsquo;azure&rsquo;, &lsquo;gcp&rsquo; or &lsquo;generic&rsquo;.
+This field is optional, and only taken into account if the .spec.type field is set to &lsquo;oci&rsquo;.
+When not specified, defaults to &lsquo;generic&rsquo;.</p>
 </td>
 </tr>
 </table>
@@ -2347,7 +2363,9 @@ Kubernetes meta/v1.Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>Timeout of the index fetch operation, defaults to 60s.</p>
+<p>Timeout is used for the index fetch operation for an HTTPS helm repository,
+and for remote OCI Repository operations like pulling for an OCI helm repository.
+Its default value is 60s.</p>
 </td>
 </tr>
 <tr>
@@ -2390,6 +2408,20 @@ string
 <em>(Optional)</em>
 <p>Type of the HelmRepository.
 When this field is set to  &ldquo;oci&rdquo;, the URL field value must be prefixed with &ldquo;oci://&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provider</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Provider used for authentication, can be &lsquo;aws&rsquo;, &lsquo;azure&rsquo;, &lsquo;gcp&rsquo; or &lsquo;generic&rsquo;.
+This field is optional, and only taken into account if the .spec.type field is set to &lsquo;oci&rsquo;.
+When not specified, defaults to &lsquo;generic&rsquo;.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/spec/v1beta2/ocirepositories.md
+++ b/docs/spec/v1beta2/ocirepositories.md
@@ -161,7 +161,7 @@ and by extension gain access to ACR.
 When the kubelet managed identity has access to ACR, source-controller running
 on it will also have access to ACR.
 
-When using aad-pod-identity to enable access to ECR, add the following patch to
+When using aad-pod-identity to enable access to ACR, add the following patch to
 your bootstrap repository, in the `flux-system/kustomization.yaml` file:
 
 ```yaml


### PR DESCRIPTION
If implemented, this pr will enable user to use the auto login feature in order to automatically login to their provider of choice's container registry (i.e. aws, gcr, acr).

This must be tested with the following providers
- [x] aws. This has been tested on an eks cluster (with `IRSA`) that was previously using a cronjob to rotate tokens.
- [x] gcr. This has been tested on gke with a chart in artifact registry.
- [x] acr. Tested by @darkowlzz successfully.

If people have existing running gke or aks clusters, that would be nice to help test this.

Fix: #867
Fix: #870
Implements: https://github.com/fluxcd/flux2/pull/3025