### PR TITLE
docs: Add note about bearer token auth with popular Git servers

### DIFF
--- a/docs/spec/v1/gitrepositories.md
+++ b/docs/spec/v1/gitrepositories.md
@@ -139,6 +139,14 @@ To authenticate towards a Git repository over HTTPS using bearer token
 authentication (in other words: using a `Authorization: Bearer` header), the referenced
 Secret is expected to contain the token in `.data.bearerToken`.
 
+**Note:** If you are looking to use OAuth tokens with popular servers (e.g.
+[GitHub](https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api?apiVersion=2022-11-28#authenticating-with-a-token-generated-by-an-app),
+[Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/using-access-tokens/),
+[GitLab](https://docs.gitlab.com/ee/gitlab-basics/start-using-git.html#clone-using-a-token)),
+you should use basic access authentication instead. These servers use basic HTTP
+authentication, with the OAuth token as the password. Check the documentation of
+your Git server for details.
+
 ```yaml
 ---
 apiVersion: v1

--- a/docs/spec/v1beta2/gitrepositories.md
+++ b/docs/spec/v1beta2/gitrepositories.md
@@ -140,6 +140,14 @@ To authenticate towards a Git repository over HTTPS using bearer token
 authentication (in other words: using a `Authorization: Bearer` header), the referenced
 Secret is expected to contain the token in `.data.bearerToken`.
 
+**Note:** If you are looking to use OAuth tokens with popular servers (e.g.
+[GitHub](https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api?apiVersion=2022-11-28#authenticating-with-a-token-generated-by-an-app),
+[Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/using-access-tokens/),
+[GitLab](https://docs.gitlab.com/ee/gitlab-basics/start-using-git.html#clone-using-a-token)),
+you should use basic access authentication instead. These servers use basic HTTP
+authentication, with the OAuth token as the password. Check the documentation of
+your Git server for details.
+
 ```yaml
 ---
 apiVersion: v1


### PR DESCRIPTION
I spent a while failing to get the source controller to pull/push repos with a GitHub App using a bearer token. Eventually, I realized that Flux's bearer token auth feature was working properly, but GitHub doesn't actually support it for cloning repos - it requires the token sent as basic auth instead. Some other people appear to have run into the same problem here: https://github.com/fluxcd/flux2/issues/3668

This PR updates the documentation to clarify that some popular Git servers require the bearer token to be provided as basic auth credentials instead of in the Authorization header.

Wording is based on this comment from go-git:
https://github.com/fluxcd/go-git/blob/2e5c9d01cfc45de34975e567cf7cf5bf13fee082/plumbing/transport/http/common.go#L222-L225