### PR TITLE
Fix OCIRepository testdata permissions

### DIFF
--- a/controllers/ocirepository_controller_test.go
+++ b/controllers/ocirepository_controller_test.go
@@ -1637,6 +1637,8 @@ func TestOCIRepository_reconcileArtifact(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
+			resetChmod(tt.targetPath, 0o755, 0o644)
+
 			obj := &sourcev1.OCIRepository{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "reconcile-artifact-",


### PR DESCRIPTION
On Ubuntu, and maybe some others, the
`TestOCIRepository_reconcileArtifact` test fails due to difference in file permission, which results in different artifact checksum. This is due to the default umask on ubuntu. Reset the permission of the testdata to fix the test on ubuntu.
There's a similar fix in `TestGitRepositoryReconciler_reconcileArtifact` test.

Refer https://github.com/fluxcd/source-controller/pull/732 for the last time we had a similar issue.