### PR TITLE
Bump libgit2 image and disable cosign verification for CI

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -33,3 +33,5 @@ jobs:
           ${{ runner.os }}-go
     - name: Smoke test Fuzzers
       run: make fuzz-smoketest
+      env:
+        SKIP_COSIGN_VERIFICATION: true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,6 +47,7 @@ jobs:
         uses: fluxcd/pkg/actions/helm@main
       - name: Run E2E tests
         env:
+          SKIP_COSIGN_VERIFICATION: true
           CREATE_CLUSTER: false
         run: make e2e
 
@@ -76,6 +77,7 @@ jobs:
           kind create cluster --name ${{ steps.prep.outputs.CLUSTER }} --kubeconfig=/tmp/${{ steps.prep.outputs.CLUSTER }}
       - name: Run e2e tests
         env:
+          SKIP_COSIGN_VERIFICATION: true
           KIND_CLUSTER_NAME: ${{ steps.prep.outputs.CLUSTER }}
           KUBECONFIG: /tmp/${{ steps.prep.outputs.CLUSTER }}
           CREATE_CLUSTER: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run tests
         env:
+          SKIP_COSIGN_VERIFICATION: true
           TEST_AZURE_ACCOUNT_NAME: ${{ secrets.TEST_AZURE_ACCOUNT_NAME }}
           TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
         run: make test
@@ -51,6 +52,8 @@ jobs:
           go-version: 1.19.x
       - name: Run tests
         env:
+          SKIP_COSIGN_VERIFICATION: true
+
           TEST_AZURE_ACCOUNT_NAME: ${{ secrets.TEST_AZURE_ACCOUNT_NAME }}
           TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
           
@@ -87,3 +90,5 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run tests
         run: make test
+        env:
+          SKIP_COSIGN_VERIFICATION: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.19
 ARG XX_VERSION=1.1.2
 
 ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2-only
-ARG LIBGIT2_TAG=v0.2.0
+ARG LIBGIT2_TAG=v0.3.0
 
 FROM ${LIBGIT2_IMG}:${LIBGIT2_TAG} AS libgit2-libs
 
@@ -64,11 +64,11 @@ ENV CGO_ENABLED=1
 
 # Instead of using xx-go, (cross) compile with vanilla go leveraging musl tool chain.
 RUN export PKG_CONFIG_PATH="/usr/local/$(xx-info triple)/lib/pkgconfig" && \
-    export CGO_LDFLAGS="$(pkg-config --static --libs --cflags libgit2) -static -fuse-ld=lld" && \
-    xx-go build \
-        -ldflags "-s -w" \
-        -tags 'netgo,osusergo,static_build' \
-        -o /source-controller -trimpath main.go;
+  export CGO_LDFLAGS="$(pkg-config --static --libs --cflags libgit2) -static -fuse-ld=lld" && \
+  xx-go build \
+  -ldflags "-s -w" \
+  -tags 'netgo,osusergo,static_build' \
+  -o /source-controller -trimpath main.go;
 
 # Ensure that the binary was cross-compiled correctly to the target platform.
 RUN xx-verify --static /source-controller

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ GO_TEST_ARGS ?= -race
 # Allows for filtering tests based on the specified prefix
 GO_TEST_PREFIX ?=
 
+# Defines whether cosign verification should be skipped.
+SKIP_COSIGN_VERIFICATION ?= false
+
 # Allows for defining additional Docker buildx arguments,
 # e.g. '--push'.
 BUILD_ARGS ?=

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG ?= latest
 
 # Base image used to build the Go binary
 LIBGIT2_IMG ?= ghcr.io/fluxcd/golang-with-libgit2-only
-LIBGIT2_TAG ?= v0.2.0
+LIBGIT2_TAG ?= v0.3.0
 
 # Allows for defining additional Go test args, e.g. '-tags integration'.
 GO_TEST_ARGS ?= -race

--- a/hack/install-libraries.sh
+++ b/hack/install-libraries.sh
@@ -6,6 +6,7 @@ IMG="${IMG:-}"
 TAG="${TAG:-}"
 IMG_TAG="${IMG}:${TAG}"
 DOWNLOAD_URL="https://github.com/fluxcd/golang-with-libgit2/releases/download/${TAG}"
+SKIP_COSIGN_VERIFICATION="${SKIP_COSIGN_VERIFICATION:-false}"
 
 TMP_DIR=$(mktemp -d)
 
@@ -48,9 +49,13 @@ cosign_verify(){
 assure_provenance() {
     [[ $# -eq 1 ]] || fatal 'assure_provenance needs exactly 1 arguments'
 
-    cosign_verify "${TMP_DIR}/checksums.txt.pem" \
-                  "${TMP_DIR}/checksums.txt.sig" \
-                  "${TMP_DIR}/checksums.txt"
+    if "${SKIP_COSIGN_VERIFICATION}"; then
+        echo 'Skipping cosign verification...'
+    else
+        cosign_verify "${TMP_DIR}/checksums.txt.pem" \
+                    "${TMP_DIR}/checksums.txt.sig" \
+                    "${TMP_DIR}/checksums.txt"
+    fi
 
     pushd "${TMP_DIR}" || exit
     if command -v sha256sum; then

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -16,7 +16,7 @@
 
 set -euxo pipefail
 
-LIBGIT2_TAG="${LIBGIT2_TAG:-v0.2.0}"
+LIBGIT2_TAG="${LIBGIT2_TAG:-v0.3.0}"
 GOPATH="${GOPATH:-/root/go}"
 GO_SRC="${GOPATH}/src"
 PROJECT_PATH="github.com/fluxcd/source-controller"


### PR DESCRIPTION
The libgit2 libraries are downloaded and verified before
some of the make targets are executed. This assures the
provenance of such files before using them and is very
important specially for end users running such tests on
their machines.

Note that has been disabled specially due to recent issues
we experienced at CI which can be seen in:
https://github.com/fluxcd/source-controller/issues/899