### PR TITLE
[OCIRepository] Produce Helm chart artifacts

### DIFF
--- a/api/v1beta2/ocirepository_types.go
+++ b/api/v1beta2/ocirepository_types.go
@@ -231,6 +231,11 @@ func (in *OCIRepository) GetLayerMediaType() string {
 	return in.Spec.LayerSelector.MediaType
 }
 
+// IsHelmMediaType returns true if the selector is set to 'application/vnd.cncf.helm.chart.content.v1.tar+gzip'
+func (in *OCIRepository) IsHelmMediaType() bool {
+	return in.GetLayerMediaType() == "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
+}
+
 // +genclient
 // +genclient:Namespaced
 // +kubebuilder:storageversion


### PR DESCRIPTION
This PR changes the behaviour of the OCIRepository controller when `.spec.layerSelector.mediaType` is set to `application/vnd.cncf.helm.chart.content.v1.tar+gzip`, to make the resulting Flux artifact compatible with Helm.

IMO OCIRepositories should produce valid Helm chart artifacts even if we chose not to use them in helm-controller. If we do chose to add `OCIRepository` as source to `HelmReleases`, then this will enable chart verification (cosgin + keyless), insecure registries which are blocked upstream in Helm, and easier debugging experience (no more hidden HelmChart objects, nor HelmRepositories). 

Changes:
- extract the Helm chart tgz from the OCI artifact and save it to storage unaltered
- set the revision to the chart version instead of the OCI digest
- emit events specific to Helm mentioning the chart version instead of digests

Given the following definition:

```yaml
apiVersion: source.toolkit.fluxcd.io/v1beta2
kind: OCIRepository
metadata:
  name: podinfo-chart-signed
  namespace: apps
spec:
  interval: 5m0s
  layerSelector:
    mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
  url: oci://ghcr.io/stefanprodan/charts/podinfo
  ref:
    semver: '6.x'
  verify:
    provider: cosign # keyless (signed in CI with GitHub Actions OIDC)
```

The controller produces the following result:

```yaml
status:
  artifact:
    checksum: 73999c9c2994a16dff89c65b7e77dd4d9e3b5b6eb43a5f2797919c54111622c9
    lastUpdateTime: "2022-09-23T10:56:08Z"
    path: ocirepository/apps/podinfo-chart-signed/podinfo-6.2.0.tgz
    revision: 6.2.0
    size: 13542
    url: http://source-controller.flux-system.svc.cluster.local./ocirepository/apps/podinfo-chart-signed/podinfo-6.2.0.tgz
  conditions:
  - lastTransitionTime: "2022-09-23T10:56:08Z"
    message: stored chart with version '6.2.0'
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: Ready
  - lastTransitionTime: "2022-09-23T10:56:08Z"
    message: stored chart with version '6.2.0'
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: ArtifactInStorage
  - lastTransitionTime: "2022-09-23T10:56:07Z"
    message: verified signature of digest 635be9b051391f32ba5edb00efcf2abe1105383fa531473c3b7255937e630cc1
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: SourceVerified
  lastHandledReconcileAt: "2022-09-23T10:57:27.981294Z"
  observedGeneration: 1
  url: http://source-controller.flux-system.svc.cluster.local./ocirepository/apps/podinfo-chart-signed/latest.tar.gz
```

And the following events:

```
  Type    Reason                      Age                 From               Message
  ----    ------                      ----                ----               -------
  Normal  NewArtifact                 42m                 source-controller  stored chart version '6.2.0'
  Normal  ArtifactUpToDate            2m9s (x9 over 41m)  source-controller  chart up-to-date with remote version: '6.2.0'
```
