### PR TITLE
Fix aliased chart dependencies resolution

### DIFF
--- a/controllers/helmchart_controller_test.go
+++ b/controllers/helmchart_controller_test.go
@@ -60,6 +60,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	serror "github.com/fluxcd/source-controller/internal/error"
 	"github.com/fluxcd/source-controller/internal/helm/chart"
+	"github.com/fluxcd/source-controller/internal/helm/chart/secureloader"
 	"github.com/fluxcd/source-controller/internal/helm/registry"
 	"github.com/fluxcd/source-controller/internal/oci"
 	sreconcile "github.com/fluxcd/source-controller/internal/reconcile"
@@ -1159,6 +1160,11 @@ func TestHelmChartReconciler_buildFromTarballArtifact(t *testing.T) {
 				g.Expect(build.Version).To(Equal("0.1.0"))
 				g.Expect(build.ResolvedDependencies).To(Equal(4))
 				g.Expect(build.Path).To(BeARegularFile())
+				chart, err := secureloader.LoadFile(build.Path)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(chart.Metadata.Name).To(Equal("helmchartwithdeps"))
+				g.Expect(chart.Metadata.Version).To(Equal("0.1.0"))
+				g.Expect(chart.Dependencies()).To(HaveLen(4))
 			},
 			cleanFunc: func(g *WithT, build *chart.Build) {
 				g.Expect(os.Remove(build.Path)).To(Succeed())

--- a/internal/helm/chart/dependency_manager.go
+++ b/internal/helm/chart/dependency_manager.go
@@ -218,6 +218,10 @@ func (dm *DependencyManager) addLocalDependency(ref LocalReference, c *chartWith
 		return err
 	}
 
+	if dep.Alias != "" {
+		ch.Metadata.Name = dep.Alias
+	}
+
 	c.mu.Lock()
 	c.AddDependency(ch)
 	c.mu.Unlock()
@@ -244,6 +248,10 @@ func (dm *DependencyManager) addRemoteDependency(chart *chartWithLock, dep *helm
 	ch, err := secureloader.LoadArchive(res)
 	if err != nil {
 		return fmt.Errorf("failed to load downloaded archive of version '%s': %w", ver.Version, err)
+	}
+
+	if dep.Alias != "" {
+		ch.Metadata.Name = dep.Alias
 	}
 
 	chart.mu.Lock()


### PR DESCRIPTION
If implemented, this fix the issue were aliased chart dependencies were detected but not included in the final packaged chart.

Fix: https://github.com/fluxcd/helm-controller/issues/575
Signed-off-by: Soule BA <soule@weave.works>