### PR TITLE
Disable system-wide git config in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ test: install-envtest test-api ## Run all tests
 	HTTPS_PROXY="" HTTP_PROXY="" \
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) \
 	GIT_CONFIG_GLOBAL=/dev/null \
+	GIT_CONFIG_NOSYSTEM=true \
 	go test $(GO_STATIC_FLAGS) \
 	  ./... \
 	  $(GO_TEST_ARGS) \


### PR DESCRIPTION
Asides from the global user config, git also checks other system files for the git config to use and this can lead to failing tests. This pull request set an environment variable in the Makefile to prevent git from doing this.