### PR TITLE
Add backport GitHub Action workflow

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    labels: ["area/build"]
+    labels: ["area/ci", "dependencies"]
     schedule:
-      # by default this will be on a monday.
+      # By default, this will be on a monday.
       interval: "weekly"

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,78 @@
+# Configuration file to declaratively configure labels
+# Ref: https://github.com/EndBug/label-sync#Config-files
+
+- name: area/bucket
+  description: Bucket related issues and PRs
+  color: '#169b4e'
+- name: area/ci
+  description: Internal CI related issues and pull requests
+  color: '#fccb4c'
+  aliases: ['area/build']
+- name: area/docs
+  description: Documentation related issues and PRs
+  color: '#007bc7'
+- name: area/git
+  description: Git related issues and PRs
+  color: '#8762c7'
+- name: area/helm
+  description: Helm related issues and PRs
+  color: '#3c1f81'
+- name: area/oci
+  description: OCI related issues and PRs
+  color: '#d621a5'
+- name: area/security
+  description: Security related issues and PRs
+  color: '#e64c15'
+- name: area/storage
+  description: Storage related issues and PRs
+  color: '#707070'
+- name: area/testing
+  description: (Unit) testing related issues and PRs
+  color: '#e8c612'
+- name: backport:release/v1.0.x
+  description: To be backported to release/v1.0.x
+  color: '#ffa600'
+- name: blocked/needs-validation
+  description: Requires wider review and validation
+  color: '#ffc985'
+  aliases: ['blocked-needs-validation']
+- name: blocked/upstream
+  description: Blocked by an upstream dependency or issue
+  color: '#a86fbb'
+  aliases: ['blocked-upstream']
+- name: bug
+  description: Something isn't working
+  color: '#e63946'
+- name: dependencies
+  description: Pull requests that update a dependency
+  color: '#186faf'
+- name: duplicate
+  description: This issue or pull request already exists
+  color: '#c4c8cc'
+- name: enhancement
+  description: New feature or request
+  color: '#68c6e8'
+- name: experimental
+  description: Issues and PRs related to experimental features
+  color: '#e5437b'
+- name: good first issue
+  description: Good for newcomers
+  color: '#6074ff'
+- name: help wanted
+  description: Extra attention is needed
+  color: '#00a87b'
+- name: hold
+  description: Issues and pull requests put on hold
+  color: '#e64c15'
+- name: invalid
+  description: This doesn't seem right
+  color: '#ffffff'
+- name: question
+  description: Further information is requested
+  color: '#e175e5'
+- name: umbrella-issue
+  description: Umbrella issue for tracking progress of a larger effort
+  color: '#b162a9'
+- name: wontfix
+  description: This will not be worked on
+  color: '#c4c8cc'

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,33 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.event.pull_request.state == 'closed' && github.event.pull_request.merged && (github.event_name != 'labeled' || startsWith('backport:', github.event.label.name))
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Create backport PRs
+        uses: korthout/backport-action@bf5fdd624b35f95d5b85991a728bd5744e8c6cf2 # v1.3.1
+        # xref: https://github.com/korthout/backport-action#inputs
+        with:
+          # Match labels with a pattern `backport:<target-branch>`
+          label_pattern: '^backport:([^ ]+)$'
+          # A bit shorter pull-request title than the default
+          pull_title: '[${target_branch}] ${pull_title}'
+          # Simpler PR description than default
+          pull_description: |-
+            Automated backport to `${target_branch}`, triggered by a label in #${pull_number}.

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,4 +1,4 @@
-name: Backport
+name: backport
 
 on:
   pull_request_target:

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -1,4 +1,4 @@
-name: CIFuzz
+name: fuzz
 on:
   pull_request:
     branches:
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  Fuzzing:
+  smoketest:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -1,4 +1,4 @@
-name: Scan
+name: scan
 
 on:
   push:

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -1,0 +1,26 @@
+name: Sync labels
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  labels:
+    name: Run sync
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: EndBug/label-sync@da00f2c11fdb78e4fae44adac2fdd713778ea3e8 # v2.3.2
+        with:
+          # Configuration file
+          config-file: .github/labels.yaml
+          # Strictly declarative
+          delete-other-labels: true

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -1,4 +1,4 @@
-name: Sync labels
+name: sync-labels
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
This workflow automatically backports pull requests labeled with `backport:<release series branch>`.

For example, `backport:release/v1.0.x` to backport the pull request to a `release/v1.0.x` branch.

:bulb: To export already defined GitHub labels in the expected YAML format, you can use:

```shell
gh label list --json name,color,description --sort name -t '{{range .}}- name: {{.name}}{{"\n"}}  description: {{.description}}{{"\n"}}  color: '"'"#{{.color}}"'"'{{"\n"}}{{end}}'
```

Part of: https://github.com/fluxcd/flux2/issues/4022