### PR TITLE
purge minio test container at the end of tests

### DIFF
--- a/pkg/minio/minio_test.go
+++ b/pkg/minio/minio_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/uuid"
 	miniov7 "github.com/minio/minio-go/v7"
 	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,6 +126,8 @@ func TestMain(m *testing.M) {
 			"MINIO_ROOT_PASSWORD=" + testMinioRootPassword,
 		},
 		Cmd: []string{"server", "/data", "--console-address", ":9001"},
+	}, func(config *docker.HostConfig) {
+		config.AutoRemove = true
 	})
 	if err != nil {
 		log.Fatalf("could not start resource: %s", err)
@@ -168,6 +171,7 @@ func TestMain(m *testing.M) {
 	run := m.Run()
 	removeObjectFromBucket(ctx)
 	deleteBucket(ctx)
+	purgeResource()
 	os.Exit(run)
 }
 


### PR DESCRIPTION
Purge minio test container at the end of tests.
Also, add container option to auto-remove a container when stopped, in case a container is left behind due to some reason.

Without it minio containers are left behind:
```
CONTAINER ID   IMAGE                                      COMMAND                  CREATED        STATUS        PORTS                                                                                      NAMES
e83053caebc5   minio/minio:RELEASE.2022-12-12T19-27-27Z   "/usr/bin/docker-ent…"   46 hours ago   Up 46 hours   0.0.0.0:49167->9000/tcp, :::49166->9000/tcp, 0.0.0.0:49166->9001/tcp, :::49165->9001/tcp   suspicious_noether
b44cf9e4082d   minio/minio:RELEASE.2022-12-12T19-27-27Z   "/usr/bin/docker-ent…"   46 hours ago   Up 46 hours   0.0.0.0:49165->9000/tcp, :::49164->9000/tcp, 0.0.0.0:49164->9001/tcp, :::49163->9001/tcp   silly_hermann
7708ff92e24f   minio/minio:RELEASE.2022-12-12T19-27-27Z   "/usr/bin/docker-ent…"   3 days ago     Up 3 days     0.0.0.0:49163->9000/tcp, :::49162->9000/tcp, 0.0.0.0:49161->9001/tcp, :::49161->9001/tcp   fervent_mendeleev
bc41c28ed6e5   minio/minio:RELEASE.2022-12-12T19-27-27Z   "/usr/bin/docker-ent…"   3 days ago     Up 3 days     0.0.0.0:49160->9000/tcp, :::49160->9000/tcp, 0.0.0.0:49159->9001/tcp, :::49159->9001/tcp   gracious_bartik
f99d91caa08e   minio/minio:RELEASE.2022-12-12T19-27-27Z   "/usr/bin/docker-ent…"   3 days ago     Up 3 days     0.0.0.0:49158->9000/tcp, :::49158->9000/tcp, 0.0.0.0:49157->9001/tcp, :::49157->9001/tcp   nervous_spence
24a4e7586a76   minio/minio:RELEASE.2022-12-12T19-27-27Z   "/usr/bin/docker-ent…"   3 days ago     Up 3 days     0.0.0.0:49156->9000/tcp, :::49156->9000/tcp, 0.0.0.0:49155->9001/tcp, :::49155->9001/tcp   vibrant_pare
16917945c2d2   minio/minio:RELEASE.2022-12-12T19-27-27Z   "/usr/bin/docker-ent…"   3 days ago     Up 3 days     0.0.0.0:49154->9000/tcp, :::49154->9000/tcp, 0.0.0.0:49153->9001/tcp, :::49153->9001/tcp   serene_meitner
```

Follow-up of https://github.com/fluxcd/source-controller/pull/981