### PR TITLE
Add explicit observed artifact content configurations in status

### DIFF
--- a/api/v1beta2/bucket_types.go
+++ b/api/v1beta2/bucket_types.go
@@ -128,6 +128,11 @@ type BucketStatus struct {
 	// +optional
 	Artifact *Artifact `json:"artifact,omitempty"`
 
+	// ObservedIgnore is the observed exclusion patterns used for constructing
+	// the source artifact.
+	// +optional
+	ObservedIgnore *string `json:"observedIgnore,omitempty"`
+
 	meta.ReconcileRequestStatus `json:",inline"`
 }
 

--- a/api/v1beta2/gitrepository_types.go
+++ b/api/v1beta2/gitrepository_types.go
@@ -224,8 +224,26 @@ type GitRepositoryStatus struct {
 	// be used to determine if the content of the included repository has
 	// changed.
 	// It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
+	//
+	// Deprecated: Replaced with explicit fields for observed artifact content
+	// config in the status.
 	// +optional
 	ContentConfigChecksum string `json:"contentConfigChecksum,omitempty"`
+
+	// ObservedIgnore is the observed exclusion patterns used for constructing
+	// the source artifact.
+	// +optional
+	ObservedIgnore *string `json:"observedIgnore,omitempty"`
+
+	// ObservedRecurseSubmodules is the observed resource submodules
+	// configuration used to produce the current Artifact.
+	// +optional
+	ObservedRecurseSubmodules bool `json:"observedRecurseSubmodules,omitempty"`
+
+	// ObservedInclude is the observed list of GitRepository resources used to
+	// to produce the current Artifact.
+	// +optional
+	ObservedInclude []GitRepositoryInclude `json:"observedInclude,omitempty"`
 
 	meta.ReconcileRequestStatus `json:",inline"`
 }

--- a/api/v1beta2/ocirepository_types.go
+++ b/api/v1beta2/ocirepository_types.go
@@ -211,8 +211,21 @@ type OCIRepositoryStatus struct {
 	// be used to determine if the content configuration has changed and the
 	// artifact needs to be rebuilt.
 	// It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
+	//
+	// Deprecated: Replaced with explicit fields for observed artifact content
+	// config in the status.
 	// +optional
 	ContentConfigChecksum string `json:"contentConfigChecksum,omitempty"`
+
+	// ObservedIgnore is the observed exclusion patterns used for constructing
+	// the source artifact.
+	// +optional
+	ObservedIgnore *string `json:"observedIgnore,omitempty"`
+
+	// ObservedLayerSelector is the observed layer selector used for constructing
+	// the source artifact.
+	// +optional
+	ObservedLayerSelector *OCILayerSelector `json:"observedLayerSelector,omitempty"`
 
 	meta.ReconcileRequestStatus `json:",inline"`
 }

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -346,6 +346,16 @@ func (in *GitRepositoryStatus) DeepCopyInto(out *GitRepositoryStatus) {
 			}
 		}
 	}
+	if in.ObservedIgnore != nil {
+		in, out := &in.ObservedIgnore, &out.ObservedIgnore
+		*out = new(string)
+		**out = **in
+	}
+	if in.ObservedInclude != nil {
+		in, out := &in.ObservedInclude, &out.ObservedInclude
+		*out = make([]GitRepositoryInclude, len(*in))
+		copy(*out, *in)
+	}
 	out.ReconcileRequestStatus = in.ReconcileRequestStatus
 }
 

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -777,6 +777,16 @@ func (in *OCIRepositoryStatus) DeepCopyInto(out *OCIRepositoryStatus) {
 		*out = new(Artifact)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ObservedIgnore != nil {
+		in, out := &in.ObservedIgnore, &out.ObservedIgnore
+		*out = new(string)
+		**out = **in
+	}
+	if in.ObservedLayerSelector != nil {
+		in, out := &in.ObservedLayerSelector, &out.ObservedLayerSelector
+		*out = new(OCILayerSelector)
+		**out = **in
+	}
 	out.ReconcileRequestStatus = in.ReconcileRequestStatus
 }
 

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -166,6 +166,11 @@ func (in *BucketStatus) DeepCopyInto(out *BucketStatus) {
 		*out = new(Artifact)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ObservedIgnore != nil {
+		in, out := &in.ObservedIgnore, &out.ObservedIgnore
+		*out = new(string)
+		**out = **in
+	}
 	out.ReconcileRequestStatus = in.ReconcileRequestStatus
 }
 

--- a/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
@@ -492,6 +492,10 @@ spec:
                   the Bucket object.
                 format: int64
                 type: integer
+              observedIgnore:
+                description: ObservedIgnore is the observed exclusion patterns used
+                  for constructing the source artifact.
+                type: string
               url:
                 description: URL is the dynamic fetch link for the latest Artifact.
                   It is provided on a "best effort" basis, and using the precise BucketStatus.Artifact

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -658,13 +658,14 @@ spec:
                   type: object
                 type: array
               contentConfigChecksum:
-                description: 'ContentConfigChecksum is a checksum of all the configurations
+                description: "ContentConfigChecksum is a checksum of all the configurations
                   related to the content of the source artifact: - .spec.ignore -
                   .spec.recurseSubmodules - .spec.included and the checksum of the
                   included artifacts observed in .status.observedGeneration version
                   of the object. This can be used to determine if the content of the
                   included repository has changed. It has the format of `<algo>:<checksum>`,
-                  for example: `sha256:<checksum>`.'
+                  for example: `sha256:<checksum>`. \n Deprecated: Replaced with explicit
+                  fields for observed artifact content config in the status."
                 type: string
               includedArtifacts:
                 description: IncludedArtifacts contains a list of the last successfully
@@ -723,6 +724,44 @@ spec:
                   the GitRepository object.
                 format: int64
                 type: integer
+              observedIgnore:
+                description: ObservedIgnore is the observed exclusion patterns used
+                  for constructing the source artifact.
+                type: string
+              observedInclude:
+                description: ObservedInclude is the observed list of GitRepository
+                  resources used to to produce the current Artifact.
+                items:
+                  description: GitRepositoryInclude specifies a local reference to
+                    a GitRepository which Artifact (sub-)contents must be included,
+                    and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: FromPath specifies the path to copy contents from,
+                        defaults to the root of the Artifact.
+                      type: string
+                    repository:
+                      description: GitRepositoryRef specifies the GitRepository which
+                        Artifact contents must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: ToPath specifies the path to copy contents to,
+                        defaults to the name of the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              observedRecurseSubmodules:
+                description: ObservedRecurseSubmodules is the observed resource submodules
+                  configuration used to produce the current Artifact.
+                type: boolean
               url:
                 description: URL is the dynamic fetch link for the latest Artifact.
                   It is provided on a "best effort" basis, and using the precise GitRepositoryStatus.Artifact

--- a/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
@@ -301,12 +301,14 @@ spec:
                   type: object
                 type: array
               contentConfigChecksum:
-                description: 'ContentConfigChecksum is a checksum of all the configurations
+                description: "ContentConfigChecksum is a checksum of all the configurations
                   related to the content of the source artifact: - .spec.ignore -
                   .spec.layerSelector observed in .status.observedGeneration version
                   of the object. This can be used to determine if the content configuration
                   has changed and the artifact needs to be rebuilt. It has the format
-                  of `<algo>:<checksum>`, for example: `sha256:<checksum>`.'
+                  of `<algo>:<checksum>`, for example: `sha256:<checksum>`. \n Deprecated:
+                  Replaced with explicit fields for observed artifact content config
+                  in the status."
                 type: string
               lastHandledReconcileAt:
                 description: LastHandledReconcileAt holds the value of the most recent
@@ -317,6 +319,29 @@ spec:
                 description: ObservedGeneration is the last observed generation.
                 format: int64
                 type: integer
+              observedIgnore:
+                description: ObservedIgnore is the observed exclusion patterns used
+                  for constructing the source artifact.
+                type: string
+              observedLayerSelector:
+                description: ObservedLayerSelector is the observed layer selector
+                  used for constructing the source artifact.
+                properties:
+                  mediaType:
+                    description: MediaType specifies the OCI media type of the layer
+                      which should be extracted from the OCI Artifact. The first layer
+                      matching this type is selected.
+                    type: string
+                  operation:
+                    description: Operation specifies how the selected layer should
+                      be processed. By default, the layer compressed content is extracted
+                      to storage. When the operation is set to 'copy', the layer compressed
+                      content is persisted to storage as it is.
+                    enum:
+                    - extract
+                    - copy
+                    type: string
+                type: object
               url:
                 description: URL is the download link for the artifact output of the
                   last OCI Repository sync.

--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -628,6 +628,7 @@ func (r *BucketReconciler) reconcileArtifact(ctx context.Context, obj *sourcev1.
 
 	// Record it on the object
 	obj.Status.Artifact = artifact.DeepCopy()
+	obj.Status.ObservedIgnore = obj.Spec.Ignore
 
 	// Update symlink on a "best effort" basis
 	url, err := r.Storage.Symlink(artifact, "latest.tar.gz")

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -2608,7 +2608,8 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepositorySpec">OCIRepositorySpec</a>)
+<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepositorySpec">OCIRepositorySpec</a>, 
+<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepositoryStatus">OCIRepositoryStatus</a>)
 </p>
 <p>OCILayerSelector specifies which layer should be extracted from an OCI Artifact</p>
 <div class="md-typeset__scrollwrap">
@@ -3010,6 +3011,36 @@ observed in .status.observedGeneration version of the object. This can
 be used to determine if the content configuration has changed and the
 artifact needs to be rebuilt.
 It has the format of <code>&lt;algo&gt;:&lt;checksum&gt;</code>, for example: <code>sha256:&lt;checksum&gt;</code>.</p>
+<p>Deprecated: Replaced with explicit fields for observed artifact content
+config in the status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedIgnore</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedIgnore is the observed exclusion patterns used for constructing
+the source artifact.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedLayerSelector</code><br>
+<em>
+<a href="#source.toolkit.fluxcd.io/v1beta2.OCILayerSelector">
+OCILayerSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedLayerSelector is the observed layer selector used for constructing
+the source artifact.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -1518,6 +1518,19 @@ Artifact
 </tr>
 <tr>
 <td>
+<code>observedIgnore</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedIgnore is the observed exclusion patterns used for constructing
+the source artifact.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>ReconcileRequestStatus</code><br>
 <em>
 <a href="https://godoc.org/github.com/fluxcd/pkg/apis/meta#ReconcileRequestStatus">

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -1539,7 +1539,8 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositorySpec">GitRepositorySpec</a>)
+<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositorySpec">GitRepositorySpec</a>, 
+<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositoryStatus">GitRepositoryStatus</a>)
 </p>
 <p>GitRepositoryInclude specifies a local reference to a GitRepository which
 Artifact (sub-)contents must be included, and where they should be placed.</p>
@@ -1969,6 +1970,49 @@ observed in .status.observedGeneration version of the object. This can
 be used to determine if the content of the included repository has
 changed.
 It has the format of <code>&lt;algo&gt;:&lt;checksum&gt;</code>, for example: <code>sha256:&lt;checksum&gt;</code>.</p>
+<p>Deprecated: Replaced with explicit fields for observed artifact content
+config in the status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedIgnore</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedIgnore is the observed exclusion patterns used for constructing
+the source artifact.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedRecurseSubmodules</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedRecurseSubmodules is the observed resource submodules
+configuration used to produce the current Artifact.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedInclude</code><br>
+<em>
+<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositoryInclude">
+[]GitRepositoryInclude
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedInclude is the observed list of GitRepository resources used to
+to produce the current Artifact.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta2/buckets.md
+++ b/docs/spec/v1beta2/buckets.md
@@ -1064,6 +1064,25 @@ Note that a Bucket can be [reconciling](#reconciling-bucket) while failing at
 the same time, for example due to a newly introduced configuration issue in the
 Bucket spec.
 
+### Observed Ignore
+
+The source-controller reports an observed ignore in the Bucket's
+`.status.observedIgnore`. The observed ignore is the latest `.spec.ignore` value
+which resulted in a [ready state](#ready-bucket), or stalled due to error
+it can not recover from without human intervention. The value is the same as the
+[ignore in spec](#ignore). It indicates the ignore rules used in building the
+current artifact in storage.
+
+Example:
+```yaml
+status:
+  ...
+  observedIgnore: |
+    hpa.yaml
+    build
+  ...
+```
+
 ### Observed Generation
 
 The source-controller reports an

--- a/docs/spec/v1beta2/gitrepositories.md
+++ b/docs/spec/v1beta2/gitrepositories.md
@@ -854,6 +854,79 @@ configurations of the GitRepository that indicate a change in source and
 records it in `.status.contentConfigChecksum`. This field is used to determine
 if the source artifact needs to be rebuilt.
 
+**Deprecation Note:** `contentConfigChecksum` is no longer used and will be
+removed in the next API version. The individual components used for generating
+content configuration checksum now have explicit fields in the status. This
+makes the observations used by the controller for making artifact rebuild
+decisions more transparent and easier to debug.
+
+### Observed Ignore
+
+The source-controller reports an observed ignore in the GitRepository's
+`.status.observedIgnore`. The observed ignore is the latest `.spec.ignore` value
+which resulted in a [ready state](#ready-gitrepository), or stalled due to error
+it can not recover from without human intervention.
+The value is the same as the [ignore in spec](#ignore).
+It indicates the ignore rules used in building the current artifact in storage.
+It is also used by the controller to determine if an artifact needs to be
+rebuilt.
+
+Example:
+```yaml
+status:
+  ...
+  observedIgnore: |
+    cue
+    pkg
+  ...
+```
+
+### Observed Recurse Submodules
+
+The source-controller reports an observed recurse submodule in the
+GitRepository's `.status.observedRecurseSubmodules`. The observed recurse
+submodules is the latest `.spec.recurseSubmodules` value which resulted in a
+[ready state](#ready-gitrepository), or stalled due to error it can not recover
+from without human intervention. The value is the same as the
+[recurse submodules in spec](#recurse-submodules). It indicates the recurse
+submodules configuration used in building the current artifact in storage. It is
+also used by the controller to determine if an artifact needs to be rebuilt.
+
+Example:
+```yaml
+status:
+  ...
+  observedRecurseSubmodules: true
+  ...
+```
+
+### Observed Include
+
+The source-controller reports observed include in the GitRepository's
+`.status.observedInclude`. The observed include is the latest
+`.spec.recurseSubmodules` value which resulted in a
+[ready state](#ready-gitrepository), or stalled due to error it can not recover
+from without human intervention. The value is the same as the
+[include in spec](#include). It indicates the include configuration used in
+building the current artifact in storage. It is also used by the controller to
+determine if an artifact needs to be rebuilt.
+
+Example:
+```yaml
+status:
+  ...
+  observedInclude:
+  - fromPath: deploy/webapp
+    repository:
+      name: repo1
+    toPath: foo
+  - fromPath: deploy/secure
+    repository:
+      name: repo2
+    toPath: bar
+  ...
+```
+
 ### Observed Generation
 
 The source-controller reports an [observed generation][typical-status-properties]

--- a/docs/spec/v1beta2/ocirepositories.md
+++ b/docs/spec/v1beta2/ocirepositories.md
@@ -868,6 +868,53 @@ configurations of the OCIRepository that indicate a change in source and
 records it in `.status.contentConfigChecksum`. This field is used to determine
 if the source artifact needs to be rebuilt.
 
+**Deprecation Note:** `contentConfigChecksum` is no longer used and will be
+removed in the next API version. The individual components used for generating
+content configuration checksum now have explicit fields in the status. This
+makes the observations used by the controller for making artifact rebuild
+decisions more transparent and easier to debug.
+
+### Observed Ignore
+
+The source-controller reports an observed ignore in the OCIRepository's
+`.status.observedIgnore`. The observed ignore is the latest `.spec.ignore` value
+which resulted in a [ready state](#ready-ocirepository), or stalled due to error
+it can not recover from without human intervention. The value is the same as the
+[ignore in spec](#ignore). It indicates the ignore rules used in building the
+current artifact in storage. It is also used by the controller to determine if
+an artifact needs to be rebuilt.
+
+Example:
+```yaml
+status:
+  ...
+  observedIgnore: |
+    hpa.yaml
+    build
+  ...
+```
+
+### Observed Layer Selector
+
+The source-controller reports an observed layer selector in the OCIRepository's
+`.status.observedLayerSelector`. The observed layer selector is the latest
+`.spec.layerSelector` value which resulted in a [ready state](#ready-ocirepository),
+or stalled due to error it can not recover from without human intervention.
+The value is the same as the [layer selector in spec](#layer-selector).
+It indicates the layer selection configuration used in building the current
+artifact in storage. It is also used by the controller to determine if an
+artifact needs to be rebuilt.
+
+Example:
+```yaml
+status:
+  ...
+  observedLayerSelector:
+    mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    operation: copy
+  ...
+```
+
 ### Observed Generation
 
 The source-controller reports an [observed generation][typical-status-properties]


### PR DESCRIPTION
GitRepositoryReconciler and OCIRepositoryReconcilers support no-op reconciliation which makes these reconcilers efficient in their operations. The no-op reconciliation is determined by taking into considerations all the variables that affect the source artifact content. In #724 and #917, the values of these variables were computed as a checksum and stored in the status in a field called the content config checksum. Although it worked, the checksum of multiple variables wasn't friendly to debug or see the observations of the controller. This change replaces the content config checksum with explicit status fields for the observed variables that contribute to the source artifact content. The content config checksum remains in the status API for now, but is not used and unset for any existing resources. It'll be removed in the next API version.

In GitRepository source, three new status fields `observedIgnore`, `observedRecurseSubmodules` and `observedInclude` are introduced. https://gist.github.com/darkowlzz/3ffc1000754580a0fac6f9068e06643e shows the status with these new fields under some relevant scenarios.

In OCIRepository source, two new status fields `observedIgnore` and `observedLayerSelector` are introduced. https://gist.github.com/darkowlzz/ece8718c5ed195948d1c8e2f4ea2f941 shows the status with these new fields under some relevant scenarios.

Spec docs and tests have been updated for these changes.