### PR TITLE
api: add custom validation for v1.Duration types

### DIFF
--- a/api/v1beta2/bucket_types.go
+++ b/api/v1beta2/bucket_types.go
@@ -78,11 +78,15 @@ type BucketSpec struct {
 	SecretRef *meta.LocalObjectReference `json:"secretRef,omitempty"`
 
 	// Interval at which to check the Endpoint for updates.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +required
 	Interval metav1.Duration `json:"interval"`
 
 	// Timeout for fetch operations, defaults to 60s.
 	// +kubebuilder:default="60s"
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 

--- a/api/v1beta2/gitrepository_types.go
+++ b/api/v1beta2/gitrepository_types.go
@@ -62,11 +62,15 @@ type GitRepositorySpec struct {
 	SecretRef *meta.LocalObjectReference `json:"secretRef,omitempty"`
 
 	// Interval at which to check the GitRepository for updates.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +required
 	Interval metav1.Duration `json:"interval"`
 
 	// Timeout for Git operations like cloning, defaults to 60s.
 	// +kubebuilder:default="60s"
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 

--- a/api/v1beta2/helmchart_types.go
+++ b/api/v1beta2/helmchart_types.go
@@ -46,6 +46,8 @@ type HelmChartSpec struct {
 	SourceRef LocalHelmChartSourceReference `json:"sourceRef"`
 
 	// Interval is the interval at which to check the Source for updates.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +required
 	Interval metav1.Duration `json:"interval"`
 

--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -65,6 +65,8 @@ type HelmRepositorySpec struct {
 	PassCredentials bool `json:"passCredentials,omitempty"`
 
 	// Interval at which to check the URL for updates.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +required
 	Interval metav1.Duration `json:"interval"`
 
@@ -72,6 +74,8 @@ type HelmRepositorySpec struct {
 	// and for remote OCI Repository operations like pulling for an OCI helm repository.
 	// Its default value is 60s.
 	// +kubebuilder:default:="60s"
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 

--- a/api/v1beta2/ocirepository_types.go
+++ b/api/v1beta2/ocirepository_types.go
@@ -99,11 +99,15 @@ type OCIRepositorySpec struct {
 	CertSecretRef *meta.LocalObjectReference `json:"certSecretRef,omitempty"`
 
 	// The interval at which to check for image updates.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +required
 	Interval metav1.Duration `json:"interval"`
 
 	// The timeout for remote OCI Repository operations like pulling, defaults to 60s.
 	// +kubebuilder:default="60s"
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 

--- a/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
@@ -331,6 +331,7 @@ spec:
                 type: boolean
               interval:
                 description: Interval at which to check the Endpoint for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               provider:
                 default: generic
@@ -363,6 +364,7 @@ spec:
               timeout:
                 default: 60s
                 description: Timeout for fetch operations, defaults to 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                 type: string
             required:
             - bucketName

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -459,6 +459,7 @@ spec:
                 type: array
               interval:
                 description: Interval at which to check the GitRepository for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               recurseSubmodules:
                 description: RecurseSubmodules enables the initialization of all submodules
@@ -510,6 +511,7 @@ spec:
                 default: 60s
                 description: Timeout for Git operations like cloning, defaults to
                   60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                 type: string
               url:
                 description: URL specifies the Git repository URL, it can be an HTTP/S

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -352,6 +352,7 @@ spec:
               interval:
                 description: Interval is the interval at which to check the Source
                   for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               reconcileStrategy:
                 default: ChartVersion

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -302,6 +302,7 @@ spec:
                 type: object
               interval:
                 description: Interval at which to check the URL for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               passCredentials:
                 description: PassCredentials allows the credentials from the SecretRef
@@ -344,6 +345,7 @@ spec:
                 description: Timeout is used for the index fetch operation for an
                   HTTPS helm repository, and for remote OCI Repository operations
                   like pulling for an OCI helm repository. Its default value is 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                 type: string
               type:
                 description: Type of the HelmRepository. When this field is set to  "oci",

--- a/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
@@ -78,6 +78,7 @@ spec:
                 type: boolean
               interval:
                 description: The interval at which to check for image updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               layerSelector:
                 description: LayerSelector specifies which layer should be extracted
@@ -140,6 +141,7 @@ spec:
                 default: 60s
                 description: The timeout for remote OCI Repository operations like
                   pulling, defaults to 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                 type: string
               url:
                 description: URL is a reference to an OCI artifact repository hosted


### PR DESCRIPTION
To solve discrepancies between parsing versus validation.

xref: https://github.com/kubernetes/apimachinery/issues/131
