### PR TITLE
Add custom CA certificates to system certificates

### DIFF
--- a/internal/helm/getter/getter.go
+++ b/internal/helm/getter/getter.go
@@ -81,7 +81,10 @@ func TLSClientConfigFromSecret(secret corev1.Secret, repositoryUrl string) (*tls
 	}
 
 	if len(caBytes) > 0 {
-		cp := x509.NewCertPool()
+		cp, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("cannot retrieve system certificate pool: %w", err)
+		}
 		if !cp.AppendCertsFromPEM(caBytes) {
 			return nil, fmt.Errorf("cannot append certificate into certificate pool: invalid caFile")
 		}


### PR DESCRIPTION
When a custom CA certificate is provided in a Secret's `caCert` field
referenced in `HelmRepository.spec.secretRef` then that CA cert is now
added to the list of system certificates instead of it replacing the
system certificates. This makes HelmRepositories work in mixed
environments where charts are pulled from both, a public repository
and a private repository (e.g. through a chart dependency).

The test that is added as part of this change will fail without the
change and passes with it.

closes #866
closes fluxcd/helm-controller#519
