### PR TITLE
Build with Go 1.19

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
     - id: go-env
       run: |
         echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Restore Go cache
         uses: actions/cache@v3
         with:
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Enable integration tests
         # Only run integration tests for main branch
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19.x
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Restore Go cache
         uses: actions/cache@v3
         with:
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Run tests
         env:
           TEST_AZURE_ACCOUNT_NAME: ${{ secrets.TEST_AZURE_ACCOUNT_NAME }}
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Restore Go cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Restore Go cache
         uses: actions/cache@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.19
 ARG XX_VERSION=1.1.2
 
 ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2-only

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,8 @@ api-docs: gen-crd-api-reference-docs  ## Generate API reference documentation
 	$(GEN_CRD_API_REFERENCE_DOCS) -api-dir=./api/v1beta2 -config=./hack/api-docs/config.json -template-dir=./hack/api-docs/template -out-file=./docs/api/source.md
 
 tidy:  ## Run go mod tidy
-	cd api; rm -f go.sum; go mod tidy -compat=1.18
-	rm -f go.sum; go mod tidy -compat=1.18
+	cd api; rm -f go.sum; go mod tidy -compat=1.19
+	rm -f go.sum; go mod tidy -compat=1.19
 
 fmt:  ## Run go fmt against code
 	go fmt ./...
@@ -155,7 +155,7 @@ docker-push:  ## Push Docker image
 CONTROLLER_GEN = $(GOBIN)/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0)
 
 # Find or download gen-crd-api-reference-docs
 GEN_CRD_API_REFERENCE_DOCS = $(GOBIN)/gen-crd-api-reference-docs

--- a/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: buckets.source.toolkit.fluxcd.io
 spec:
@@ -167,14 +166,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -422,14 +419,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: gitrepositories.source.toolkit.fluxcd.io
 spec:
@@ -236,14 +235,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -597,14 +594,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -664,8 +659,8 @@ spec:
                 type: array
               contentConfigChecksum:
                 description: 'ContentConfigChecksum is a checksum of all the configurations
-                  related to the content of the source artifact:  - .spec.ignore  -
-                  .spec.recurseSubmodules  - .spec.included and the checksum of the
+                  related to the content of the source artifact: - .spec.ignore -
+                  .spec.recurseSubmodules - .spec.included and the checksum of the
                   included artifacts observed in .status.observedGeneration version
                   of the object. This can be used to determine if the content of the
                   included repository has changed. It has the format of `<algo>:<checksum>`,

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: helmcharts.source.toolkit.fluxcd.io
 spec:
@@ -192,14 +191,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -469,14 +466,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: helmrepositories.source.toolkit.fluxcd.io
 spec:
@@ -155,14 +154,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -414,14 +411,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: ocirepositories.source.toolkit.fluxcd.io
 spec:
@@ -53,11 +52,11 @@ spec:
             properties:
               certSecretRef:
                 description: "CertSecretRef can be given the name of a secret containing
-                  either or both of \n  - a PEM-encoded client certificate (`certFile`)
-                  and private  key (`keyFile`);  - a PEM-encoded CA certificate (`caFile`)
-                  \n  and whichever are supplied, will be used for connecting to the
-                  \ registry. The client cert and key are useful if you are  authenticating
-                  with a certificate; the CA cert is useful if  you are using a self-signed
+                  either or both of \n - a PEM-encoded client certificate (`certFile`)
+                  and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`)
+                  \n and whichever are supplied, will be used for connecting to the
+                  registry. The client cert and key are useful if you are authenticating
+                  with a certificate; the CA cert is useful if you are using a self-signed
                   server certificate."
                 properties:
                   name:
@@ -238,14 +237,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/cache/metrics.go
+++ b/internal/cache/metrics.go
@@ -40,6 +40,7 @@ type CacheRecorder struct {
 //   - "miss"
 //   - "hit"
 //   - "update"
+//
 // The name is the name of the reconciled resource.
 // The namespace is the namespace of the reconciled resource.
 func NewCacheRecorder() *CacheRecorder {

--- a/internal/helm/chart/errors.go
+++ b/internal/helm/chart/errors.go
@@ -53,8 +53,9 @@ func (e *BuildError) Error() string {
 // Is returns true if the Reason or Err equals target.
 // It can be used to programmatically place an arbitrary Err in the
 // context of the Builder:
-//  err := &BuildError{Reason: ErrChartPull, Err: errors.New("arbitrary transport error")}
-//  errors.Is(err, ErrChartPull)
+//
+//	err := &BuildError{Reason: ErrChartPull, Err: errors.New("arbitrary transport error")}
+//	errors.Is(err, ErrChartPull)
 func (e *BuildError) Is(target error) bool {
 	if e.Reason == target {
 		return true

--- a/internal/helm/chart/secureloader/ignore/doc.go
+++ b/internal/helm/chart/secureloader/ignore/doc.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package ignore provides tools for writing ignore files (a la .gitignore).
+/*
+Package ignore provides tools for writing ignore files (a la .gitignore).
 
 This provides both an ignore parser and a file-aware processor.
 
@@ -23,19 +24,19 @@ format for .gitignore files (https://git-scm.com/docs/gitignore).
 
 The formatting rules are as follows:
 
-	- Parsing is line-by-line
-	- Empty lines are ignored
-	- Lines the begin with # (comments) will be ignored
-	- Leading and trailing spaces are always ignored
-	- Inline comments are NOT supported ('foo* # Any foo' does not contain a comment)
-	- There is no support for multi-line patterns
-	- Shell glob patterns are supported. See Go's "path/filepath".Match
-	- If a pattern begins with a leading !, the match will be negated.
-	- If a pattern begins with a leading /, only paths relatively rooted will match.
-	- If the pattern ends with a trailing /, only directories will match
-	- If a pattern contains no slashes, file basenames are tested (not paths)
-	- The pattern sequence "**", while legal in a glob, will cause an error here
-	  (to indicate incompatibility with .gitignore).
+  - Parsing is line-by-line
+  - Empty lines are ignored
+  - Lines the begin with # (comments) will be ignored
+  - Leading and trailing spaces are always ignored
+  - Inline comments are NOT supported ('foo* # Any foo' does not contain a comment)
+  - There is no support for multi-line patterns
+  - Shell glob patterns are supported. See Go's "path/filepath".Match
+  - If a pattern begins with a leading !, the match will be negated.
+  - If a pattern begins with a leading /, only paths relatively rooted will match.
+  - If the pattern ends with a trailing /, only directories will match
+  - If a pattern contains no slashes, file basenames are tested (not paths)
+  - The pattern sequence "**", while legal in a glob, will cause an error here
+    (to indicate incompatibility with .gitignore).
 
 Example:
 
@@ -58,10 +59,10 @@ Example:
 	a[b-d].txt
 
 Notable differences from .gitignore:
-	- The '**' syntax is not supported.
-	- The globbing library is Go's 'filepath.Match', not fnmatch(3)
-	- Trailing spaces are always ignored (there is no supported escape sequence)
-	- The evaluation of escape sequences has not been tested for compatibility
-	- There is no support for '\!' as a special leading sequence.
+  - The '**' syntax is not supported.
+  - The globbing library is Go's 'filepath.Match', not fnmatch(3)
+  - Trailing spaces are always ignored (there is no supported escape sequence)
+  - The evaluation of escape sequences has not been tested for compatibility
+  - There is no support for '\!' as a special leading sequence.
 */
 package ignore

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -174,9 +174,10 @@ func ComputeReconcileResult(obj conditions.Setter, res Result, recErr error, rb 
 // LowestRequeuingResult returns the ReconcileResult with the lowest requeue
 // period.
 // Weightage:
-//  ResultRequeue - immediate requeue (lowest)
-//  ResultSuccess - requeue at an interval
-//  ResultEmpty - no requeue
+//
+//	ResultRequeue - immediate requeue (lowest)
+//	ResultSuccess - requeue at an interval
+//	ResultEmpty - no requeue
 func LowestRequeuingResult(i, j Result) Result {
 	switch {
 	case i == ResultEmpty:

--- a/pkg/azure/blob.go
+++ b/pkg/azure/blob.go
@@ -67,18 +67,18 @@ type BlobClient struct {
 // Bucket and Secret. It detects credentials in the Secret in the following
 // order:
 //
-//  - azidentity.ClientSecretCredential when `tenantId`, `clientId` and
-//    `clientSecret` fields are found.
-//  - azidentity.ClientCertificateCredential when `tenantId`,
-//    `clientCertificate` (and optionally `clientCertificatePassword`) fields
-//    are found.
-//  - azidentity.ManagedIdentityCredential for a User ID, when a `clientId`
-//    field but no `tenantId` is found.
-//  - azblob.SharedKeyCredential when an `accountKey` field is found.
-//    The account name is extracted from the endpoint specified on the Bucket
-//    object.
-//  - azidentity.ChainedTokenCredential with azidentity.EnvironmentCredential
-//    and azidentity.ManagedIdentityCredential.
+//   - azidentity.ClientSecretCredential when `tenantId`, `clientId` and
+//     `clientSecret` fields are found.
+//   - azidentity.ClientCertificateCredential when `tenantId`,
+//     `clientCertificate` (and optionally `clientCertificatePassword`) fields
+//     are found.
+//   - azidentity.ManagedIdentityCredential for a User ID, when a `clientId`
+//     field but no `tenantId` is found.
+//   - azblob.SharedKeyCredential when an `accountKey` field is found.
+//     The account name is extracted from the endpoint specified on the Bucket
+//     object.
+//   - azidentity.ChainedTokenCredential with azidentity.EnvironmentCredential
+//     and azidentity.ManagedIdentityCredential.
 //
 // If no credentials are found, and the azidentity.ChainedTokenCredential can
 // not be established. A simple client without credentials is returned.
@@ -309,14 +309,14 @@ func (c *BlobClient) ObjectIsNotFound(err error) bool {
 
 // tokenCredentialsFromSecret attempts to create an azcore.TokenCredential
 // based on the data fields of the given Secret. It returns, in order:
-// - azidentity.ClientSecretCredential when `tenantId`, `clientId` and
-//   `clientSecret` fields are found.
-// - azidentity.ClientCertificateCredential when `tenantId`,
-//   `clientCertificate` (and optionally `clientCertificatePassword`) fields
-//   are found.
-// - azidentity.ManagedIdentityCredential for a User ID, when a `clientId`
-//   field but no `tenantId` is found.
-// - Nil, if no valid set of credential fields was found.
+//   - azidentity.ClientSecretCredential when `tenantId`, `clientId` and
+//     `clientSecret` fields are found.
+//   - azidentity.ClientCertificateCredential when `tenantId`,
+//     `clientCertificate` (and optionally `clientCertificatePassword`) fields
+//     are found.
+//   - azidentity.ManagedIdentityCredential for a User ID, when a `clientId`
+//     field but no `tenantId` is found.
+//   - Nil, if no valid set of credential fields was found.
 func tokenCredentialFromSecret(secret *corev1.Secret) (azcore.TokenCredential, error) {
 	if secret == nil {
 		return nil, nil
@@ -407,11 +407,11 @@ func sasTokenFromSecret(ep string, secret *corev1.Secret) (string, error) {
 // azidentity.ChainedTokenCredential if at least one of the following tokens was
 // successfully created:
 //
-// - azidentity.EnvironmentCredential with `authorityHost` from Secret, if
-//   provided.
-// - azidentity.ManagedIdentityCredential with Client ID from AZURE_CLIENT_ID
-//   environment variable, if found.
-// - azidentity.ManagedIdentityCredential with defaults.
+//   - azidentity.EnvironmentCredential with `authorityHost` from Secret, if
+//     provided.
+//   - azidentity.ManagedIdentityCredential with Client ID from AZURE_CLIENT_ID
+//     environment variable, if found.
+//   - azidentity.ManagedIdentityCredential with defaults.
 //
 // If no valid token is created, it returns nil.
 func chainCredentialWithSecret(secret *corev1.Secret) (azcore.TokenCredential, error) {


### PR DESCRIPTION
Changes:
- Update Go to 1.19 in CI
- Use Go 1.19 in base image
- Update controller-gen v0.8.0 (v0.7 fails with Go 1.19) and regenerate manifests