### PR TITLE
helm/oci: Add context to chart download failure

### DIFF
--- a/internal/helm/chart/builder_remote_test.go
+++ b/internal/helm/chart/builder_remote_test.go
@@ -225,7 +225,7 @@ entries:
 	}
 }
 
-func TestRemoteBuilder_BuildFromOCIChatRepository(t *testing.T) {
+func TestRemoteBuilder_BuildFromOCIChartRepository(t *testing.T) {
 	g := NewWithT(t)
 
 	chartGrafana, err := os.ReadFile("./../testdata/charts/helmchart-0.1.0.tgz")
@@ -293,7 +293,7 @@ func TestRemoteBuilder_BuildFromOCIChatRepository(t *testing.T) {
 			name:       "chart version not in repository",
 			reference:  RemoteReference{Name: "grafana", Version: "1.1.1"},
 			repository: mockRepoWithoutChart(),
-			wantErr:    "failed to download chart for remote reference",
+			wantErr:    "failed to download chart for remote reference: failed to get",
 		},
 		{
 			name:       "invalid version metadata",

--- a/internal/helm/repository/oci_chart_repository.go
+++ b/internal/helm/repository/oci_chart_repository.go
@@ -231,7 +231,11 @@ func (r *OCIChartRepository) DownloadChart(chart *repo.ChartVersion) (*bytes.Buf
 	defer transport.Release(t)
 
 	// trim the oci scheme prefix if needed
-	return r.Client.Get(strings.TrimPrefix(u.String(), fmt.Sprintf("%s://", registry.OCIScheme)), clientOpts...)
+	b, err := r.Client.Get(strings.TrimPrefix(u.String(), fmt.Sprintf("%s://", registry.OCIScheme)), clientOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get '%s': %w", ref, err)
+	}
+	return b, nil
 }
 
 // Login attempts to login to the OCI registry.


### PR DESCRIPTION
Add chart address in the OCI chart download failure error message to make it clear about the chart URL that was attempted to download.
Results in:

> `chart pull error: failed to download chart for remote reference: failed to get 'oci://localhost:5000/my_repo/grafana:1.1.1': chart doesn't exist`

This is based on the test server and the last error would vary depending on the server and test scenario.

For http helm chart, the Go HTTP client should contain the URL in the error. So this is not needed there.

Fixes https://github.com/fluxcd/source-controller/issues/1011