### PR TITLE
Update sourceignore to fix pattern domain bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/fluxcd/pkg/masktoken v0.2.0
 	github.com/fluxcd/pkg/oci v0.21.1
 	github.com/fluxcd/pkg/runtime v0.31.0
-	github.com/fluxcd/pkg/sourceignore v0.3.2
+	github.com/fluxcd/pkg/sourceignore v0.3.3
 	github.com/fluxcd/pkg/ssh v0.7.3
 	github.com/fluxcd/pkg/testserver v0.4.0
 	github.com/fluxcd/pkg/untar v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -550,8 +550,8 @@ github.com/fluxcd/pkg/oci v0.21.1 h1:9kn19wkabE2xB77NRlOtMJlSYhZmUjdloZCzlHdAS6s
 github.com/fluxcd/pkg/oci v0.21.1/go.mod h1:9E2DBlQII7YmeWt2ieTh38wwkiBqx3yg5NEJ51uefaA=
 github.com/fluxcd/pkg/runtime v0.31.0 h1:addyXaANHl/A68bEjCbiR4HzcFKgfXv1eaG7B7ZHxOo=
 github.com/fluxcd/pkg/runtime v0.31.0/go.mod h1:toGOOubMo4ZC1aWhB8C3drdTglr1/A1dETeNwjiIv0g=
-github.com/fluxcd/pkg/sourceignore v0.3.2 h1:UXRguBJA9frgRDSr7Lsc873a9YTbbpbJafEaYjkpVEs=
-github.com/fluxcd/pkg/sourceignore v0.3.2/go.mod h1:yuJzKggph0Bdbk9LgXjJQhvJZSTJV/1vS7mJuB7mPa0=
+github.com/fluxcd/pkg/sourceignore v0.3.3 h1:Ue29JAuPECEYdvIqdpXpQaDxpeySn7amarLArp7XoIs=
+github.com/fluxcd/pkg/sourceignore v0.3.3/go.mod h1:yuJzKggph0Bdbk9LgXjJQhvJZSTJV/1vS7mJuB7mPa0=
 github.com/fluxcd/pkg/ssh v0.7.3 h1:Dhs+nXdp806lBriUJtPyRi0SVIVWbJafJGD/qQ71GiY=
 github.com/fluxcd/pkg/ssh v0.7.3/go.mod h1:/z5ZNgQz+h9s/2nNFKAcZDHtZRMA1nj5YcriGDUOoLY=
 github.com/fluxcd/pkg/testserver v0.4.0 h1:pDZ3gistqYhwlf3sAjn1Q8NzN4Qe6I1BEmHMHi46lMg=


### PR DESCRIPTION
Refer https://github.com/fluxcd/pkg/pull/512 

RC image to try this:
```
ghcr.io/fluxcd/source-controller:rc-1303c254@sha256:0b9ea0503f76faf9c4e827c3d1dff72f4c10d8aa9a3be6cfd67e7c467423ee86
```
Image build https://github.com/fluxcd/source-controller/actions/runs/4426321843/jobs/7762473318