### PR TITLE
gitrepo: remove `OptimizedGitClones` as a feature gate

### DIFF
--- a/internal/controller/gitrepository_controller_test.go
+++ b/internal/controller/gitrepository_controller_test.go
@@ -562,10 +562,7 @@ func TestGitRepositoryReconciler_reconcileSource_authStrategy(t *testing.T) {
 				Client:        clientBuilder.Build(),
 				EventRecorder: record.NewFakeRecorder(32),
 				Storage:       testStorage,
-				features: map[string]bool{
-					features.OptimizedGitClones: true,
-				},
-				patchOptions: getPatchOptions(gitRepositoryReadyCondition.Owned, "sc"),
+				patchOptions:  getPatchOptions(gitRepositoryReadyCondition.Owned, "sc"),
 			}
 
 			tmpDir := t.TempDir()
@@ -792,10 +789,7 @@ func TestGitRepositoryReconciler_reconcileSource_checkoutStrategy(t *testing.T) 
 			Build(),
 		EventRecorder: record.NewFakeRecorder(32),
 		Storage:       testStorage,
-		features: map[string]bool{
-			features.OptimizedGitClones: true,
-		},
-		patchOptions: getPatchOptions(gitRepositoryReadyCondition.Owned, "sc"),
+		patchOptions:  getPatchOptions(gitRepositoryReadyCondition.Owned, "sc"),
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -50,7 +50,6 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/fluxcd/source-controller/internal/cache"
-	"github.com/fluxcd/source-controller/internal/features"
 	"github.com/fluxcd/source-controller/internal/helm/registry"
 	// +kubebuilder:scaffold:imports
 )
@@ -241,9 +240,6 @@ func TestMain(m *testing.M) {
 		EventRecorder: record.NewFakeRecorder(32),
 		Metrics:       testMetricsH,
 		Storage:       testStorage,
-		features: map[string]bool{
-			features.OptimizedGitClones: true,
-		},
 	}).SetupWithManagerAndOptions(testEnv, GitRepositoryReconcilerOptions{
 		RateLimiter: controller.GetDefaultRateLimiter(),
 	}); err != nil {

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -22,13 +22,6 @@ package features
 import feathelper "github.com/fluxcd/pkg/runtime/features"
 
 const (
-	// OptimizedGitClones decreases resource utilization for GitRepository
-	// reconciliations.
-	//
-	// When enabled, avoids full clone operations by first checking whether
-	// the last revision is still the same at the target repository,
-	// and if that is so, skips the reconciliation.
-	OptimizedGitClones = "OptimizedGitClones"
 	// CacheSecretsAndConfigMaps controls whether secrets and configmaps should be cached.
 	//
 	// When enabled, it will cache both object types, resulting in increased memory usage
@@ -37,9 +30,6 @@ const (
 )
 
 var features = map[string]bool{
-	// OptimizedGitClones
-	// opt-out from v0.25
-	OptimizedGitClones: true,
 	// CacheSecretsAndConfigMaps
 	// opt-in from v0.34
 	CacheSecretsAndConfigMaps: false,


### PR DESCRIPTION
Remove the `OptimizedGitClones` feature gate, making optimized Git clones when using a branch or tag to checkout, the default behavior.