### PR TITLE
build: Enable SBOM and SLSA Provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Publish images
         uses: docker/build-push-action@v3
         with:
+          sbom: true
+          provenance: true
           push: true
           builder: ${{ steps.buildx.outputs.name }}
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN export CGO_LDFLAGS="-static -fuse-ld=lld" && \
 # Ensure that the binary was cross-compiled correctly to the target platform.
 RUN xx-verify --static /source-controller
 
-FROM alpine:3.16
+FROM alpine:3.17
 
 ARG TARGETPLATFORM
 RUN apk --no-cache add ca-certificates \


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/3522

To download the SBOM and SLSA Provenance from GHCR:

```sh
docker buildx imagetools inspect fluxcd/source-controller:rc-59e061c8 \
    --format "{{ json (index .SBOM \"linux/amd64\").SPDX}}"

docker buildx imagetools inspect fluxcd/source-controller:rc-59e061c8 \
    --format "{{ json (index .Provenance \"linux/amd64\").SLSA}}"
```
