### PR TITLE
api: omit empty Digest in Artifact

### DIFF
--- a/api/v1beta2/artifact_types.go
+++ b/api/v1beta2/artifact_types.go
@@ -51,7 +51,7 @@ type Artifact struct {
 	// Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
 	// +optional
 	// +kubebuilder:validation:Pattern="^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$"
-	Digest string `json:"digest"`
+	Digest string `json:"digest,omitempty"`
 
 	// LastUpdateTime is the timestamp corresponding to the last update of the
 	// Artifact.


### PR DESCRIPTION
While we initially decided against it, this otherwise causes the regexp validator to error on an empty field when it goes through a YAML -> JSON encode loop (even when marked with `+optional`).

This is not actually a viable path the controller could take, as the controller trying to update the Artifact with an older version of the API package would omit the `Digest` field (because it does not exist in that version), while a newer version of the controller would always include the field (because we produce it for all kinds). While in cases where the controller would be backed by a Persistent Volume (and a partial status update is made), the validation rule would not be triggered because the field is not part of the patch.

However, for sake of correctness, we still issue a patch.