### PR TITLE
Fix: Normalize helm repository url with query params properly

### DIFF
--- a/internal/helm/chart/dependency_manager.go
+++ b/internal/helm/chart/dependency_manager.go
@@ -266,7 +266,10 @@ func (dm *DependencyManager) resolveRepository(url string) (repo repository.Down
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 
-	nUrl := repository.NormalizeURL(url)
+	nUrl, err := repository.NormalizeURL(url)
+	if err != nil {
+		return
+	}
 	err = repository.ValidateDepURL(nUrl)
 	if err != nil {
 		return

--- a/internal/helm/repository/utils.go
+++ b/internal/helm/repository/utils.go
@@ -18,6 +18,7 @@ package repository
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	helmreg "helm.sh/helm/v3/pkg/registry"
@@ -35,17 +36,22 @@ var (
 )
 
 // NormalizeURL normalizes a ChartRepository URL by its scheme.
-func NormalizeURL(repositoryURL string) string {
+func NormalizeURL(repositoryURL string) (string, error) {
 	if repositoryURL == "" {
-		return ""
+		return "", nil
+	}
+	u, err := url.Parse(repositoryURL)
+	if err != nil {
+		return "", err
 	}
 
-	if strings.Contains(repositoryURL, helmreg.OCIScheme) {
-		return strings.TrimRight(repositoryURL, "/")
+	if u.Scheme == helmreg.OCIScheme {
+		u.Path = strings.TrimRight(u.Path, "/")
+		return u.String(), nil
 	}
 
-	return strings.TrimRight(repositoryURL, "/") + "/"
-
+	u.Path = strings.TrimRight(u.Path, "/") + "/"
+	return u.String(), nil
 }
 
 // ValidateDepURL returns an error if the given depended repository URL declaration is not supported

--- a/internal/helm/repository/utils_test.go
+++ b/internal/helm/repository/utils_test.go
@@ -24,9 +24,10 @@ import (
 
 func TestNormalizeURL(t *testing.T) {
 	tests := []struct {
-		name string
-		url  string
-		want string
+		name    string
+		url     string
+		want    string
+		wantErr bool
 	}{
 		{
 			name: "with slash",
@@ -44,11 +45,6 @@ func TestNormalizeURL(t *testing.T) {
 			want: "http://example.com/",
 		},
 		{
-			name: "empty",
-			url:  "",
-			want: "",
-		},
-		{
 			name: "oci with slash",
 			url:  "oci://example.com/",
 			want: "oci://example.com",
@@ -58,12 +54,38 @@ func TestNormalizeURL(t *testing.T) {
 			url:  "oci://example.com//",
 			want: "oci://example.com",
 		},
+		{
+			name: "url with query",
+			url:  "http://example.com?st=pr",
+			want: "http://example.com/?st=pr",
+		},
+		{
+			name: "url with slash and query",
+			url:  "http://example.com/?st=pr",
+			want: "http://example.com/?st=pr",
+		},
+		{
+			name: "empty url",
+			url:  "",
+			want: "",
+		},
+		{
+			name:    "bad url",
+			url:     "://badurl.",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			got := NormalizeURL(tt.url)
+			got, err := NormalizeURL(tt.url)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).To(Not(HaveOccurred()))
 			g.Expect(got).To(Equal(tt.want))
 		})
 	}


### PR DESCRIPTION
This pr fixes an issue that causes a 403 forbidden error when trying to download a chart using an Azure SAS token. 
This happens because the query parameters get encoded and a trailing slash is added at the end of the query.

Fix: #1018

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>