### PR TITLE
helmrepo: add `.spec.certSecretRef` for specifying TLS auth data

### DIFF
--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -51,10 +51,17 @@ type HelmRepositorySpec struct {
 	// for the HelmRepository.
 	// For HTTP/S basic auth the secret must contain 'username' and 'password'
 	// fields.
-	// For TLS the secret must contain a 'certFile' and 'keyFile', and/or
-	// 'caFile' fields.
+	// Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile'
+	// keys is deprecated. Please use `.spec.certSecretRef` instead.
 	// +optional
 	SecretRef *meta.LocalObjectReference `json:"secretRef,omitempty"`
+
+	// CertSecretRef specifies the Secret containing the TLS authentication
+	// data. The secret must contain a 'certFile' and 'keyFile', and/or 'caFile'
+	// fields. It takes precedence over the values specified in the Secret
+	// referred to by `.spec.secretRef`.
+	// +optional
+	CertSecretRef *meta.LocalObjectReference `json:"certSecretRef,omitempty"`
 
 	// PassCredentials allows the credentials from the SecretRef to be passed
 	// on to a host that does not match the host as defined in URL.

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -577,6 +577,11 @@ func (in *HelmRepositorySpec) DeepCopyInto(out *HelmRepositorySpec) {
 		*out = new(meta.LocalObjectReference)
 		**out = **in
 	}
+	if in.CertSecretRef != nil {
+		in, out := &in.CertSecretRef, &out.CertSecretRef
+		*out = new(meta.LocalObjectReference)
+		**out = **in
+	}
 	out.Interval = in.Interval
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -296,6 +296,18 @@ spec:
                 required:
                 - namespaceSelectors
                 type: object
+              certSecretRef:
+                description: CertSecretRef specifies the Secret containing the TLS
+                  authentication data. The secret must contain a 'certFile' and 'keyFile',
+                  and/or 'caFile' fields. It takes precedence over the values specified
+                  in the Secret referred to by `.spec.secretRef`.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
               interval:
                 description: Interval at which to check the URL for updates.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
@@ -323,8 +335,9 @@ spec:
               secretRef:
                 description: SecretRef specifies the Secret containing authentication
                   credentials for the HelmRepository. For HTTP/S basic auth the secret
-                  must contain 'username' and 'password' fields. For TLS the secret
-                  must contain a 'certFile' and 'keyFile', and/or 'caFile' fields.
+                  must contain 'username' and 'password' fields. Support for TLS auth
+                  using the 'certFile' and 'keyFile', and/or 'caFile' keys is deprecated.
+                  Please use `.spec.certSecretRef` instead.
                 properties:
                   name:
                     description: Name of the referent.

--- a/docs/api/v1beta2/source.md
+++ b/docs/api/v1beta2/source.md
@@ -792,8 +792,25 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 for the HelmRepository.
 For HTTP/S basic auth the secret must contain &lsquo;username&rsquo; and &lsquo;password&rsquo;
 fields.
-For TLS the secret must contain a &lsquo;certFile&rsquo; and &lsquo;keyFile&rsquo;, and/or
-&lsquo;caFile&rsquo; fields.</p>
+Support for TLS auth using the &lsquo;certFile&rsquo; and &lsquo;keyFile&rsquo;, and/or &lsquo;caFile&rsquo;
+keys is deprecated. Please use <code>.spec.certSecretRef</code> instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>certSecretRef</code><br>
+<em>
+<a href="https://pkg.go.dev/github.com/fluxcd/pkg/apis/meta#LocalObjectReference">
+github.com/fluxcd/pkg/apis/meta.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CertSecretRef specifies the Secret containing the TLS authentication
+data. The secret must contain a &lsquo;certFile&rsquo; and &lsquo;keyFile&rsquo;, and/or &lsquo;caFile&rsquo;
+fields. It takes precedence over the values specified in the Secret
+referred to by <code>.spec.secretRef</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2459,8 +2476,25 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 for the HelmRepository.
 For HTTP/S basic auth the secret must contain &lsquo;username&rsquo; and &lsquo;password&rsquo;
 fields.
-For TLS the secret must contain a &lsquo;certFile&rsquo; and &lsquo;keyFile&rsquo;, and/or
-&lsquo;caFile&rsquo; fields.</p>
+Support for TLS auth using the &lsquo;certFile&rsquo; and &lsquo;keyFile&rsquo;, and/or &lsquo;caFile&rsquo;
+keys is deprecated. Please use <code>.spec.certSecretRef</code> instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>certSecretRef</code><br>
+<em>
+<a href="https://pkg.go.dev/github.com/fluxcd/pkg/apis/meta#LocalObjectReference">
+github.com/fluxcd/pkg/apis/meta.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CertSecretRef specifies the Secret containing the TLS authentication
+data. The secret must contain a &lsquo;certFile&rsquo; and &lsquo;keyFile&rsquo;, and/or &lsquo;caFile&rsquo;
+fields. It takes precedence over the values specified in the Secret
+referred to by <code>.spec.secretRef</code>.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta2/helmrepositories.md
+++ b/docs/spec/v1beta2/helmrepositories.md
@@ -452,15 +452,37 @@ flux create secret oci ghcr-auth \
   --password=${GITHUB_PAT}
 ```
 
-#### TLS authentication
+**Note:** Support for specifying TLS authentication data using this API has been
+deprecated. Please use [`.spec.certSecretRef`](#cert-secret-reference) instead.
+If the controller uses the secret specfied by this field to configure TLS, then
+a deprecation warning will be logged.
+
+### Cert secret reference
 
 **Note:** TLS authentication is not yet supported by OCI Helm repositories.
 
-To provide TLS credentials to use while connecting with the Helm repository,
-the referenced Secret is expected to contain `.data.certFile` and
-`.data.keyFile`, and/or `.data.caFile` values.
+`.spec.certSecretRef.name` is an optional field to specify a secret containing TLS
+certificate data. The secret can contain the following keys:
 
-For example:
+* `certFile` and `keyFile`, to specify the client certificate and private key used for
+TLS client authentication. These must be used in conjunction, i.e. specifying one without
+the other will lead to an error.
+* `caFile`, to specify the CA certificate used to verify the server, which is required
+if the server is using a self-signed certificate.
+
+If the server is using a self-signed certificate and has TLS client authentication enabled,
+all three values are required.
+
+All the files in the secret are expected to be [PEM-encoded][pem-encoding]. Assuming you have
+three files; `client.key`, `client.crt` and `ca.crt` for the client private key, client
+certificate and the CA certificate respectively, you can generate the required secret using
+the `flux creat secret helm` command:
+
+```sh
+flux create secret helm tls --key-file=client.key --cert-file=client.crt --ca-file=ca.crt
+```
+
+Example usage:
 
 ```yaml
 ---
@@ -472,7 +494,7 @@ metadata:
 spec:
   interval: 5m0s
   url: https://example.com
-  secretRef:
+  certSecretRef:
     name: example-tls
 ---
 apiVersion: v1

--- a/internal/controller/helmrepository_controller_oci.go
+++ b/internal/controller/helmrepository_controller_oci.go
@@ -54,6 +54,7 @@ import (
 	"github.com/fluxcd/source-controller/internal/helm/registry"
 	"github.com/fluxcd/source-controller/internal/helm/repository"
 	"github.com/fluxcd/source-controller/internal/object"
+	soci "github.com/fluxcd/source-controller/internal/oci"
 	intpredicates "github.com/fluxcd/source-controller/internal/predicates"
 )
 
@@ -318,7 +319,7 @@ func (r *HelmRepositoryOCIReconciler) reconcile(ctx context.Context, sp *patch.S
 			return
 		}
 	} else if obj.Spec.Provider != helmv1.GenericOCIProvider && obj.Spec.Type == helmv1.HelmRepositoryTypeOCI {
-		auth, authErr := oidcAuth(ctxTimeout, obj.Spec.URL, obj.Spec.Provider)
+		auth, authErr := soci.OIDCAuth(ctxTimeout, obj.Spec.URL, obj.Spec.Provider)
 		if authErr != nil && !errors.Is(authErr, oci.ErrUnconfiguredProvider) {
 			e := fmt.Errorf("failed to get credential from %s: %w", obj.Spec.Provider, authErr)
 			conditions.MarkFalse(obj, meta.ReadyCondition, sourcev1.AuthenticationFailedReason, e.Error())

--- a/internal/helm/getter/client_opts.go
+++ b/internal/helm/getter/client_opts.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package getter
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/fluxcd/pkg/oci"
+	"github.com/google/go-containerregistry/pkg/authn"
+	helmgetter "helm.sh/helm/v3/pkg/getter"
+	helmreg "helm.sh/helm/v3/pkg/registry"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	helmv1 "github.com/fluxcd/source-controller/api/v1beta2"
+	"github.com/fluxcd/source-controller/internal/helm/registry"
+	soci "github.com/fluxcd/source-controller/internal/oci"
+)
+
+var ErrDeprecatedTLSConfig = errors.New("TLS configured in a deprecated manner")
+
+// ClientOpts contains the various options to use while constructing
+// a Helm repository client.
+type ClientOpts struct {
+	Authenticator authn.Authenticator
+	Keychain      authn.Keychain
+	RegLoginOpt   helmreg.LoginOption
+	TlsConfig     *tls.Config
+	GetterOpts    []helmgetter.Option
+}
+
+// GetClientOpts uses the provided HelmRepository object and a normalized
+// URL to construct a HelmClientOpts object. If obj is an OCI HelmRepository,
+// then the returned options object will also contain the required registry
+// auth mechanisms.
+func GetClientOpts(ctx context.Context, c client.Client, obj *helmv1.HelmRepository, url string) (*ClientOpts, error) {
+	hrOpts := &ClientOpts{
+		GetterOpts: []helmgetter.Option{
+			helmgetter.WithURL(url),
+			helmgetter.WithTimeout(obj.Spec.Timeout.Duration),
+			helmgetter.WithPassCredentialsAll(obj.Spec.PassCredentials),
+		},
+	}
+	ociRepo := obj.Spec.Type == helmv1.HelmRepositoryTypeOCI
+
+	var certSecret *corev1.Secret
+	var err error
+	// Check `.spec.certSecretRef` first for any TLS auth data.
+	if obj.Spec.CertSecretRef != nil {
+		certSecret, err = fetchSecret(ctx, c, obj.Spec.CertSecretRef.Name, obj.GetNamespace())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get TLS authentication secret '%s/%s': %w", obj.GetNamespace(), obj.Spec.CertSecretRef.Name, err)
+		}
+
+		hrOpts.TlsConfig, err = TLSClientConfigFromSecret(*certSecret, url)
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct Helm client's TLS config: %w", err)
+		}
+	}
+
+	var authSecret *corev1.Secret
+	var deprecatedTLSConfig bool
+	if obj.Spec.SecretRef != nil {
+		authSecret, err = fetchSecret(ctx, c, obj.Spec.SecretRef.Name, obj.GetNamespace())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get authentication secret '%s/%s': %w", obj.GetNamespace(), obj.Spec.SecretRef.Name, err)
+		}
+
+		// Construct actual Helm client options.
+		opts, err := GetterOptionsFromSecret(*authSecret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to configure Helm client: %w", err)
+		}
+		hrOpts.GetterOpts = append(hrOpts.GetterOpts, opts...)
+
+		// If the TLS config is nil, i.e. one couldn't be constructed using `.spec.certSecretRef`
+		// then try to use `.spec.certSecretRef`.
+		if hrOpts.TlsConfig == nil {
+			hrOpts.TlsConfig, err = TLSClientConfigFromSecret(*authSecret, url)
+			if err != nil {
+				return nil, fmt.Errorf("failed to construct Helm client's TLS config: %w", err)
+			}
+			// Constructing a TLS config using the auth secret is deprecated behavior.
+			if hrOpts.TlsConfig != nil {
+				deprecatedTLSConfig = true
+			}
+		}
+
+		if ociRepo {
+			hrOpts.Keychain, err = registry.LoginOptionFromSecret(url, *authSecret)
+			if err != nil {
+				return nil, fmt.Errorf("failed to configure login options: %w", err)
+			}
+		}
+	} else if obj.Spec.Provider != helmv1.GenericOCIProvider && obj.Spec.Type == helmv1.HelmRepositoryTypeOCI && ociRepo {
+		authenticator, authErr := soci.OIDCAuth(ctx, obj.Spec.URL, obj.Spec.Provider)
+		if authErr != nil && !errors.Is(authErr, oci.ErrUnconfiguredProvider) {
+			return nil, fmt.Errorf("failed to get credential from '%s': %w", obj.Spec.Provider, authErr)
+		}
+		if authenticator != nil {
+			hrOpts.Authenticator = authenticator
+		}
+	}
+
+	if ociRepo {
+		hrOpts.RegLoginOpt, err = registry.NewLoginOption(hrOpts.Authenticator, hrOpts.Keychain, url)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if deprecatedTLSConfig {
+		err = ErrDeprecatedTLSConfig
+	}
+
+	return hrOpts, err
+}
+
+func fetchSecret(ctx context.Context, c client.Client, name, namespace string) (*corev1.Secret, error) {
+	key := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	var secret corev1.Secret
+	if err := c.Get(ctx, key, &secret); err != nil {
+		return nil, err
+	}
+	return &secret, nil
+}
+
+// TLSClientConfigFromSecret attempts to construct a TLS client config
+// for the given v1.Secret. It returns the TLS client config or an error.
+//
+// Secrets with no certFile, keyFile, AND caFile are ignored, if only a
+// certBytes OR keyBytes is defined it returns an error.
+func TLSClientConfigFromSecret(secret corev1.Secret, repositoryUrl string) (*tls.Config, error) {
+	certBytes, keyBytes, caBytes := secret.Data["certFile"], secret.Data["keyFile"], secret.Data["caFile"]
+	switch {
+	case len(certBytes)+len(keyBytes)+len(caBytes) == 0:
+		return nil, nil
+	case (len(certBytes) > 0 && len(keyBytes) == 0) || (len(keyBytes) > 0 && len(certBytes) == 0):
+		return nil, fmt.Errorf("invalid '%s' secret data: fields 'certFile' and 'keyFile' require each other's presence",
+			secret.Name)
+	}
+
+	tlsConf := &tls.Config{}
+	if len(certBytes) > 0 && len(keyBytes) > 0 {
+		cert, err := tls.X509KeyPair(certBytes, keyBytes)
+		if err != nil {
+			return nil, err
+		}
+		tlsConf.Certificates = append(tlsConf.Certificates, cert)
+	}
+
+	if len(caBytes) > 0 {
+		cp, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("cannot retrieve system certificate pool: %w", err)
+		}
+		if !cp.AppendCertsFromPEM(caBytes) {
+			return nil, fmt.Errorf("cannot append certificate into certificate pool: invalid caFile")
+		}
+
+		tlsConf.RootCAs = cp
+	}
+
+	tlsConf.BuildNameToCertificate()
+
+	u, err := url.Parse(repositoryUrl)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse repository URL: %w", err)
+	}
+
+	tlsConf.ServerName = u.Hostname()
+
+	return tlsConf, nil
+}

--- a/internal/helm/getter/client_opts_test.go
+++ b/internal/helm/getter/client_opts_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package getter
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/google/go-containerregistry/pkg/name"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	helmv1 "github.com/fluxcd/source-controller/api/v1beta2"
+)
+
+func TestGetClientOpts(t *testing.T) {
+	tlsCA, err := os.ReadFile("../../controller/testdata/certs/ca.pem")
+	if err != nil {
+		t.Errorf("could not read CA file: %s", err)
+	}
+
+	tests := []struct {
+		name       string
+		certSecret *corev1.Secret
+		authSecret *corev1.Secret
+		afterFunc  func(t *WithT, hcOpts *ClientOpts)
+		oci        bool
+		err        error
+	}{
+		{
+			name: "HelmRepository with certSecretRef discards TLS config in secretRef",
+			certSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ca-file",
+				},
+				Data: map[string][]byte{
+					"caFile": tlsCA,
+				},
+			},
+			authSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "auth",
+				},
+				Data: map[string][]byte{
+					"username": []byte("user"),
+					"password": []byte("pass"),
+					"caFile":   []byte("invalid"),
+				},
+			},
+			afterFunc: func(t *WithT, hcOpts *ClientOpts) {
+				t.Expect(hcOpts.TlsConfig).ToNot(BeNil())
+				t.Expect(len(hcOpts.GetterOpts)).To(Equal(4))
+			},
+		},
+		{
+			name: "HelmRepository with TLS config only in secretRef is marked as deprecated",
+			authSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "auth-tls",
+				},
+				Data: map[string][]byte{
+					"username": []byte("user"),
+					"password": []byte("pass"),
+					"caFile":   tlsCA,
+				},
+			},
+			afterFunc: func(t *WithT, hcOpts *ClientOpts) {
+				t.Expect(hcOpts.TlsConfig).ToNot(BeNil())
+				t.Expect(len(hcOpts.GetterOpts)).To(Equal(4))
+			},
+			err: ErrDeprecatedTLSConfig,
+		},
+		{
+			name: "OCI HelmRepository with secretRef has auth configured",
+			authSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "auth-oci",
+				},
+				Data: map[string][]byte{
+					"username": []byte("user"),
+					"password": []byte("pass"),
+				},
+			},
+			afterFunc: func(t *WithT, hcOpts *ClientOpts) {
+				repo, err := name.NewRepository("ghcr.io/dummy")
+				t.Expect(err).ToNot(HaveOccurred())
+				authenticator, err := hcOpts.Keychain.Resolve(repo)
+				t.Expect(err).ToNot(HaveOccurred())
+				config, err := authenticator.Authorization()
+				t.Expect(err).ToNot(HaveOccurred())
+				t.Expect(config.Username).To(Equal("user"))
+				t.Expect(config.Password).To(Equal("pass"))
+			},
+			oci: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			helmRepo := &helmv1.HelmRepository{
+				Spec: helmv1.HelmRepositorySpec{
+					Timeout: &metav1.Duration{
+						Duration: time.Second,
+					},
+				},
+			}
+			if tt.oci {
+				helmRepo.Spec.Type = helmv1.HelmRepositoryTypeOCI
+			}
+
+			clientBuilder := fakeclient.NewClientBuilder()
+			if tt.authSecret != nil {
+				clientBuilder.WithObjects(tt.authSecret.DeepCopy())
+				helmRepo.Spec.SecretRef = &meta.LocalObjectReference{
+					Name: tt.authSecret.Name,
+				}
+			}
+			if tt.certSecret != nil {
+				clientBuilder.WithObjects(tt.certSecret.DeepCopy())
+				helmRepo.Spec.CertSecretRef = &meta.LocalObjectReference{
+					Name: tt.certSecret.Name,
+				}
+			}
+			c := clientBuilder.Build()
+
+			clientOpts, err := GetClientOpts(context.TODO(), c, helmRepo, "https://ghcr.io/dummy")
+			if tt.err != nil {
+				g.Expect(err).To(Equal(tt.err))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			tt.afterFunc(g, clientOpts)
+		})
+	}
+}
+
+func Test_tlsClientConfigFromSecret(t *testing.T) {
+	tlsSecretFixture := validTlsSecret(t)
+
+	tests := []struct {
+		name    string
+		secret  corev1.Secret
+		modify  func(secret *corev1.Secret)
+		wantErr bool
+		wantNil bool
+	}{
+		{"certFile, keyFile and caFile", tlsSecretFixture, nil, false, false},
+		{"without certFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "certFile") }, true, true},
+		{"without keyFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "keyFile") }, true, true},
+		{"without caFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "caFile") }, false, false},
+		{"empty", corev1.Secret{}, nil, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := tt.secret.DeepCopy()
+			if tt.modify != nil {
+				tt.modify(secret)
+			}
+
+			got, err := TLSClientConfigFromSecret(*secret, "")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TLSClientConfigFromSecret() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantNil && got != nil {
+				t.Error("TLSClientConfigFromSecret() != nil")
+				return
+			}
+		})
+	}
+}
+
+// validTlsSecret creates a secret containing key pair and CA certificate that are
+// valid from a syntax (minimum requirements) perspective.
+func validTlsSecret(t *testing.T) corev1.Secret {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal("Private key cannot be created.", err.Error())
+	}
+
+	certTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1337),
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal("Certificate cannot be created.", err.Error())
+	}
+
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(7331),
+		IsCA:         true,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		t.Fatal("CA private key cannot be created.", err.Error())
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		t.Fatal("CA certificate cannot be created.", err.Error())
+	}
+
+	keyPem := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	certPem := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	})
+
+	caPem := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	return corev1.Secret{
+		Data: map[string][]byte{
+			"certFile": []byte(certPem),
+			"keyFile":  []byte(keyPem),
+			"caFile":   []byte(caPem),
+		},
+	}
+}

--- a/internal/helm/getter/getter.go
+++ b/internal/helm/getter/getter.go
@@ -17,20 +17,17 @@ limitations under the License.
 package getter
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"net/url"
 
 	"helm.sh/helm/v3/pkg/getter"
 	corev1 "k8s.io/api/core/v1"
 )
 
-// ClientOptionsFromSecret constructs a getter.Option slice for the given secret.
+// GetterOptionsFromSecret constructs a getter.Option slice for the given secret.
 // It returns the slice, or an error.
-func ClientOptionsFromSecret(secret corev1.Secret) ([]getter.Option, error) {
+func GetterOptionsFromSecret(secret corev1.Secret) ([]getter.Option, error) {
 	var opts []getter.Option
-	basicAuth, err := BasicAuthFromSecret(secret)
+	basicAuth, err := basicAuthFromSecret(secret)
 	if err != nil {
 		return opts, err
 	}
@@ -40,12 +37,12 @@ func ClientOptionsFromSecret(secret corev1.Secret) ([]getter.Option, error) {
 	return opts, nil
 }
 
-// BasicAuthFromSecret attempts to construct a basic auth getter.Option for the
+// basicAuthFromSecret attempts to construct a basic auth getter.Option for the
 // given v1.Secret and returns the result.
 //
 // Secrets with no username AND password are ignored, if only one is defined it
 // returns an error.
-func BasicAuthFromSecret(secret corev1.Secret) (getter.Option, error) {
+func basicAuthFromSecret(secret corev1.Secret) (getter.Option, error) {
 	username, password := string(secret.Data["username"]), string(secret.Data["password"])
 	switch {
 	case username == "" && password == "":
@@ -54,52 +51,4 @@ func BasicAuthFromSecret(secret corev1.Secret) (getter.Option, error) {
 		return nil, fmt.Errorf("invalid '%s' secret data: required fields 'username' and 'password'", secret.Name)
 	}
 	return getter.WithBasicAuth(username, password), nil
-}
-
-// TLSClientConfigFromSecret attempts to construct a TLS client config
-// for the given v1.Secret. It returns the TLS client config or an error.
-//
-// Secrets with no certFile, keyFile, AND caFile are ignored, if only a
-// certBytes OR keyBytes is defined it returns an error.
-func TLSClientConfigFromSecret(secret corev1.Secret, repositoryUrl string) (*tls.Config, error) {
-	certBytes, keyBytes, caBytes := secret.Data["certFile"], secret.Data["keyFile"], secret.Data["caFile"]
-	switch {
-	case len(certBytes)+len(keyBytes)+len(caBytes) == 0:
-		return nil, nil
-	case (len(certBytes) > 0 && len(keyBytes) == 0) || (len(keyBytes) > 0 && len(certBytes) == 0):
-		return nil, fmt.Errorf("invalid '%s' secret data: fields 'certFile' and 'keyFile' require each other's presence",
-			secret.Name)
-	}
-
-	tlsConf := &tls.Config{}
-	if len(certBytes) > 0 && len(keyBytes) > 0 {
-		cert, err := tls.X509KeyPair(certBytes, keyBytes)
-		if err != nil {
-			return nil, err
-		}
-		tlsConf.Certificates = append(tlsConf.Certificates, cert)
-	}
-
-	if len(caBytes) > 0 {
-		cp, err := x509.SystemCertPool()
-		if err != nil {
-			return nil, fmt.Errorf("cannot retrieve system certificate pool: %w", err)
-		}
-		if !cp.AppendCertsFromPEM(caBytes) {
-			return nil, fmt.Errorf("cannot append certificate into certificate pool: invalid caFile")
-		}
-
-		tlsConf.RootCAs = cp
-	}
-
-	tlsConf.BuildNameToCertificate()
-
-	u, err := url.Parse(repositoryUrl)
-	if err != nil {
-		return nil, fmt.Errorf("cannot parse repository URL: %w", err)
-	}
-
-	tlsConf.ServerName = u.Hostname()
-
-	return tlsConf, nil
 }

--- a/internal/helm/getter/getter_test.go
+++ b/internal/helm/getter/getter_test.go
@@ -17,11 +17,6 @@ limitations under the License.
 package getter
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
-	"math/big"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,7 +31,7 @@ var (
 	}
 )
 
-func TestClientOptionsFromSecret(t *testing.T) {
+func TestGetterOptionsFromSecret(t *testing.T) {
 	tests := []struct {
 		name    string
 		secrets []corev1.Secret
@@ -53,7 +48,7 @@ func TestClientOptionsFromSecret(t *testing.T) {
 				}
 			}
 
-			got, err := ClientOptionsFromSecret(secret)
+			got, err := GetterOptionsFromSecret(secret)
 			if err != nil {
 				t.Errorf("ClientOptionsFromSecret() error = %v", err)
 				return
@@ -65,7 +60,7 @@ func TestClientOptionsFromSecret(t *testing.T) {
 	}
 }
 
-func TestBasicAuthFromSecret(t *testing.T) {
+func Test_basicAuthFromSecret(t *testing.T) {
 	tests := []struct {
 		name    string
 		secret  corev1.Secret
@@ -84,7 +79,7 @@ func TestBasicAuthFromSecret(t *testing.T) {
 			if tt.modify != nil {
 				tt.modify(secret)
 			}
-			got, err := BasicAuthFromSecret(*secret)
+			got, err := basicAuthFromSecret(*secret)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BasicAuthFromSecret() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -94,98 +89,5 @@ func TestBasicAuthFromSecret(t *testing.T) {
 				return
 			}
 		})
-	}
-}
-
-func TestTLSClientConfigFromSecret(t *testing.T) {
-	tlsSecretFixture := validTlsSecret(t)
-
-	tests := []struct {
-		name    string
-		secret  corev1.Secret
-		modify  func(secret *corev1.Secret)
-		wantErr bool
-		wantNil bool
-	}{
-		{"certFile, keyFile and caFile", tlsSecretFixture, nil, false, false},
-		{"without certFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "certFile") }, true, true},
-		{"without keyFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "keyFile") }, true, true},
-		{"without caFile", tlsSecretFixture, func(s *corev1.Secret) { delete(s.Data, "caFile") }, false, false},
-		{"empty", corev1.Secret{}, nil, false, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			secret := tt.secret.DeepCopy()
-			if tt.modify != nil {
-				tt.modify(secret)
-			}
-
-			got, err := TLSClientConfigFromSecret(*secret, "")
-			if (err != nil) != tt.wantErr {
-				t.Errorf("TLSClientConfigFromSecret() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if tt.wantNil && got != nil {
-				t.Error("TLSClientConfigFromSecret() != nil")
-				return
-			}
-		})
-	}
-}
-
-// validTlsSecret creates a secret containing key pair and CA certificate that are
-// valid from a syntax (minimum requirements) perspective.
-func validTlsSecret(t *testing.T) corev1.Secret {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatal("Private key cannot be created.", err.Error())
-	}
-
-	certTemplate := x509.Certificate{
-		SerialNumber: big.NewInt(1337),
-	}
-	cert, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &key.PublicKey, key)
-	if err != nil {
-		t.Fatal("Certificate cannot be created.", err.Error())
-	}
-
-	ca := &x509.Certificate{
-		SerialNumber: big.NewInt(7331),
-		IsCA:         true,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-	}
-
-	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
-	if err != nil {
-		t.Fatal("CA private key cannot be created.", err.Error())
-	}
-
-	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
-	if err != nil {
-		t.Fatal("CA certificate cannot be created.", err.Error())
-	}
-
-	keyPem := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(key),
-	})
-
-	certPem := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: cert,
-	})
-
-	caPem := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: caBytes,
-	})
-
-	return corev1.Secret{
-		Data: map[string][]byte{
-			"certFile": []byte(certPem),
-			"keyFile":  []byte(keyPem),
-			"caFile":   []byte(caPem),
-		},
 	}
 }

--- a/internal/helm/registry/auth.go
+++ b/internal/helm/registry/auth.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fluxcd/source-controller/internal/oci"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"helm.sh/helm/v3/pkg/registry"
+	helmreg "helm.sh/helm/v3/pkg/registry"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -138,4 +139,18 @@ func (r stringResource) String() string {
 
 func (r stringResource) RegistryStr() string {
 	return r.registry
+}
+
+// NewLoginOption returns a registry login option for the given HelmRepository.
+// If the HelmRepository does not specify a secretRef, a nil login option is returned.
+func NewLoginOption(auth authn.Authenticator, keychain authn.Keychain, registryURL string) (helmreg.LoginOption, error) {
+	if auth != nil {
+		return AuthAdaptHelper(auth)
+	}
+
+	if keychain != nil {
+		return KeychainAdaptHelper(keychain)(registryURL)
+	}
+
+	return nil, nil
 }

--- a/internal/oci/auth.go
+++ b/internal/oci/auth.go
@@ -16,7 +16,17 @@ limitations under the License.
 
 package oci
 
-import "github.com/google/go-containerregistry/pkg/authn"
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/pkg/oci/auth/login"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
+)
 
 // Anonymous is an authn.AuthConfig that always returns an anonymous
 // authenticator. It is useful for registries that do not require authentication
@@ -27,4 +37,25 @@ type Anonymous authn.AuthConfig
 // Resolve implements authn.Keychain.
 func (a Anonymous) Resolve(_ authn.Resource) (authn.Authenticator, error) {
 	return authn.Anonymous, nil
+}
+
+// OIDCAuth generates the OIDC credential authenticator based on the specified cloud provider.
+func OIDCAuth(ctx context.Context, url, provider string) (authn.Authenticator, error) {
+	u := strings.TrimPrefix(url, sourcev1.OCIRepositoryPrefix)
+	ref, err := name.ParseReference(u)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL '%s': %w", u, err)
+	}
+
+	opts := login.ProviderOptions{}
+	switch provider {
+	case sourcev1.AmazonOCIProvider:
+		opts.AwsAutoLogin = true
+	case sourcev1.AzureOCIProvider:
+		opts.AzureAutoLogin = true
+	case sourcev1.GoogleOCIProvider:
+		opts.GcpAutoLogin = true
+	}
+
+	return login.NewManager().Login(ctx, u, ref, opts)
 }


### PR DESCRIPTION
Add `.spec.certSecretRef` for specifying TLS authentication data using the `certFile`, `keyFile` and `caFile` keys. Deprecate the usage of these keys in the secret specified by `.spec.secretRef`. 
Introduce (and refactor) Helm client builder and auth helpers to reduce duplicated code and increase uniformity and testability.

Fixes: #1131
Prerequisite to: #1097 