### PR TITLE
ci: Remove the macOS runner

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,32 +64,3 @@ jobs:
           # current issue is resolved.
           GO_TEST_ARGS: ''
         run: make test
-
-  # Runs 'make test' on MacOS to ensure the continuous support for contributors
-  # using it as a development environment.
-  darwin-amd64:
-    strategy:
-      matrix:
-        os: [macos-12]
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-      - name: Setup Go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version: 1.20.x
-          cache-dependency-path: |
-            **/go.sum
-            **/go.mod
-      - name: Install and configure Docker using colima
-        # Ref: https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running
-        run: |
-          brew install docker
-          colima start
-          echo "DOCKER_HOST=unix://$HOME/.colima/default/docker.sock" >> $GITHUB_ENV
-      - name: Run tests
-        run: make test
-        env:
-          SKIP_COSIGN_VERIFICATION: true


### PR DESCRIPTION
Remove the Darwin AMD64 runner since we no longer depend on C code when building source-controller.