### PR TITLE
CI: Revert Public ECR push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,18 +39,6 @@ jobs:
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ECR_ROLE_TO_ASSUME }}
-          aws-region: us-east-1
-      - name: Login to Amazon ECR Public
-        id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          registry-type: public
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -69,7 +57,6 @@ jobs:
           images: |
             fluxcd/${{ env.CONTROLLER }}
             ghcr.io/fluxcd/${{ env.CONTROLLER }}
-            public.ecr.aws/fluxcd/${{ env.CONTROLLER }}
           tags: |
             type=raw,value=${{ steps.prep.outputs.VERSION }}
       - name: Publish images
@@ -86,7 +73,6 @@ jobs:
         run: |
           docker buildx imagetools inspect docker.io/fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
           docker buildx imagetools inspect ghcr.io/fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
-          docker buildx imagetools inspect public.ecr.aws/fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
           docker pull docker.io/fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
           docker pull ghcr.io/fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
       - uses: sigstore/cosign-installer@main
@@ -96,7 +82,6 @@ jobs:
         run: |
           cosign sign fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
           cosign sign ghcr.io/fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
-          cosign sign public.ecr.aws/fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
       - name: Generate release artifacts
         if: startsWith(github.ref, 'refs/tags/v')
         run: |


### PR DESCRIPTION
I'm reverting this as the AWS credentials don't work, ref: https://github.com/fluxcd/community/issues/212