### PR TITLE
build: Add postbuild script for fuzzing

### DIFF
--- a/tests/fuzz/oss_fuzz_postbuild.sh
+++ b/tests/fuzz/oss_fuzz_postbuild.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Flux authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euxo pipefail
+
+# This file is executed by upstream oss-fuzz after its building process.
+# Use it for unsetting any environment variables that may impact other building
+# processes.
+
+unset TARGET_DIR
+unset CGO_ENABLED
+unset LIBRARY_PATH
+unset PKG_CONFIG_PATH
+unset CGO_CFLAGS
+unset CGO_LDFLAGS
+unset ADDITIONAL_LIBS


### PR DESCRIPTION
In order to reduce the complexity of the fuzzing setup the majority of the code is moving upstream. For that to work, each project with specific requirements need to configure pre and post build scripts to ensure actions take place before the build, and any clean up happens at the very end.

Relates to https://github.com/fluxcd/flux2/issues/3346