### PR TITLE
[OCI] Static credentials should take precedence over the OIDC provider

### DIFF
--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -516,10 +516,8 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 		}
 
 		loginOpts = append([]helmreg.LoginOption{}, loginOpt)
-	}
-
-	if repo.Spec.Provider != sourcev1.GenericOCIProvider && repo.Spec.Type == sourcev1.HelmRepositoryTypeOCI {
-		auth, authErr := oidcAuth(ctxTimeout, repo)
+	} else if repo.Spec.Provider != sourcev1.GenericOCIProvider && repo.Spec.Type == sourcev1.HelmRepositoryTypeOCI {
+		auth, authErr := oidcAuthFromAdapter(ctxTimeout, repo.Spec.URL, repo.Spec.Provider)
 		if authErr != nil && !errors.Is(authErr, oci.ErrUnconfiguredProvider) {
 			e := &serror.Event{
 				Err:    fmt.Errorf("failed to get credential from %s: %w", repo.Spec.Provider, authErr),
@@ -991,10 +989,8 @@ func (r *HelmChartReconciler) namespacedChartRepositoryCallback(ctx context.Cont
 			}
 
 			loginOpts = append([]helmreg.LoginOption{}, loginOpt)
-		}
-
-		if repo.Spec.Provider != sourcev1.GenericOCIProvider && repo.Spec.Type == sourcev1.HelmRepositoryTypeOCI {
-			auth, authErr := oidcAuth(ctxTimeout, repo)
+		} else if repo.Spec.Provider != sourcev1.GenericOCIProvider && repo.Spec.Type == sourcev1.HelmRepositoryTypeOCI {
+			auth, authErr := oidcAuthFromAdapter(ctxTimeout, repo.Spec.URL, repo.Spec.Provider)
 			if authErr != nil && !errors.Is(authErr, oci.ErrUnconfiguredProvider) {
 				return nil, fmt.Errorf("failed to get credential from %s: %w", repo.Spec.Provider, authErr)
 			}

--- a/internal/util/auth.go
+++ b/internal/util/auth.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "github.com/google/go-containerregistry/pkg/authn"
+
+// Anonymous is an authn.AuthConfig that always returns an anonymous
+// authenticator. It is useful for registries that do not require authentication
+// or when the credentials are not known.
+// It implements authn.Keychain `Resolve` method and can be used as a keychain.
+type Anonymous authn.AuthConfig
+
+// Resolve implements authn.Keychain.
+func (a Anonymous) Resolve(_ authn.Resource) (authn.Authenticator, error) {
+	return authn.Anonymous, nil
+}


### PR DESCRIPTION
fixes #874 

If `spec.SecretRef` or `spec.ServiceAccountName` is provided, the controller will use the static credentials from the referenced secret.

Otherwise, if a non-generic provider is present in the definition, the controller will try to resolve credentials from the provider.

Signed-off-by: Soule BA <soule@weave.works>