### PR TITLE
Remove nsswitch.conf creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,10 +80,6 @@ ARG TARGETPLATFORM
 RUN apk --no-cache add ca-certificates \
   && update-ca-certificates
 
-# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
-# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
-
 # Copy over binary from build
 COPY --from=build /source-controller /usr/local/bin/
 COPY ATTRIBUTIONS.md /


### PR DESCRIPTION
Since 11-11-2022, the alpine:3.16 includes that file on its base image. More information can be found at:
https://git.alpinelinux.org/aports/commit/?id=348653a9ba0701e8e968b3344e72313a9ef334e4