### PR TITLE
Fix the helm cache arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -380,7 +380,7 @@ func mustSetupHelmLimits(indexLimit, chartLimit, chartFileLimit int64) {
 	helm.MaxChartFileSize = chartFileLimit
 }
 
-func mustInitHelmCache(maxSize int, purgeInterval, itemTTL string) (*cache.Cache, time.Duration) {
+func mustInitHelmCache(maxSize int, itemTTL, purgeInterval string) (*cache.Cache, time.Duration) {
 	if maxSize <= 0 {
 		setupLog.Info("caching of Helm index files is disabled")
 		return nil, -1


### PR DESCRIPTION
Index TTL and purge interval were switched in a recent refactor.
Refer https://github.com/fluxcd/source-controller/commit/747d6a335c08de82ce635f3a8436e45f7b79b5f5.