### PR TITLE
helm: only use Digest to calculcate index revision

### DIFF
--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -318,8 +318,8 @@ func (r *HelmRepositoryReconciler) notify(ctx context.Context, oldObj, newObj *s
 			if sreconcile.FailureRecovery(oldObj, newObj, helmRepositoryFailConditions) {
 				r.AnnotatedEventf(newObj, annotations, corev1.EventTypeNormal,
 					meta.SucceededReason, message)
+				ctrl.LoggerFrom(ctx).Info(message)
 			}
-			ctrl.LoggerFrom(ctx).Info(message)
 		}
 	}
 }

--- a/controllers/helmrepository_controller.go
+++ b/controllers/helmrepository_controller.go
@@ -475,8 +475,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 		}
 		if curDig.Validate() == nil {
 			// Short-circuit based on the fetched index being an exact match to the
-			// stored Artifact. This prevents having to unmarshal the YAML to calculate
-			// the (stable) revision, which is a memory expensive operation.
+			// stored Artifact.
 			if newDig := chartRepo.Digest(curDig.Algorithm()); newDig.Validate() == nil && (newDig == curDig) {
 				*artifact = *curArtifact
 				conditions.Delete(obj, sourcev1.FetchFailedCondition)
@@ -501,11 +500,11 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 	var changed bool
 	if artifact := obj.Status.Artifact; artifact != nil {
 		curRev := digest.Digest(sourcev1.TransformLegacyRevision(artifact.Revision))
-		changed = curRev.Validate() != nil || curRev != chartRepo.Revision(curRev.Algorithm())
+		changed = curRev.Validate() != nil || curRev != chartRepo.Digest(curRev.Algorithm())
 	}
 
 	// Calculate revision.
-	revision := chartRepo.Revision(intdigest.Canonical)
+	revision := chartRepo.Digest(intdigest.Canonical)
 	if revision.Validate() != nil {
 		e := &serror.Event{
 			Err:    fmt.Errorf("failed to calculate revision: %w", err),

--- a/controllers/helmrepository_controller_test.go
+++ b/controllers/helmrepository_controller_test.go
@@ -775,7 +775,7 @@ func TestHelmRepositoryReconciler_reconcileSource(t *testing.T) {
 				checksum = newChartRepo.Digest(intdigest.Canonical)
 
 				g.Expect(newChartRepo.LoadFromPath()).To(Succeed())
-				revision = newChartRepo.Revision(intdigest.Canonical)
+				revision = newChartRepo.Digest(intdigest.Canonical)
 			}
 			if tt.beforeFunc != nil {
 				tt.beforeFunc(g, obj, revision, checksum)

--- a/internal/helm/repository/chart_repository.go
+++ b/internal/helm/repository/chart_repository.go
@@ -386,6 +386,8 @@ func (r *ChartRepository) DownloadIndex(w io.Writer) (err error) {
 
 // Revision returns the revision of the ChartRepository's Index. It assumes
 // the Index is stable sorted.
+// Deprecated: because of expensive memory usage of (YAML) marshal operations.
+// We only use Digest now.
 func (r *ChartRepository) Revision(algorithm digest.Algorithm) digest.Digest {
 	if !r.HasIndex() {
 		return ""


### PR DESCRIPTION
**Release candidate:** `ghcr.io/fluxcd/source-controller:rc-e5c0313d`

In #1001 bits around the Helm repository reconciliation logic were rewritten, mostly based
on the documented behavior instead of the actual code. This resulted in the reintroduction
of a YAML marshal of the (sorted) index YAML instead of reliance of just the checksum of
the file.

This to take situations into account in which a repository would e.g. provide a new
random order on every generation. However, this approach is (extremely) expensive as
the encoder goes through a JSON -> YAML loop, eating lots of RAM in the process.

As the further (silently) introduced behavior has not resulted in any reported issues, I deem
this approach safe and better than e.g. encoding to just JSON which would still require a
substantial amount of memory.

Fixes https://github.com/fluxcd/flux2/issues/3620