### PR TITLE
Consider bipolarity conditions in Ready condition summarization

### DIFF
--- a/controllers/ocirepository_controller.go
+++ b/controllers/ocirepository_controller.go
@@ -719,7 +719,7 @@ func (r *OCIRepositoryReconciler) keychain(ctx context.Context, obj *sourcev1.OC
 		imagePullSecret := corev1.Secret{}
 		err := r.Get(ctx, types.NamespacedName{Namespace: obj.Namespace, Name: imagePullSecretName}, &imagePullSecret)
 		if err != nil {
-			r.eventLogf(ctx, obj, events.EventSeverityTrace, sourcev1.AuthenticationFailedReason,
+			r.eventLogf(ctx, obj, events.EventTypeTrace, sourcev1.AuthenticationFailedReason,
 				"auth secret '%s' not found", imagePullSecretName)
 			return nil, err
 		}


### PR DESCRIPTION
This change can be applied without https://github.com/fluxcd/source-controller/pull/876 but is meant to fix Ready status condition discrepancies when bipolarity conditions, like SourceVerified, is False. It fixes the same issue in GitRepository reconciler for commit verification.

Bipolarity condition is not a typical status property. It is a mix of positive and negative polarities. It's "normal-true" and "abnormal-false". With this change, failing bipolarity conditions are prioritized over other conditions to show the actual reason of failure on the Ready status.
An example of bipolar condition is SourceVerified. When it's verified/normal, its value is True. When it's unverified/fails/abnormal, its value is False.

### Problem

Without special consideration to the bipolarity conditions, when a reconciliation fails, it also leaves the other negative conditions on the status which are usually removed on successful reconciliation. Negative conditions being of the highest priority are set as the value of Ready condition. Example of the status in this scenario:

```yaml
status:
  conditions:
  - lastTransitionTime: "2022-09-20T16:25:54Z"
    message: new digest 'f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4'
      for 'example.com/local-dev/hello-world:1'
    observedGeneration: 1
    reason: NewRevision
    status: "True"
    type: Reconciling
  - lastTransitionTime: "2022-09-20T16:25:54Z"
    message: new digest 'f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4'
      for 'example.com/local-dev/hello-world:1'
    observedGeneration: 1
    reason: NewRevision
    status: "False"
    type: Ready
  - lastTransitionTime: "2022-09-20T16:25:54Z"
    message: new digest 'f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4'
      for 'example.com/local-dev/hello-world:1'
    observedGeneration: 1
    reason: NewRevision
    status: "True"
    type: ArtifactOutdated
  - lastTransitionTime: "2022-09-20T16:25:54Z"
    message: 'failed to verify the signature using provider ''cosign'': no matching
      signatures were found for ''example.com/local-dev/hello-world:1'''
    observedGeneration: 1
    reason: VerificationError
    status: "False"
    type: SourceVerified
  observedGeneration: -1
```
In the above scenario, the Ready condition shows the reason for not being Ready as `new digest ... for ...`. This value of Ready doesn't indicate the actual reason for the failure, which is the source verification failure. Because we couldn't verify the source, new artifact wasn't created.

### Solution

In order to fix this, failing bipolarity conditions need to be prioritized over any other reconciling conditions.
The changes in internal/reconcile/summarize/summary.go fix this issue by evaluating the value of bipolar conditions in the status. With this, the above scenario becomes:

```yaml
status:
  conditions:
  - lastTransitionTime: "2022-09-21T20:11:13Z"
    message: new digest 'f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4'
      for 'example.com/local-dev/hello-world:1'
    observedGeneration: 1
    reason: NewRevision
    status: "True"
    type: Reconciling
  - lastTransitionTime: "2022-09-21T20:11:13Z"
    message: 'failed to verify the signature using provider ''cosign'': no matching
      signatures were found for ''example.com/local-dev/hello-world:1'''
    observedGeneration: 1
    reason: VerificationError
    status: "False"
    type: Ready
  - lastTransitionTime: "2022-09-21T20:11:13Z"
    message: new digest 'f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4'
      for 'example.com/local-dev/hello-world:1'
    observedGeneration: 1
    reason: NewRevision
    status: "True"
    type: ArtifactOutdated
  - lastTransitionTime: "2022-09-21T20:11:13Z"
    message: 'failed to verify the signature using provider ''cosign'': no matching
      signatures were found for ''example.com/local-dev/hello-world:1'''
    observedGeneration: 1
    reason: VerificationError
    status: "False"
    type: SourceVerified
  observedGeneration: -1
```
The Ready condition now shows the actual reason for the failure `failed to verify the signature using provider...`.

Now, since bipolarity gets the highest priority when it's False, even in presence of other negative conditions, this could results in scenarios like the following:

```yaml
  conditions:
  - lastTransitionTime: "2022-09-21T21:17:25Z"
    message: reconciling new object generation (6)
    observedGeneration: 6
    reason: NewGeneration
    status: "True"
    type: Reconciling
  - lastTransitionTime: "2022-09-21T21:17:09Z"
    message: 'failed to verify the signature using provider ''cosign'': no matching
      signatures were found for ''example.com/local-dev/hello-world:1'''
    observedGeneration: 6
    reason: VerificationError
    status: "False"
    type: Ready
  - lastTransitionTime: "2022-09-21T21:17:25Z"
    message: 'failed to get credential: Secret "blah" not found'
    observedGeneration: 6
    reason: AuthenticationFailed
    status: "True"
    type: FetchFailed
  - lastTransitionTime: "2022-09-21T21:17:09Z"
    message: 'failed to verify the signature using provider ''cosign'': no matching
      signatures were found for ''example.com/local-dev/hello-world:1'''
    observedGeneration: 5
    reason: VerificationError
    status: "False"
    type: SourceVerified
  - lastTransitionTime: "2022-09-21T21:15:42Z"
    message: stored artifact for digest 'f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4'
    observedGeneration: 4
    reason: Succeeded
    status: "True"
    type: ArtifactInStorage
  observedGeneration: 4
```
In this, Ready shows that the failure is due to verification failure, but FetchFailed condition shows that the actual reason for the failure is an authentication failure. Since bipolar False conditions are of the highest priority, their presence need to be handled better. The above situation is due to a stale SourceVerified=False condition from the previous reconciliation.

For the record, the same is seen in GitRepository with commit verification enabled:

```yaml
  conditions:
  - lastTransitionTime: "2022-09-21T21:41:54Z"
    message: reconciling new object generation (11)
    observedGeneration: 11
    reason: NewGeneration
    status: "True"
    type: Reconciling
  - lastTransitionTime: "2022-09-21T21:41:27Z"
    message: 'signature verification of commit ''4f5cdeba0c59c98c1fbc0ffdac7ff4de62abef35''
      failed: failed to verify commit with any of the given key rings'
    observedGeneration: 11
    reason: InvalidCommitSignature
    status: "False"
    type: Ready
  - lastTransitionTime: "2022-09-21T21:41:54Z"
    message: 'failed to get secret ''default/blah'': Secret "blah" not found'
    observedGeneration: 11
    reason: AuthenticationFailed
    status: "True"
    type: FetchFailed
  - lastTransitionTime: "2022-09-21T20:43:56Z"
    message: stored artifact for revision 'main/4f5cdeba0c59c98c1fbc0ffdac7ff4de62abef35'
    observedGeneration: 10
    reason: Succeeded
    status: "True"
    type: ArtifactInStorage
  - lastTransitionTime: "2022-09-21T21:41:27Z"
    message: 'signature verification of commit ''4f5cdeba0c59c98c1fbc0ffdac7ff4de62abef35''
      failed: failed to verify commit with any of the given key rings'
    observedGeneration: 10
    reason: InvalidCommitSignature
    status: "False"
    type: SourceVerified
  contentConfigChecksum: sha256:fcbcf165908dd18a9e49f7ff27810176db8e9f63b4352213741664245224f8aa
  observedGeneration: 10
```

A way to solve this is to remove any stale failing bipolarity condition at the beginning of the reconciliation and let it be recalculated if it's still failing. But leave any stale True bipolarity conditions as they don't have high priority.
Result of this fix is:

```yaml
  conditions:
  - lastTransitionTime: "2022-09-21T21:38:36Z"
    message: reconciling new object generation (8)
    observedGeneration: 8
    reason: NewGeneration
    status: "True"
    type: Reconciling
  - lastTransitionTime: "2022-09-21T21:38:36Z"
    message: 'failed to get credential: Secret "blah" not found'
    observedGeneration: 8
    reason: AuthenticationFailed
    status: "False"
    type: Ready
  - lastTransitionTime: "2022-09-21T21:17:25Z"
    message: 'failed to get credential: Secret "blah" not found'
    observedGeneration: 8
    reason: AuthenticationFailed
    status: "True"
    type: FetchFailed
  - lastTransitionTime: "2022-09-21T21:15:42Z"
    message: stored artifact for digest 'f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4'
    observedGeneration: 4
    reason: Succeeded
    status: "True"
    type: ArtifactInStorage
  observedGeneration: 4
```
The same examples apply to GitRepository reconciler. Both OCIRepository and GitRepository reconcilers have also been updated to handle these concerns.