### PR TITLE
Helm OCI: Add support for TLS registries with self-signed certs

### DIFF
--- a/docs/spec/v1beta2/helmrepositories.md
+++ b/docs/spec/v1beta2/helmrepositories.md
@@ -459,8 +459,6 @@ a deprecation warning will be logged.
 
 ### Cert secret reference
 
-**Note:** TLS authentication is not yet supported by OCI Helm repositories.
-
 `.spec.certSecretRef.name` is an optional field to specify a secret containing TLS
 certificate data. The secret can contain the following keys:
 

--- a/internal/controller/helmrepository_controller.go
+++ b/internal/controller/helmrepository_controller.go
@@ -399,7 +399,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 		return sreconcile.ResultEmpty, e
 	}
 
-	clientOpts, err := getter.GetClientOpts(ctx, r.Client, obj, normalizedURL)
+	clientOpts, _, err := getter.GetClientOpts(ctx, r.Client, obj, normalizedURL)
 	if err != nil {
 		if errors.Is(err, getter.ErrDeprecatedTLSConfig) {
 			ctrl.LoggerFrom(ctx).

--- a/internal/controller/helmrepository_controller_test.go
+++ b/internal/controller/helmrepository_controller_test.go
@@ -796,7 +796,7 @@ func TestHelmRepositoryReconciler_reconcileSource(t *testing.T) {
 				if tt.url != "" {
 					repoURL = tt.url
 				}
-				tlsConf, serr = getter.TLSClientConfigFromSecret(*secret, repoURL)
+				tlsConf, _, serr = getter.TLSClientConfigFromSecret(*secret, repoURL)
 				if serr != nil {
 					validSecret = false
 				}

--- a/internal/helm/getter/client_opts.go
+++ b/internal/helm/getter/client_opts.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
+	"path"
 
 	"github.com/fluxcd/pkg/oci"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -37,23 +39,47 @@ import (
 	soci "github.com/fluxcd/source-controller/internal/oci"
 )
 
+const (
+	certFileName = "cert.pem"
+	keyFileName  = "key.pem"
+	caFileName   = "ca.pem"
+)
+
 var ErrDeprecatedTLSConfig = errors.New("TLS configured in a deprecated manner")
+
+// TLSBytes contains the bytes of the TLS files.
+type TLSBytes struct {
+	// CertBytes is the bytes of the certificate file.
+	CertBytes []byte
+	// KeyBytes is the bytes of the key file.
+	KeyBytes []byte
+	// CABytes is the bytes of the CA file.
+	CABytes []byte
+}
 
 // ClientOpts contains the various options to use while constructing
 // a Helm repository client.
 type ClientOpts struct {
 	Authenticator authn.Authenticator
 	Keychain      authn.Keychain
-	RegLoginOpt   helmreg.LoginOption
+	RegLoginOpts  []helmreg.LoginOption
 	TlsConfig     *tls.Config
 	GetterOpts    []helmgetter.Option
+}
+
+// MustLoginToRegistry returns true if the client options contain at least
+// one registry login option.
+func (o ClientOpts) MustLoginToRegistry() bool {
+	return len(o.RegLoginOpts) > 0 && o.RegLoginOpts[0] != nil
 }
 
 // GetClientOpts uses the provided HelmRepository object and a normalized
 // URL to construct a HelmClientOpts object. If obj is an OCI HelmRepository,
 // then the returned options object will also contain the required registry
 // auth mechanisms.
-func GetClientOpts(ctx context.Context, c client.Client, obj *helmv1.HelmRepository, url string) (*ClientOpts, error) {
+// A temporary directory is created to store the certs files if needed and its path is returned along with the options object. It is the
+// caller's responsibility to clean up the directory.
+func GetClientOpts(ctx context.Context, c client.Client, obj *helmv1.HelmRepository, url string) (*ClientOpts, string, error) {
 	hrOpts := &ClientOpts{
 		GetterOpts: []helmgetter.Option{
 			helmgetter.WithURL(url),
@@ -63,18 +89,25 @@ func GetClientOpts(ctx context.Context, c client.Client, obj *helmv1.HelmReposit
 	}
 	ociRepo := obj.Spec.Type == helmv1.HelmRepositoryTypeOCI
 
-	var certSecret *corev1.Secret
-	var err error
+	var (
+		certSecret *corev1.Secret
+		tlsBytes   *TLSBytes
+		certFile   string
+		keyFile    string
+		caFile     string
+		dir        string
+		err        error
+	)
 	// Check `.spec.certSecretRef` first for any TLS auth data.
 	if obj.Spec.CertSecretRef != nil {
 		certSecret, err = fetchSecret(ctx, c, obj.Spec.CertSecretRef.Name, obj.GetNamespace())
 		if err != nil {
-			return nil, fmt.Errorf("failed to get TLS authentication secret '%s/%s': %w", obj.GetNamespace(), obj.Spec.CertSecretRef.Name, err)
+			return nil, "", fmt.Errorf("failed to get TLS authentication secret '%s/%s': %w", obj.GetNamespace(), obj.Spec.CertSecretRef.Name, err)
 		}
 
-		hrOpts.TlsConfig, err = TLSClientConfigFromSecret(*certSecret, url)
+		hrOpts.TlsConfig, tlsBytes, err = TLSClientConfigFromSecret(*certSecret, url)
 		if err != nil {
-			return nil, fmt.Errorf("failed to construct Helm client's TLS config: %w", err)
+			return nil, "", fmt.Errorf("failed to construct Helm client's TLS config: %w", err)
 		}
 	}
 
@@ -83,22 +116,22 @@ func GetClientOpts(ctx context.Context, c client.Client, obj *helmv1.HelmReposit
 	if obj.Spec.SecretRef != nil {
 		authSecret, err = fetchSecret(ctx, c, obj.Spec.SecretRef.Name, obj.GetNamespace())
 		if err != nil {
-			return nil, fmt.Errorf("failed to get authentication secret '%s/%s': %w", obj.GetNamespace(), obj.Spec.SecretRef.Name, err)
+			return nil, "", fmt.Errorf("failed to get authentication secret '%s/%s': %w", obj.GetNamespace(), obj.Spec.SecretRef.Name, err)
 		}
 
 		// Construct actual Helm client options.
 		opts, err := GetterOptionsFromSecret(*authSecret)
 		if err != nil {
-			return nil, fmt.Errorf("failed to configure Helm client: %w", err)
+			return nil, "", fmt.Errorf("failed to configure Helm client: %w", err)
 		}
 		hrOpts.GetterOpts = append(hrOpts.GetterOpts, opts...)
 
 		// If the TLS config is nil, i.e. one couldn't be constructed using `.spec.certSecretRef`
-		// then try to use `.spec.certSecretRef`.
+		// then try to use `.spec.secretRef`.
 		if hrOpts.TlsConfig == nil {
-			hrOpts.TlsConfig, err = TLSClientConfigFromSecret(*authSecret, url)
+			hrOpts.TlsConfig, tlsBytes, err = TLSClientConfigFromSecret(*authSecret, url)
 			if err != nil {
-				return nil, fmt.Errorf("failed to construct Helm client's TLS config: %w", err)
+				return nil, "", fmt.Errorf("failed to construct Helm client's TLS config: %w", err)
 			}
 			// Constructing a TLS config using the auth secret is deprecated behavior.
 			if hrOpts.TlsConfig != nil {
@@ -109,13 +142,13 @@ func GetClientOpts(ctx context.Context, c client.Client, obj *helmv1.HelmReposit
 		if ociRepo {
 			hrOpts.Keychain, err = registry.LoginOptionFromSecret(url, *authSecret)
 			if err != nil {
-				return nil, fmt.Errorf("failed to configure login options: %w", err)
+				return nil, "", fmt.Errorf("failed to configure login options: %w", err)
 			}
 		}
 	} else if obj.Spec.Provider != helmv1.GenericOCIProvider && obj.Spec.Type == helmv1.HelmRepositoryTypeOCI && ociRepo {
 		authenticator, authErr := soci.OIDCAuth(ctx, obj.Spec.URL, obj.Spec.Provider)
 		if authErr != nil && !errors.Is(authErr, oci.ErrUnconfiguredProvider) {
-			return nil, fmt.Errorf("failed to get credential from '%s': %w", obj.Spec.Provider, authErr)
+			return nil, "", fmt.Errorf("failed to get credential from '%s': %w", obj.Spec.Provider, authErr)
 		}
 		if authenticator != nil {
 			hrOpts.Authenticator = authenticator
@@ -123,16 +156,34 @@ func GetClientOpts(ctx context.Context, c client.Client, obj *helmv1.HelmReposit
 	}
 
 	if ociRepo {
-		hrOpts.RegLoginOpt, err = registry.NewLoginOption(hrOpts.Authenticator, hrOpts.Keychain, url)
+		// Persist the certs files to the path if needed.
+		if tlsBytes != nil {
+			dir, err = os.MkdirTemp("", "helm-repo-oci-certs")
+			if err != nil {
+				return nil, "", fmt.Errorf("cannot create temporary directory: %w", err)
+			}
+			certFile, keyFile, caFile, err = StoreTLSCertificateFiles(tlsBytes, dir)
+			if err != nil {
+				return nil, "", fmt.Errorf("cannot write certs files to path: %w", err)
+			}
+		}
+		loginOpt, err := registry.NewLoginOption(hrOpts.Authenticator, hrOpts.Keychain, url)
 		if err != nil {
-			return nil, err
+			return nil, "", err
+		}
+		if loginOpt != nil {
+			hrOpts.RegLoginOpts = []helmreg.LoginOption{loginOpt}
+		}
+		tlsLoginOpt := registry.TLSLoginOption(certFile, keyFile, caFile)
+		if tlsLoginOpt != nil {
+			hrOpts.RegLoginOpts = append(hrOpts.RegLoginOpts, tlsLoginOpt)
 		}
 	}
 	if deprecatedTLSConfig {
 		err = ErrDeprecatedTLSConfig
 	}
 
-	return hrOpts, err
+	return hrOpts, dir, err
 }
 
 func fetchSecret(ctx context.Context, c client.Client, name, namespace string) (*corev1.Secret, error) {
@@ -152,13 +203,13 @@ func fetchSecret(ctx context.Context, c client.Client, name, namespace string) (
 //
 // Secrets with no certFile, keyFile, AND caFile are ignored, if only a
 // certBytes OR keyBytes is defined it returns an error.
-func TLSClientConfigFromSecret(secret corev1.Secret, repositoryUrl string) (*tls.Config, error) {
+func TLSClientConfigFromSecret(secret corev1.Secret, repositoryUrl string) (*tls.Config, *TLSBytes, error) {
 	certBytes, keyBytes, caBytes := secret.Data["certFile"], secret.Data["keyFile"], secret.Data["caFile"]
 	switch {
 	case len(certBytes)+len(keyBytes)+len(caBytes) == 0:
-		return nil, nil
+		return nil, nil, nil
 	case (len(certBytes) > 0 && len(keyBytes) == 0) || (len(keyBytes) > 0 && len(certBytes) == 0):
-		return nil, fmt.Errorf("invalid '%s' secret data: fields 'certFile' and 'keyFile' require each other's presence",
+		return nil, nil, fmt.Errorf("invalid '%s' secret data: fields 'certFile' and 'keyFile' require each other's presence",
 			secret.Name)
 	}
 
@@ -166,7 +217,7 @@ func TLSClientConfigFromSecret(secret corev1.Secret, repositoryUrl string) (*tls
 	if len(certBytes) > 0 && len(keyBytes) > 0 {
 		cert, err := tls.X509KeyPair(certBytes, keyBytes)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		tlsConf.Certificates = append(tlsConf.Certificates, cert)
 	}
@@ -174,10 +225,10 @@ func TLSClientConfigFromSecret(secret corev1.Secret, repositoryUrl string) (*tls
 	if len(caBytes) > 0 {
 		cp, err := x509.SystemCertPool()
 		if err != nil {
-			return nil, fmt.Errorf("cannot retrieve system certificate pool: %w", err)
+			return nil, nil, fmt.Errorf("cannot retrieve system certificate pool: %w", err)
 		}
 		if !cp.AppendCertsFromPEM(caBytes) {
-			return nil, fmt.Errorf("cannot append certificate into certificate pool: invalid caFile")
+			return nil, nil, fmt.Errorf("cannot append certificate into certificate pool: invalid caFile")
 		}
 
 		tlsConf.RootCAs = cp
@@ -187,10 +238,50 @@ func TLSClientConfigFromSecret(secret corev1.Secret, repositoryUrl string) (*tls
 
 	u, err := url.Parse(repositoryUrl)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse repository URL: %w", err)
+		return nil, nil, fmt.Errorf("cannot parse repository URL: %w", err)
 	}
 
 	tlsConf.ServerName = u.Hostname()
 
-	return tlsConf, nil
+	return tlsConf, &TLSBytes{
+		CertBytes: certBytes,
+		KeyBytes:  keyBytes,
+		CABytes:   caBytes,
+	}, nil
+}
+
+// StoreTLSCertificateFiles writes the certs files to the given path and returns the files paths.
+func StoreTLSCertificateFiles(tlsBytes *TLSBytes, path string) (string, string, string, error) {
+	var (
+		certFile string
+		keyFile  string
+		caFile   string
+		err      error
+	)
+	if len(tlsBytes.CertBytes) > 0 && len(tlsBytes.KeyBytes) > 0 {
+		certFile, err = writeToFile(tlsBytes.CertBytes, certFileName, path)
+		if err != nil {
+			return "", "", "", err
+		}
+		keyFile, err = writeToFile(tlsBytes.KeyBytes, keyFileName, path)
+		if err != nil {
+			return "", "", "", err
+		}
+	}
+	if len(tlsBytes.CABytes) > 0 {
+		caFile, err = writeToFile(tlsBytes.CABytes, caFileName, path)
+		if err != nil {
+			return "", "", "", err
+		}
+	}
+	return certFile, keyFile, caFile, nil
+}
+
+func writeToFile(data []byte, filename, tmpDir string) (string, error) {
+	file := path.Join(tmpDir, filename)
+	err := os.WriteFile(file, data, 0o644)
+	if err != nil {
+		return "", err
+	}
+	return file, nil
 }

--- a/internal/helm/registry/auth.go
+++ b/internal/helm/registry/auth.go
@@ -154,3 +154,13 @@ func NewLoginOption(auth authn.Authenticator, keychain authn.Keychain, registryU
 
 	return nil, nil
 }
+
+// TLSLoginOption returns a LoginOption that can be used to configure the TLS client.
+// It requires either the caFile or both certFile and keyFile to be not blank.
+func TLSLoginOption(certFile, keyFile, caFile string) registry.LoginOption {
+	if (certFile != "" && keyFile != "") || caFile != "" {
+		return registry.LoginOptTLSClientConfig(certFile, keyFile, caFile)
+	}
+
+	return nil
+}

--- a/internal/helm/repository/oci_chart_repository.go
+++ b/internal/helm/repository/oci_chart_repository.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -65,8 +66,12 @@ type OCIChartRepository struct {
 
 	// RegistryClient is a client to use while downloading tags or charts from a registry.
 	RegistryClient RegistryClient
+
 	// credentialsFile is a temporary credentials file to use while downloading tags or charts from a registry.
 	credentialsFile string
+
+	// certificatesStore is a temporary store to use while downloading tags or charts from a registry.
+	certificatesStore string
 
 	// verifiers is a list of verifiers to use when verifying a chart.
 	verifiers []oci.Verifier
@@ -116,6 +121,14 @@ func WithOCIGetterOptions(getterOpts []getter.Option) OCIChartRepositoryOption {
 func WithCredentialsFile(credentialsFile string) OCIChartRepositoryOption {
 	return func(r *OCIChartRepository) error {
 		r.credentialsFile = credentialsFile
+		return nil
+	}
+}
+
+// WithCertificatesStore returns a ChartRepositoryOption that will set the certificates store
+func WithCertificatesStore(store string) OCIChartRepositoryOption {
+	return func(r *OCIChartRepository) error {
+		r.certificatesStore = store
 		return nil
 	}
 }
@@ -265,14 +278,24 @@ func (r *OCIChartRepository) HasCredentials() bool {
 
 // Clear deletes the OCI registry credentials file.
 func (r *OCIChartRepository) Clear() error {
+	var errs error
 	// clean the credentials file if it exists
 	if r.credentialsFile != "" {
 		if err := os.Remove(r.credentialsFile); err != nil {
-			return err
+			errs = errors.Join(errs, err)
 		}
 	}
 	r.credentialsFile = ""
-	return nil
+
+	// clean the certificates store if it exists
+	if r.certificatesStore != "" {
+		if err := os.RemoveAll(r.certificatesStore); err != nil {
+			errs = errors.Join(errs, err)
+		}
+	}
+	r.certificatesStore = ""
+
+	return errs
 }
 
 // getLastMatchingVersionOrConstraint returns the last version that matches the given version string.

--- a/main.go
+++ b/main.go
@@ -198,7 +198,6 @@ func main() {
 		Client:                  mgr.GetClient(),
 		EventRecorder:           eventRecorder,
 		Metrics:                 metrics,
-		Getters:                 getters,
 		ControllerName:          controllerName,
 		RegistryClientGenerator: registry.ClientGenerator,
 	}).SetupWithManagerAndOptions(mgr, controller.HelmRepositoryReconcilerOptions{


### PR DESCRIPTION
fixes #723 

If implemented user will be able to provide their own custom start and bypass tls verification when interacting with OCI registries over https to pull helmCharts.