### PR TITLE
Use `logger.SetLogger` to also configure `klog`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/fluxcd/pkg/lockedfile v0.1.0
 	github.com/fluxcd/pkg/masktoken v0.2.0
 	github.com/fluxcd/pkg/oci v0.20.1
-	github.com/fluxcd/pkg/runtime v0.30.0
+	github.com/fluxcd/pkg/runtime v0.31.0
 	github.com/fluxcd/pkg/sourceignore v0.3.2
 	github.com/fluxcd/pkg/ssh v0.7.2
 	github.com/fluxcd/pkg/testserver v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/fluxcd/pkg/masktoken v0.2.0 h1:HoSPTk4l1fz5Fevs2vVRvZGru33blfMwWSZKsH
 github.com/fluxcd/pkg/masktoken v0.2.0/go.mod h1:EA7GleAHL33kN6kTW06m5R3/Q26IyuGO7Ef/0CtpDI0=
 github.com/fluxcd/pkg/oci v0.20.1 h1:MysI8N4lcKjb3B/EMtFXVoyStU5xTVGIKXj9J81xeAM=
 github.com/fluxcd/pkg/oci v0.20.1/go.mod h1:DvGuPqQvoVeDmiIKNCpjgIIs2MdkGIS0BjhLZIVfOWA=
-github.com/fluxcd/pkg/runtime v0.30.0 h1:mAC6uO0q/K3lQ3QnBCBWyleplrYlppQ6Dco5kXH1L40=
-github.com/fluxcd/pkg/runtime v0.30.0/go.mod h1:wzJVtLLf34v1wPhSoB+z8qkwS/pZqUArjSoCcekXc30=
+github.com/fluxcd/pkg/runtime v0.31.0 h1:addyXaANHl/A68bEjCbiR4HzcFKgfXv1eaG7B7ZHxOo=
+github.com/fluxcd/pkg/runtime v0.31.0/go.mod h1:toGOOubMo4ZC1aWhB8C3drdTglr1/A1dETeNwjiIv0g=
 github.com/fluxcd/pkg/sourceignore v0.3.2 h1:UXRguBJA9frgRDSr7Lsc873a9YTbbpbJafEaYjkpVEs=
 github.com/fluxcd/pkg/sourceignore v0.3.2/go.mod h1:yuJzKggph0Bdbk9LgXjJQhvJZSTJV/1vS7mJuB7mPa0=
 github.com/fluxcd/pkg/ssh v0.7.2 h1:kyAcwUYOMdxN9sOBNSYKiNgmIpbx94VufwqtKucW54M=

--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func main() {
 
 	flag.Parse()
 
-	ctrl.SetLogger(logger.NewLogger(logOptions))
+	logger.SetLogger(logger.NewLogger(logOptions))
 
 	err := featureGates.WithLogger(setupLog).
 		SupportedFeatures(features.FeatureGates())


### PR DESCRIPTION
This uses the newly introduced helper from runtime, which also
configures the logger for `klog`.

Resulting in all logs now being properly formatted in, even when logged
by internal Kubernetes elements like the leader election or a dynamic
client.