### PR TITLE
gitrepo: remove obsolete proxy docs

### DIFF
--- a/docs/spec/v1/gitrepositories.md
+++ b/docs/spec/v1/gitrepositories.md
@@ -433,11 +433,6 @@ GitRepository, and changes to the resource or in the Git repository will not
 result in a new Artifact. When the field is set to `false` or removed, it will
 resume.
 
-#### Proxy support
-
-When a proxy is configured in the source-controller Pod through the appropriate
-environment variables, for example `HTTPS_PROXY`, `NO_PROXY`, etc.
-
 ### Recurse submodules
 
 `.spec.recurseSubmodules` is an optional field to enable the initialization of


### PR DESCRIPTION
The proxy section is a leftover from when we had different Git implementations and is non sensical, thus remove it.