### PR TITLE
Store Helm indexes in JSON format

### DIFF
--- a/internal/helm/repository/chart_repository_test.go
+++ b/internal/helm/repository/chart_repository_test.go
@@ -39,9 +39,10 @@ import (
 var now = time.Now()
 
 const (
-	testFile            = "../testdata/local-index.yaml"
-	chartmuseumTestFile = "../testdata/chartmuseum-index.yaml"
-	unorderedTestFile   = "../testdata/local-index-unordered.yaml"
+	testFile                = "../testdata/local-index.yaml"
+	chartmuseumTestFile     = "../testdata/chartmuseum-index.yaml"
+	chartmuseumJSONTestFile = "../testdata/chartmuseum-index.json"
+	unorderedTestFile       = "../testdata/local-index-unordered.yaml"
 )
 
 // mockGetter is a simple mocking getter.Getter implementation, returning
@@ -80,6 +81,10 @@ func TestIndexFromFile(t *testing.T) {
 		{
 			name:     "chartmuseum index file",
 			filename: chartmuseumTestFile,
+		},
+		{
+			name:     "chartmuseum json index file",
+			filename: chartmuseumJSONTestFile,
 		},
 		{
 			name:     "error if index size exceeds max size",
@@ -405,6 +410,25 @@ func TestChartRepository_CacheIndex(t *testing.T) {
 	g.Expect(b).To(Equal(mg.Response))
 
 	g.Expect(r.digests).To(BeEmpty())
+}
+
+func TestChartRepository_ToJSON(t *testing.T) {
+	g := NewWithT(t)
+
+	r := newChartRepository()
+	r.Path = chartmuseumTestFile
+
+	_, err := r.ToJSON()
+	g.Expect(err).To(HaveOccurred())
+
+	g.Expect(r.LoadFromPath()).To(Succeed())
+	b, err := r.ToJSON()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	jsonBytes, err := os.ReadFile(chartmuseumJSONTestFile)
+	jsonBytes = bytes.TrimRight(jsonBytes, "\n")
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(string(b)).To(Equal(string(jsonBytes)))
 }
 
 func TestChartRepository_DownloadIndex(t *testing.T) {

--- a/internal/helm/testdata/chartmuseum-index.json
+++ b/internal/helm/testdata/chartmuseum-index.json
@@ -1,0 +1,82 @@
+{
+  "serverInfo": {
+    "contextPath": "/v1/helm"
+  },
+  "apiVersion": "v1",
+  "generated": "0001-01-01T00:00:00Z",
+  "entries": {
+    "alpine": [
+      {
+        "name": "alpine",
+        "home": "https://github.com/something",
+        "version": "1.0.0",
+        "description": "string",
+        "keywords": [
+          "linux",
+          "alpine",
+          "small",
+          "sumtin"
+        ],
+        "apiVersion": "v1",
+        "urls": [
+          "https://kubernetes-charts.storage.googleapis.com/alpine-1.0.0.tgz",
+          "http://storage2.googleapis.com/kubernetes-charts/alpine-1.0.0.tgz"
+        ],
+        "created": "0001-01-01T00:00:00Z",
+        "digest": "sha256:1234567890abcdef"
+      }
+    ],
+    "chartWithNoURL": [
+      {
+        "name": "chartWithNoURL",
+        "home": "https://github.com/something",
+        "version": "1.0.0",
+        "description": "string",
+        "keywords": [
+          "small",
+          "sumtin"
+        ],
+        "apiVersion": "v1",
+        "urls": null,
+        "created": "0001-01-01T00:00:00Z",
+        "digest": "sha256:1234567890abcdef"
+      }
+    ],
+    "nginx": [
+      {
+        "name": "nginx",
+        "home": "https://github.com/something/else",
+        "version": "0.2.0",
+        "description": "string",
+        "keywords": [
+          "popular",
+          "web server",
+          "proxy"
+        ],
+        "apiVersion": "v1",
+        "urls": [
+          "https://kubernetes-charts.storage.googleapis.com/nginx-0.2.0.tgz"
+        ],
+        "created": "0001-01-01T00:00:00Z",
+        "digest": "sha256:1234567890abcdef"
+      },
+      {
+        "name": "nginx",
+        "home": "https://github.com/something",
+        "version": "0.1.0",
+        "description": "string",
+        "keywords": [
+          "popular",
+          "web server",
+          "proxy"
+        ],
+        "apiVersion": "v1",
+        "urls": [
+          "https://kubernetes-charts.storage.googleapis.com/nginx-0.1.0.tgz"
+        ],
+        "created": "0001-01-01T00:00:00Z",
+        "digest": "sha256:1234567890abcdef"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #1172 

Store helm indexes in JSON format for more efficient caching.
See linked issue above for more details.