### PR TITLE
fuzz: Use upstream cifuzz action

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -8,30 +8,27 @@ on:
       - 'README.md'
       - 'MAINTAINERS'
 
-permissions:
-  contents: read
+permissions: {}
   
 jobs:
   Fuzzing:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Setup Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.19.x
-    - id: go-env
-      run: |
-        echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"
-    - name: Restore Go cache
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.go-env.outputs.go-mod-cache }}
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go
-    - name: Smoke test Fuzzers
-      run: make fuzz-smoketest
-      env:
-        SKIP_COSIGN_VERIFICATION: true
+   runs-on: ubuntu-latest
+   steps:
+   - name: Build Fuzzers
+     id: build
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'fluxcd'
+       language: go
+   - name: Run Fuzzers
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'fluxcd'
+       language: go
+       fuzz-seconds: 120
+   - name: Upload Crash
+     uses: actions/upload-artifact@v3
+     if: failure() && steps.build.outcome == 'success'
+     with:
+       name: artifacts
+       path: ./out/artifacts

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,7 +47,6 @@ jobs:
         uses: fluxcd/pkg/actions/helm@main
       - name: Run E2E tests
         env:
-          SKIP_COSIGN_VERIFICATION: true
           CREATE_CLUSTER: false
         run: make e2e
 
@@ -77,7 +76,6 @@ jobs:
           kind create cluster --name ${{ steps.prep.outputs.CLUSTER }} --kubeconfig=/tmp/${{ steps.prep.outputs.CLUSTER }}
       - name: Run e2e tests
         env:
-          SKIP_COSIGN_VERIFICATION: true
           KIND_CLUSTER_NAME: ${{ steps.prep.outputs.CLUSTER }}
           KUBECONFIG: /tmp/${{ steps.prep.outputs.CLUSTER }}
           CREATE_CLUSTER: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -93,5 +93,5 @@ jobs:
           echo "DOCKER_HOST=unix://$HOME/.colima/default/docker.sock" >> $GITHUB_ENV
       - name: Run tests
         run: make test
-        env:
-          SKIP_COSIGN_VERIFICATION: true
+      - name: Smoke test Fuzzers
+        run: make fuzz-smoketest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,7 +34,6 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run tests
         env:
-          SKIP_COSIGN_VERIFICATION: true
           TEST_AZURE_ACCOUNT_NAME: ${{ secrets.TEST_AZURE_ACCOUNT_NAME }}
           TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
         run: make test
@@ -52,8 +51,6 @@ jobs:
           go-version: 1.19.x
       - name: Run tests
         env:
-          SKIP_COSIGN_VERIFICATION: true
-
           TEST_AZURE_ACCOUNT_NAME: ${{ secrets.TEST_AZURE_ACCOUNT_NAME }}
           TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
           

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ GO_TEST_ARGS ?= -race
 # Allows for filtering tests based on the specified prefix
 GO_TEST_PREFIX ?=
 
-# Defines whether cosign verification should be skipped.
-SKIP_COSIGN_VERIFICATION ?= false
-
 # Allows for defining additional Docker buildx arguments,
 # e.g. '--push'.
 BUILD_ARGS ?=

--- a/tests/fuzz/Dockerfile.builder
+++ b/tests/fuzz/Dockerfile.builder
@@ -1,8 +1,5 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 
-ENV SRC=$GOPATH/src/github.com/fluxcd/source-controller
-ENV FLUX_CI=true
-
 COPY ./ $SRC
 RUN wget https://raw.githubusercontent.com/google/oss-fuzz/master/projects/fluxcd/build.sh -O $SRC/build.sh
 


### PR DESCRIPTION
Due to [recent changes](https://github.com/google/oss-fuzz/commit/998e83199dce7b7496640ae983efbad461baa380) upstream we should be able to use the recommended upstream cifuzz GitHub action.

The `make fuzz-smoketest` has been moved to the tests workflow, to ensure it will continue to work - as that provides an easier way for the maintainers to check for problems.

Relates to https://github.com/fluxcd/flux2/issues/3346.