### PR TITLE
[OCIRepository] Add support for non-TLS insecure container registries

### DIFF
--- a/api/v1beta2/ocirepository_types.go
+++ b/api/v1beta2/ocirepository_types.go
@@ -113,6 +113,10 @@ type OCIRepositorySpec struct {
 	// +optional
 	Ignore *string `json:"ignore,omitempty"`
 
+	// Insecure allows connecting to a non-TLS HTTP container registry.
+	// +optional
+	Insecure bool `json:"insecure,omitempty"`
+
 	// This flag tells the controller to suspend the reconciliation of this source.
 	// +optional
 	Suspend bool `json:"suspend,omitempty"`

--- a/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
@@ -72,6 +72,10 @@ spec:
                   a default will be used, consult the documentation for your version
                   to find out what those are.
                 type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS HTTP container
+                  registry.
+                type: boolean
               interval:
                 description: The interval at which to check for image updates.
                 type: string

--- a/controllers/ocirepository_controller.go
+++ b/controllers/ocirepository_controller.go
@@ -301,7 +301,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, obj *sour
 	ctxTimeout, cancel := context.WithTimeout(ctx, obj.Spec.Timeout.Duration)
 	defer cancel()
 
-	options := r.craneOptions(ctxTimeout)
+	options := r.craneOptions(ctxTimeout, obj.Spec.Insecure)
 
 	// Generate the registry credential keychain either from static credentials or using cloud OIDC
 	keychain, err := r.keychain(ctx, obj)
@@ -684,12 +684,16 @@ func (r *OCIRepositoryReconciler) oidcAuth(ctx context.Context, obj *sourcev1.OC
 
 // craneOptions sets the auth headers, timeout and user agent
 // for all operations against remote container registries.
-func (r *OCIRepositoryReconciler) craneOptions(ctx context.Context) []crane.Option {
+func (r *OCIRepositoryReconciler) craneOptions(ctx context.Context, insecure bool) []crane.Option {
 	options := []crane.Option{
 		crane.WithContext(ctx),
 		crane.WithUserAgent(oci.UserAgent),
 	}
-	options = append(options, crane.Insecure)
+
+	if insecure {
+		options = append(options, crane.Insecure)
+	}
+
 	return options
 }
 

--- a/controllers/ocirepository_controller.go
+++ b/controllers/ocirepository_controller.go
@@ -689,6 +689,7 @@ func (r *OCIRepositoryReconciler) craneOptions(ctx context.Context) []crane.Opti
 		crane.WithContext(ctx),
 		crane.WithUserAgent(oci.UserAgent),
 	}
+	options = append(options, crane.Insecure)
 	return options
 }
 

--- a/controllers/ocirepository_controller_test.go
+++ b/controllers/ocirepository_controller_test.go
@@ -623,7 +623,7 @@ func TestOCIRepository_reconcileSource_authStrategy(t *testing.T) {
 				Storage:       testStorage,
 			}
 
-			opts := r.craneOptions(ctx)
+			opts := r.craneOptions(ctx, true)
 			opts = append(opts, crane.WithAuthFromKeychain(authn.DefaultKeychain))
 			repoURL, err := r.getArtifactURL(obj, opts)
 			g.Expect(err).To(BeNil())
@@ -1158,7 +1158,7 @@ func TestOCIRepository_getArtifactURL(t *testing.T) {
 				obj.Spec.Reference = tt.reference
 			}
 
-			opts := r.craneOptions(ctx)
+			opts := r.craneOptions(ctx, true)
 			opts = append(opts, crane.WithAuthFromKeychain(authn.DefaultKeychain))
 			got, err := r.getArtifactURL(obj, opts)
 			if tt.wantErr {

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -1107,6 +1107,18 @@ consult the documentation for your version to find out what those are.</p>
 </tr>
 <tr>
 <td>
+<code>insecure</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Insecure allows connecting to a non-TLS HTTP container registry.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>suspend</code><br>
 <em>
 bool
@@ -2835,6 +2847,18 @@ string
 <p>Ignore overrides the set of excluded patterns in the .sourceignore format
 (which is the same as .gitignore). If not provided, a default will be used,
 consult the documentation for your version to find out what those are.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>insecure</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Insecure allows connecting to a non-TLS HTTP container registry.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta2/ocirepositories.md
+++ b/docs/spec/v1beta2/ocirepositories.md
@@ -287,6 +287,12 @@ kubectl create secret generic tls-certs \
   --from-file=caFile=ca.crt
 ```
 
+### Insecure
+
+`.spec.insecure` is an optional field to allow connecting to an insecure (HTTP)
+container registry server, if set to `true`. The default value is `false`,
+denying insecure (HTTP) connections.
+
 ### Interval
 
 `.spec.interval` is a required field that specifies the interval at which the


### PR DESCRIPTION
This PR adds an optinal field named `insecure` to the OCIRepository API. With `spec.insecure` we allow Flux to work with in-cluster container registries such as [Kubernetes Kind Docker registry](https://kind.sigs.k8s.io/docs/user/local-registry/). This will enable users to run Flux locally for dev/testing without the need to connect their local clusters to a registry SaaS or setup TLS with self-signed certs. 

PS. In the future, the insecure flags will be subject to https://github.com/fluxcd/source-controller/issues/806 so that cluster admin could disable this behaviour on production environments.