### PR TITLE
Remove custom reconcileID value from OCI HelmRepo logger and context overwrite

### DIFF
--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -249,10 +249,6 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	start := time.Now()
 	log := ctrl.LoggerFrom(ctx)
 
-	// logger will be associated to the new context that is
-	// returned from ctrl.LoggerInto.
-	ctx = ctrl.LoggerInto(ctx, log)
-
 	// Fetch the Bucket
 	obj := &sourcev1.Bucket{}
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {

--- a/controllers/gitrepository_controller.go
+++ b/controllers/gitrepository_controller.go
@@ -164,10 +164,6 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	start := time.Now()
 	log := ctrl.LoggerFrom(ctx)
 
-	// logger will be associated to the new context that is
-	// returned from ctrl.LoggerInto.
-	ctx = ctrl.LoggerInto(ctx, log)
-
 	// Fetch the GitRepository
 	obj := &sourcev1.GitRepository{}
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {

--- a/controllers/helmchart_controller.go
+++ b/controllers/helmchart_controller.go
@@ -185,10 +185,6 @@ func (r *HelmChartReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	start := time.Now()
 	log := ctrl.LoggerFrom(ctx)
 
-	// logger will be associated to the new context that is
-	// returned from ctrl.LoggerInto.
-	ctx = ctrl.LoggerInto(ctx, log)
-
 	// Fetch the HelmChart
 	obj := &sourcev1.HelmChart{}
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -150,10 +150,6 @@ func (r *HelmRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	start := time.Now()
 	log := ctrl.LoggerFrom(ctx)
 
-	// logger will be associated to the new context that is
-	// returned from ctrl.LoggerInto.
-	ctx = ctrl.LoggerInto(ctx, log)
-
 	// Fetch the HelmRepository
 	obj := &sourcev1.HelmRepository{}
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {

--- a/controllers/helmrepository_controller_oci.go
+++ b/controllers/helmrepository_controller_oci.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -113,9 +112,7 @@ func (r *HelmRepositoryOCIReconciler) SetupWithManagerAndOptions(mgr ctrl.Manage
 
 func (r *HelmRepositoryOCIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	start := time.Now()
-	log := ctrl.LoggerFrom(ctx).
-		// Sets a reconcile ID to correlate logs from all suboperations.
-		WithValues("reconcileID", uuid.NewUUID())
+	log := ctrl.LoggerFrom(ctx)
 
 	// logger will be associated to the new context that is
 	// returned from ctrl.LoggerInto.

--- a/controllers/helmrepository_controller_oci.go
+++ b/controllers/helmrepository_controller_oci.go
@@ -114,10 +114,6 @@ func (r *HelmRepositoryOCIReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	start := time.Now()
 	log := ctrl.LoggerFrom(ctx)
 
-	// logger will be associated to the new context that is
-	// returned from ctrl.LoggerInto.
-	ctx = ctrl.LoggerInto(ctx, log)
-
 	// Fetch the HelmRepository
 	obj := &sourcev1.HelmRepository{}
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {

--- a/controllers/ocirepository_controller.go
+++ b/controllers/ocirepository_controller.go
@@ -161,10 +161,6 @@ func (r *OCIRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	start := time.Now()
 	log := ctrl.LoggerFrom(ctx)
 
-	// logger will be associated to the new context that is
-	// returned from ctrl.LoggerInto.
-	ctx = ctrl.LoggerInto(ctx, log)
-
 	// Fetch the OCIRepository
 	obj := &sourcev1.OCIRepository{}
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {


### PR DESCRIPTION
With the new controller-runtime, the `reconcileID` is automatically set
per reconciliation and need not be set explicitly. It's was missed in #882
for the OCI helm repository reconciler.

In all the reconcilers, context was overwritten after adding new
log field `reconcileID` in the logger. Since the `reconcileID` is now
set by controller-runtime, this is no longer needed. The logger in the
context already has the field set and when the context is passed to
other functions, they too get the logger with the `reconcileID` set.
Refer #778 where it was introduced.

Follow up of https://github.com/fluxcd/source-controller/pull/882 