### PR TITLE
fix typo in helmRepo secretRef spec CRD

### DIFF
--- a/api/v1beta1/helmrepository_types.go
+++ b/api/v1beta1/helmrepository_types.go
@@ -43,7 +43,7 @@ type HelmRepositorySpec struct {
 	// For HTTP/S basic auth the secret must contain username and
 	// password fields.
 	// For TLS the secret must contain a certFile and keyFile, and/or
-	// caCert fields.
+	// caFile fields.
 	// +optional
 	SecretRef *meta.LocalObjectReference `json:"secretRef,omitempty"`
 

--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -51,7 +51,7 @@ type HelmRepositorySpec struct {
 	// For HTTP/S basic auth the secret must contain 'username' and 'password'
 	// fields.
 	// For TLS the secret must contain a 'certFile' and 'keyFile', and/or
-	// 'caCert' fields.
+	// 'caFile' fields.
 	// +optional
 	SecretRef *meta.LocalObjectReference `json:"secretRef,omitempty"`
 

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -92,7 +92,7 @@ spec:
                 description: The name of the secret containing authentication credentials
                   for the Helm repository. For HTTP/S basic auth the secret must contain
                   username and password fields. For TLS the secret must contain a
-                  certFile and keyFile, and/or caCert fields.
+                  certFile and keyFile, and/or caFile fields.
                 properties:
                   name:
                     description: Name of the referent.
@@ -325,7 +325,7 @@ spec:
                 description: SecretRef specifies the Secret containing authentication
                   credentials for the HelmRepository. For HTTP/S basic auth the secret
                   must contain 'username' and 'password' fields. For TLS the secret
-                  must contain a 'certFile' and 'keyFile', and/or 'caCert' fields.
+                  must contain a 'certFile' and 'keyFile', and/or 'caFile' fields.
                 properties:
                   name:
                     description: Name of the referent.

--- a/docs/api/source.md
+++ b/docs/api/source.md
@@ -794,7 +794,7 @@ for the HelmRepository.
 For HTTP/S basic auth the secret must contain &lsquo;username&rsquo; and &lsquo;password&rsquo;
 fields.
 For TLS the secret must contain a &lsquo;certFile&rsquo; and &lsquo;keyFile&rsquo;, and/or
-&lsquo;caCert&rsquo; fields.</p>
+&lsquo;caFile&rsquo; fields.</p>
 </td>
 </tr>
 <tr>
@@ -2444,7 +2444,7 @@ for the HelmRepository.
 For HTTP/S basic auth the secret must contain &lsquo;username&rsquo; and &lsquo;password&rsquo;
 fields.
 For TLS the secret must contain a &lsquo;certFile&rsquo; and &lsquo;keyFile&rsquo;, and/or
-&lsquo;caCert&rsquo; fields.</p>
+&lsquo;caFile&rsquo; fields.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1alpha1/helmrepositories.md
+++ b/docs/spec/v1alpha1/helmrepositories.md
@@ -19,7 +19,7 @@ type HelmRepositorySpec struct {
 	// repository.
 	// For HTTP/S basic auth the secret must contain username and
 	// password fields.
-	// For TLS the secret must contain caFile, keyFile and caCert
+	// For TLS the secret must contain caFile, keyFile and caFile
 	// fields.
     // +optional
 	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty"`

--- a/docs/spec/v1beta1/helmrepositories.md
+++ b/docs/spec/v1beta1/helmrepositories.md
@@ -20,7 +20,7 @@ type HelmRepositorySpec struct {
 	// For HTTP/S basic auth the secret must contain username and
 	// password fields.
 	// For TLS the secret must contain a certFile and keyFile, and/or
-	// caCert fields.
+	// caFile fields.
 	// +optional
 	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty"`
 


### PR DESCRIPTION
When using a TLS authentication, user can provide a custom certificate by setting the caFile key in the secret, not caCert.

Signed-off-by: Yohan Belléguic <yohan.belleguic@arkea.com>