### PR TITLE
build: Disable macos-11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,7 +71,7 @@ jobs:
   darwin-amd64:
     strategy:
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This specific environment seems to be more prone to a data race that is already fixed on the git-refactoring branch. Whilst those changes are not merged into main, let's disable this environment to quieten the unnecessary noise.

Note that this test only exists to ensure that contributors using macos-11 as their development environment don't experience issues building and debugging the project.