### PR TITLE
feat(ref): #1017 added name field for gitref

### DIFF
--- a/api/v1beta2/gitrepository_types.go
+++ b/api/v1beta2/gitrepository_types.go
@@ -170,13 +170,19 @@ type GitRepositoryRef struct {
 	// +optional
 	SemVer string `json:"semver,omitempty"`
 
-	// Commit SHA to check out, takes precedence over all reference fields.
+	// Commit SHA to check out, takes precedence over Branch, Tag and SemVer.
 	//
 	// When GitRepositorySpec.GitImplementation is set to 'go-git', this can be
 	// combined with Branch to shallow clone the branch, in which the commit is
 	// expected to exist.
 	// +optional
 	Commit string `json:"commit,omitempty"`
+
+	// Name to checkout, takes precedence over all reference fields.
+	//
+	// If Name is found for both Branch and Tag, Tag is used
+	// +optional
+	Name string `json:"name,omitempty"`
 }
 
 // GitRepositoryVerification specifies the Git commit signature verification

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -476,10 +476,15 @@ spec:
                       is performed."
                     type: string
                   commit:
-                    description: "Commit SHA to check out, takes precedence over all
-                      reference fields. \n When GitRepositorySpec.GitImplementation
+                    description: "Commit SHA to check out, takes precedence over Branch,
+                      Tag and SemVer. \n When GitRepositorySpec.GitImplementation
                       is set to 'go-git', this can be combined with Branch to shallow
                       clone the branch, in which the commit is expected to exist."
+                    type: string
+                  name:
+                    description: "Name to checkout, takes precedence over all reference
+                      fields. \n If Name is found for both Branch and Tag, Tag is
+                      used"
                     type: string
                   semver:
                     description: SemVer tag expression to check out, takes precedence

--- a/internal/util/commit_for_name.go
+++ b/internal/util/commit_for_name.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+
+	"github.com/fluxcd/go-git/v5"
+	"github.com/fluxcd/go-git/v5/config"
+	"github.com/fluxcd/go-git/v5/storage/memory"
+)
+
+type GitName struct {
+	rem git.Remote
+}
+
+func (g *GitName) GetGitCommitForName(name string, o *git.ListOptions) (string, error) {
+	refs, err := g.rem.List(o)
+	if err != nil {
+		return "", err
+	}
+
+	branchCommit := ""
+	for _, ref := range refs {
+		if ref.Name().Short() == name {
+			if ref.Name().IsTag() {
+				return ref.Hash().String(), nil
+			} else if ref.Name().IsBranch() {
+				branchCommit = ref.Hash().String()
+			}
+		}
+	}
+
+	if branchCommit != "" {
+		return branchCommit, nil
+	}
+
+	return "", errors.New("no commit found for name:" + name)
+}
+
+func NewGitName(config *config.RemoteConfig) (GitName, error) {
+	return GitName{rem: *git.NewRemote(memory.NewStorage(), config)}, nil
+}

--- a/internal/util/gogitv5_transport_auth.go
+++ b/internal/util/gogitv5_transport_auth.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/fluxcd/go-git/v5/plumbing/transport"
+	"github.com/fluxcd/go-git/v5/plumbing/transport/http"
+	gogit "github.com/fluxcd/go-git/v5/plumbing/transport/ssh"
+	git "github.com/fluxcd/pkg/git"
+	"golang.org/x/crypto/ssh"
+)
+
+func AuthGit(authOpts *git.AuthOptions) (transport.AuthMethod, []byte, error) {
+
+	if authOpts.Transport == git.HTTPS {
+		if authOpts.BearerToken != "" {
+			return &http.TokenAuth{
+				Token: authOpts.BearerToken,
+			}, authOpts.CAFile, nil
+		}
+		return &http.BasicAuth{
+			Username: authOpts.Username,
+			Password: authOpts.Password,
+		}, authOpts.CAFile, nil
+	}
+
+	if authOpts.Transport == git.SSH {
+		if authOpts.Identity != nil {
+			var signer ssh.Signer
+			if authOpts.Password != "" {
+				var err error
+				signer, err = ssh.ParsePrivateKeyWithPassphrase([]byte(authOpts.Identity), []byte(authOpts.Password))
+				if err != nil {
+					return nil, nil, err
+				}
+			}
+			//ToDo(haarchri): ssh: must specify HostKeyCallback"
+			return &gogit.PublicKeys{
+				User:   "git",
+				Signer: signer,
+			}, authOpts.CAFile, nil
+		}
+	}
+
+	return nil, nil, nil
+}


### PR DESCRIPTION
Signed-off-by: Christopher Paul Haar <christopherpaul.haar@dkb.de>
Co-Authored-by: André Kesser <andre.kesser@dkb.de> 

implemented Name field for GitRepositoryRef wich takes precedence over all reference fields. If Name is found for both Branch and Tag, Tag is used!

implements #1017 

**Open:**
need to implement HostKeyCallback for go-git v5:
ssh: must specify HostKeyCallback

**Tests:**

**branch: v1.x**
```
spec:
  gitImplementation: go-git
  interval: 5m0s
  ref:
    name: v1.x
  timeout: 60s
  url: https://github.com/stefanprodan/podinfo
```

```
kubectl get gitrepo -A 
NAMESPACE   NAME      URL                                       AGE     READY   STATUS
default     podinfo   https://github.com/stefanprodan/podinfo   1h51m   True    stored artifact for revision 'HEAD/6c8a85a5ab953874c7c83d50317359a0e5a352a9'
```

**tag: 6.0.3**

```
spec:
  gitImplementation: go-git
  interval: 5m0s
  ref:
    name: 6.0.3
  timeout: 60s
  url: https://github.com/stefanprodan/podinfo
```

```
kubectl get gitrepo -A 
NAMESPACE   NAME      URL                                       AGE     READY   STATUS
default     podinfo   https://github.com/stefanprodan/podinfo    1h58m   True    stored artifact for revision 'HEAD/ea292aa958c5e348266518af2261dc04d6270439'
```