### PR TITLE
Adopt Kubernetes style TLS Secrets

### DIFF
--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -56,10 +56,21 @@ type HelmRepositorySpec struct {
 	// +optional
 	SecretRef *meta.LocalObjectReference `json:"secretRef,omitempty"`
 
-	// CertSecretRef specifies the Secret containing the TLS authentication
-	// data. The secret must contain a 'certFile' and 'keyFile', and/or 'caFile'
-	// fields. It takes precedence over the values specified in the Secret
-	// referred to by `.spec.secretRef`.
+	// CertSecretRef can be given the name of a Secret containing
+	// either or both of
+	//
+	// - a PEM-encoded client certificate (`tls.crt`) and private
+	// key (`tls.key`);
+	// - a PEM-encoded CA certificate (`ca.crt`)
+	//
+	// and whichever are supplied, will be used for connecting to the
+	// registry. The client cert and key are useful if you are
+	// authenticating with a certificate; the CA cert is useful if
+	// you are using a self-signed server certificate. The Secret must
+	// be of type `Opaque` or `kubernetes.io/tls`.
+	//
+	// It takes precedence over the values specified in the Secret referred
+	// to by `.spec.secretRef`.
 	// +optional
 	CertSecretRef *meta.LocalObjectReference `json:"certSecretRef,omitempty"`
 

--- a/api/v1beta2/ocirepository_types.go
+++ b/api/v1beta2/ocirepository_types.go
@@ -97,17 +97,21 @@ type OCIRepositorySpec struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
-	// CertSecretRef can be given the name of a secret containing
+	// CertSecretRef can be given the name of a Secret containing
 	// either or both of
 	//
-	//  - a PEM-encoded client certificate (`certFile`) and private
-	//  key (`keyFile`);
-	//  - a PEM-encoded CA certificate (`caFile`)
+	// - a PEM-encoded client certificate (`tls.crt`) and private
+	// key (`tls.key`);
+	// - a PEM-encoded CA certificate (`ca.crt`)
 	//
-	//  and whichever are supplied, will be used for connecting to the
-	//  registry. The client cert and key are useful if you are
-	//  authenticating with a certificate; the CA cert is useful if
-	//  you are using a self-signed server certificate.
+	// and whichever are supplied, will be used for connecting to the
+	// registry. The client cert and key are useful if you are
+	// authenticating with a certificate; the CA cert is useful if
+	// you are using a self-signed server certificate. The Secret must
+	// be of type `Opaque` or `kubernetes.io/tls`.
+	//
+	// Note: Support for the `caFile`, `certFile` and `keyFile` keys have
+	// been deprecated.
 	// +optional
 	CertSecretRef *meta.LocalObjectReference `json:"certSecretRef,omitempty"`
 

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -297,10 +297,15 @@ spec:
                 - namespaceSelectors
                 type: object
               certSecretRef:
-                description: CertSecretRef specifies the Secret containing the TLS
-                  authentication data. The secret must contain a 'certFile' and 'keyFile',
-                  and/or 'caFile' fields. It takes precedence over the values specified
-                  in the Secret referred to by `.spec.secretRef`.
+                description: "CertSecretRef can be given the name of a Secret containing
+                  either or both of \n - a PEM-encoded client certificate (`tls.crt`)
+                  and private key (`tls.key`); - a PEM-encoded CA certificate (`ca.crt`)
+                  \n and whichever are supplied, will be used for connecting to the
+                  registry. The client cert and key are useful if you are authenticating
+                  with a certificate; the CA cert is useful if you are using a self-signed
+                  server certificate. The Secret must be of type `Opaque` or `kubernetes.io/tls`.
+                  \n It takes precedence over the values specified in the Secret referred
+                  to by `.spec.secretRef`."
                 properties:
                   name:
                     description: Name of the referent.

--- a/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
@@ -50,13 +50,15 @@ spec:
             description: OCIRepositorySpec defines the desired state of OCIRepository
             properties:
               certSecretRef:
-                description: "CertSecretRef can be given the name of a secret containing
-                  either or both of \n - a PEM-encoded client certificate (`certFile`)
-                  and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`)
+                description: "CertSecretRef can be given the name of a Secret containing
+                  either or both of \n - a PEM-encoded client certificate (`tls.crt`)
+                  and private key (`tls.key`); - a PEM-encoded CA certificate (`ca.crt`)
                   \n and whichever are supplied, will be used for connecting to the
                   registry. The client cert and key are useful if you are authenticating
                   with a certificate; the CA cert is useful if you are using a self-signed
-                  server certificate."
+                  server certificate. The Secret must be of type `Opaque` or `kubernetes.io/tls`.
+                  \n Note: Support for the `caFile`, `certFile` and `keyFile` keys
+                  have been deprecated."
                 properties:
                   name:
                     description: Name of the referent.

--- a/docs/api/v1beta2/source.md
+++ b/docs/api/v1beta2/source.md
@@ -1119,17 +1119,20 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>CertSecretRef can be given the name of a secret containing
+<p>CertSecretRef can be given the name of a Secret containing
 either or both of</p>
 <ul>
-<li>a PEM-encoded client certificate (<code>certFile</code>) and private
-key (<code>keyFile</code>);</li>
-<li>a PEM-encoded CA certificate (<code>caFile</code>)</li>
+<li>a PEM-encoded client certificate (<code>tls.crt</code>) and private
+key (<code>tls.key</code>);</li>
+<li>a PEM-encoded CA certificate (<code>ca.crt</code>)</li>
 </ul>
 <p>and whichever are supplied, will be used for connecting to the
 registry. The client cert and key are useful if you are
 authenticating with a certificate; the CA cert is useful if
-you are using a self-signed server certificate.</p>
+you are using a self-signed server certificate. The Secret must
+be of type <code>Opaque</code> or <code>kubernetes.io/tls</code>.</p>
+<p>Note: Support for the <code>caFile</code>, <code>certFile</code> and <code>keyFile</code> keys have
+been deprecated.</p>
 </td>
 </tr>
 <tr>
@@ -3024,17 +3027,20 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>CertSecretRef can be given the name of a secret containing
+<p>CertSecretRef can be given the name of a Secret containing
 either or both of</p>
 <ul>
-<li>a PEM-encoded client certificate (<code>certFile</code>) and private
-key (<code>keyFile</code>);</li>
-<li>a PEM-encoded CA certificate (<code>caFile</code>)</li>
+<li>a PEM-encoded client certificate (<code>tls.crt</code>) and private
+key (<code>tls.key</code>);</li>
+<li>a PEM-encoded CA certificate (<code>ca.crt</code>)</li>
 </ul>
 <p>and whichever are supplied, will be used for connecting to the
 registry. The client cert and key are useful if you are
 authenticating with a certificate; the CA cert is useful if
-you are using a self-signed server certificate.</p>
+you are using a self-signed server certificate. The Secret must
+be of type <code>Opaque</code> or <code>kubernetes.io/tls</code>.</p>
+<p>Note: Support for the <code>caFile</code>, <code>certFile</code> and <code>keyFile</code> keys have
+been deprecated.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api/v1beta2/source.md
+++ b/docs/api/v1beta2/source.md
@@ -811,10 +811,20 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>CertSecretRef specifies the Secret containing the TLS authentication
-data. The secret must contain a &lsquo;certFile&rsquo; and &lsquo;keyFile&rsquo;, and/or &lsquo;caFile&rsquo;
-fields. It takes precedence over the values specified in the Secret
-referred to by <code>.spec.secretRef</code>.</p>
+<p>CertSecretRef can be given the name of a Secret containing
+either or both of</p>
+<ul>
+<li>a PEM-encoded client certificate (<code>tls.crt</code>) and private
+key (<code>tls.key</code>);</li>
+<li>a PEM-encoded CA certificate (<code>ca.crt</code>)</li>
+</ul>
+<p>and whichever are supplied, will be used for connecting to the
+registry. The client cert and key are useful if you are
+authenticating with a certificate; the CA cert is useful if
+you are using a self-signed server certificate. The Secret must
+be of type <code>Opaque</code> or <code>kubernetes.io/tls</code>.</p>
+<p>It takes precedence over the values specified in the Secret referred
+to by <code>.spec.secretRef</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2503,10 +2513,20 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>CertSecretRef specifies the Secret containing the TLS authentication
-data. The secret must contain a &lsquo;certFile&rsquo; and &lsquo;keyFile&rsquo;, and/or &lsquo;caFile&rsquo;
-fields. It takes precedence over the values specified in the Secret
-referred to by <code>.spec.secretRef</code>.</p>
+<p>CertSecretRef can be given the name of a Secret containing
+either or both of</p>
+<ul>
+<li>a PEM-encoded client certificate (<code>tls.crt</code>) and private
+key (<code>tls.key</code>);</li>
+<li>a PEM-encoded CA certificate (<code>ca.crt</code>)</li>
+</ul>
+<p>and whichever are supplied, will be used for connecting to the
+registry. The client cert and key are useful if you are
+authenticating with a certificate; the CA cert is useful if
+you are using a self-signed server certificate. The Secret must
+be of type <code>Opaque</code> or <code>kubernetes.io/tls</code>.</p>
+<p>It takes precedence over the values specified in the Secret referred
+to by <code>.spec.secretRef</code>.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1/gitrepositories.md
+++ b/docs/spec/v1/gitrepositories.md
@@ -161,8 +161,9 @@ data:
 #### HTTPS Certificate Authority
 
 To provide a Certificate Authority to trust while connecting with a Git
-repository over HTTPS, the referenced Secret can contain a `.data.caFile`
-value.
+repository over HTTPS, the referenced Secret's `.data` can contain a `ca.crt`
+or `caFile` key. `ca.crt` takes precedence over `caFile`, i.e. if both keys 
+are present, the value of `ca.crt` will be taken into consideration.
 
 ```yaml
 ---
@@ -173,7 +174,7 @@ metadata:
   namespace: default
 type: Opaque
 data:
-  caFile: <BASE64>
+  ca.crt: <BASE64>
 ```
 
 #### SSH authentication

--- a/docs/spec/v1beta2/helmrepositories.md
+++ b/docs/spec/v1beta2/helmrepositories.md
@@ -467,32 +467,33 @@ flux create secret oci ghcr-auth \
   --password=${GITHUB_PAT}
 ```
 
-**Note:** Support for specifying TLS authentication data using this API has been
+**Warning:** Support for specifying TLS authentication data using this API has been
 deprecated. Please use [`.spec.certSecretRef`](#cert-secret-reference) instead.
 If the controller uses the secret specfied by this field to configure TLS, then
 a deprecation warning will be logged.
 
 ### Cert secret reference
 
-`.spec.certSecretRef.name` is an optional field to specify a secret containing TLS
-certificate data. The secret can contain the following keys:
+`.spec.certSecretRef.name` is an optional field to specify a secret containing
+TLS certificate data. The secret can contain the following keys:
 
-* `certFile` and `keyFile`, to specify the client certificate and private key used for
-TLS client authentication. These must be used in conjunction, i.e. specifying one without
-the other will lead to an error.
-* `caFile`, to specify the CA certificate used to verify the server, which is required
-if the server is using a self-signed certificate.
+* `tls.crt` and `tls.key`, to specify the client certificate and private key used
+for TLS client authentication. These must be used in conjunction, i.e.
+specifying one without the other will lead to an error.
+* `ca.crt`, to specify the CA certificate used to verify the server, which is
+required if the server is using a self-signed certificate.
 
-If the server is using a self-signed certificate and has TLS client authentication enabled,
-all three values are required.
+If the server is using a self-signed certificate and has TLS client
+authentication enabled, all three values are required.
 
-All the files in the secret are expected to be [PEM-encoded][pem-encoding]. Assuming you have
-three files; `client.key`, `client.crt` and `ca.crt` for the client private key, client
-certificate and the CA certificate respectively, you can generate the required secret using
-the `flux creat secret helm` command:
+The Secret should be of type `Opaque` or `kubernetes.io/tls`. All the files in
+the Secret are expected to be [PEM-encoded][pem-encoding]. Assuming you have
+three files; `client.key`, `client.crt` and `ca.crt` for the client private key,
+client certificate and the CA certificate respectively, you can generate the
+required Secret using the `flux create secret tls` command:
 
 ```sh
-flux create secret helm tls --key-file=client.key --cert-file=client.crt --ca-file=ca.crt
+flux create secret tls --tls-key-file=client.key --tls-crt-file=client.crt --ca-crt-file=ca.crt
 ```
 
 Example usage:
@@ -515,11 +516,12 @@ kind: Secret
 metadata:
   name: example-tls
   namespace: default
+type: kubernetes.io/tls # or Opaque
 data:
-  certFile: <BASE64>
-  keyFile: <BASE64>
+  tls.crt: <BASE64>
+  tls.key: <BASE64>
   # NOTE: Can be supplied without the above values
-  caFile: <BASE64>
+  ca.crt: <BASE64>
 ```
 
 ### Pass credentials

--- a/internal/controller/helmchart_controller_test.go
+++ b/internal/controller/helmchart_controller_test.go
@@ -2248,7 +2248,7 @@ func TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy(t *testing.T) {
 		registryOpts     registryOptions
 		secretOpts       secretOptions
 		secret           *corev1.Secret
-		certsecret       *corev1.Secret
+		certSecret       *corev1.Secret
 		insecure         bool
 		provider         string
 		providerImg      string
@@ -2363,16 +2363,16 @@ func TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy(t *testing.T) {
 				Type: corev1.SecretTypeDockerConfigJson,
 				Data: map[string][]byte{},
 			},
-			certsecret: &corev1.Secret{
+			certSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "certs-secretref",
 				},
 				Data: map[string][]byte{
-					"caFile": []byte("invalid caFile"),
+					"ca.crt": []byte("invalid caFile"),
 				},
 			},
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, "Unknown", "unknown build error: failed to construct Helm client's TLS config: cannot append certificate into certificate pool: invalid caFile"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, "Unknown", "unknown build error: failed to construct Helm client's TLS config: cannot append certificate into certificate pool: invalid CA certificate"),
 			},
 		},
 		{
@@ -2393,14 +2393,14 @@ func TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy(t *testing.T) {
 				Type: corev1.SecretTypeDockerConfigJson,
 				Data: map[string][]byte{},
 			},
-			certsecret: &corev1.Secret{
+			certSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "certs-secretref",
 				},
 				Data: map[string][]byte{
-					"caFile":   tlsCA,
-					"certFile": clientPublicKey,
-					"keyFile":  clientPrivateKey,
+					"ca.crt":  tlsCA,
+					"tls.crt": clientPublicKey,
+					"tls.key": clientPrivateKey,
 				},
 			},
 			assertConditions: []metav1.Condition{
@@ -2472,11 +2472,11 @@ func TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy(t *testing.T) {
 				clientBuilder.WithObjects(tt.secret)
 			}
 
-			if tt.certsecret != nil {
+			if tt.certSecret != nil {
 				repo.Spec.CertSecretRef = &meta.LocalObjectReference{
-					Name: tt.certsecret.Name,
+					Name: tt.certSecret.Name,
 				}
-				clientBuilder.WithObjects(tt.certsecret)
+				clientBuilder.WithObjects(tt.certSecret)
 			}
 
 			clientBuilder.WithObjects(repo)

--- a/internal/controller/helmrepository_controller_oci_test.go
+++ b/internal/controller/helmrepository_controller_oci_test.go
@@ -325,12 +325,12 @@ func TestHelmRepositoryOCIReconciler_authStrategy(t *testing.T) {
 					Name: "certs-secretref",
 				},
 				Data: map[string][]byte{
-					"caFile": []byte("invalid caFile"),
+					"ca.crt": []byte("invalid caFile"),
 				},
 			},
 			assertConditions: []metav1.Condition{
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingWithRetryReason, "processing object: new generation 0 -> 1"),
-				*conditions.FalseCondition(meta.ReadyCondition, sourcev1.AuthenticationFailedReason, "cannot append certificate into certificate pool: invalid caFile"),
+				*conditions.FalseCondition(meta.ReadyCondition, sourcev1.AuthenticationFailedReason, "cannot append certificate into certificate pool: invalid CA certificate"),
 			},
 		},
 		{
@@ -356,9 +356,9 @@ func TestHelmRepositoryOCIReconciler_authStrategy(t *testing.T) {
 					Name: "certs-secretref",
 				},
 				Data: map[string][]byte{
-					"caFile":   tlsCA,
-					"certFile": clientPublicKey,
-					"keyFile":  clientPrivateKey,
+					"ca.crt":  tlsCA,
+					"tls.crt": clientPublicKey,
+					"tls.key": clientPrivateKey,
 				},
 			},
 			assertConditions: []metav1.Condition{

--- a/internal/tls/config.go
+++ b/internal/tls/config.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	neturl "net/url"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const CACrtKey = "ca.crt"
+
+// TLSBytes contains the bytes of the TLS files.
+type TLSBytes struct {
+	// CertBytes is the bytes of the certificate file.
+	CertBytes []byte
+	// KeyBytes is the bytes of the key file.
+	KeyBytes []byte
+	// CABytes is the bytes of the CA file.
+	CABytes []byte
+}
+
+// KubeTLSClientConfigFromSecret returns a TLS client config as a `tls.Config`
+// object and in its bytes representation. The secret is expected to have the
+// following keys:
+// - tls.key, for the private key
+// - tls.crt, for the certificate
+// - ca.crt, for the CA certificate
+//
+// Secrets with no certificate, private key, AND CA cert are ignored. If only a
+// certificate OR private key is found, an error is returned.
+func KubeTLSClientConfigFromSecret(secret corev1.Secret, url string) (*tls.Config, *TLSBytes, error) {
+	return tlsClientConfigFromSecret(secret, url, true)
+}
+
+// TLSClientConfigFromSecret returns a TLS client config as a `tls.Config`
+// object and in its bytes representation. The secret is expected to have the
+// following keys:
+// - keyFile, for the private key
+// - certFile, for the certificate
+// - caFile, for the CA certificate
+//
+// Secrets with no certificate, private key, AND CA cert are ignored. If only a
+// certificate OR private key is found, an error is returned.
+func TLSClientConfigFromSecret(secret corev1.Secret, url string) (*tls.Config, *TLSBytes, error) {
+	return tlsClientConfigFromSecret(secret, url, false)
+}
+
+// tlsClientConfigFromSecret attempts to construct and return a TLS client
+// config from the given Secret. If the Secret does not contain any TLS
+// data, it returns nil.
+//
+// kubernetesTLSKeys is a boolean indicating whether to check the Secret
+// for keys expected to be present in a Kubernetes TLS Secret. Based on its
+// value, the Secret is checked for the following keys:
+// - tls.key/keyFile for the private key
+// - tls.crt/certFile for the certificate
+// - ca.crt/caFile for the CA certificate
+// The keys should adhere to a single convention, i.e. a Secret with tls.key
+// and certFile is invalid.
+func tlsClientConfigFromSecret(secret corev1.Secret, url string, kubernetesTLSKeys bool) (*tls.Config, *TLSBytes, error) {
+	// Only Secrets of type Opaque and TLS are allowed. We also allow Secrets with a blank
+	// type, to avoid having to specify the type of the Secret for every test case.
+	// Since a real Kubernetes Secret is of type Opaque by default, its safe to allow this.
+	switch secret.Type {
+	case corev1.SecretTypeOpaque, corev1.SecretTypeTLS, "":
+	default:
+		return nil, nil, fmt.Errorf("cannot use secret '%s' to construct TLS config: invalid secret type: '%s'", secret.Name, secret.Type)
+	}
+
+	var certBytes, keyBytes, caBytes []byte
+	if kubernetesTLSKeys {
+		certBytes, keyBytes, caBytes = secret.Data[corev1.TLSCertKey], secret.Data[corev1.TLSPrivateKeyKey], secret.Data[CACrtKey]
+	} else {
+		certBytes, keyBytes, caBytes = secret.Data["certFile"], secret.Data["keyFile"], secret.Data["caFile"]
+	}
+
+	switch {
+	case len(certBytes)+len(keyBytes)+len(caBytes) == 0:
+		return nil, nil, nil
+	case (len(certBytes) > 0 && len(keyBytes) == 0) || (len(keyBytes) > 0 && len(certBytes) == 0):
+		return nil, nil, fmt.Errorf("invalid '%s' secret data: both certificate and private key need to be provided",
+			secret.Name)
+	}
+
+	tlsConf := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	if len(certBytes) > 0 && len(keyBytes) > 0 {
+		cert, err := tls.X509KeyPair(certBytes, keyBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		tlsConf.Certificates = append(tlsConf.Certificates, cert)
+	}
+
+	if len(caBytes) > 0 {
+		cp, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot retrieve system certificate pool: %w", err)
+		}
+		if !cp.AppendCertsFromPEM(caBytes) {
+			return nil, nil, fmt.Errorf("cannot append certificate into certificate pool: invalid CA certificate")
+		}
+
+		tlsConf.RootCAs = cp
+	}
+
+	if url != "" {
+		u, err := neturl.Parse(url)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot parse repository URL: %w", err)
+		}
+
+		tlsConf.ServerName = u.Hostname()
+	}
+
+	return tlsConf, &TLSBytes{
+		CertBytes: certBytes,
+		KeyBytes:  keyBytes,
+		CABytes:   caBytes,
+	}, nil
+}

--- a/internal/tls/config_test.go
+++ b/internal/tls/config_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/url"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_tlsClientConfigFromSecret(t *testing.T) {
+	kubernetesTlsSecretFixture := validTlsSecret(t, true)
+	tlsSecretFixture := validTlsSecret(t, false)
+
+	tests := []struct {
+		name    string
+		secret  corev1.Secret
+		modify  func(secret *corev1.Secret)
+		tlsKeys bool
+		url     string
+		wantErr bool
+		wantNil bool
+	}{
+		{
+			name:    "tls.crt, tls.key and ca.crt",
+			secret:  kubernetesTlsSecretFixture,
+			modify:  nil,
+			tlsKeys: true,
+			url:     "https://example.com",
+		},
+		{
+			name:    "certFile, keyFile and caFile",
+			secret:  tlsSecretFixture,
+			modify:  nil,
+			tlsKeys: false,
+			url:     "https://example.com",
+		},
+		{
+			name:    "without tls.crt",
+			secret:  kubernetesTlsSecretFixture,
+			modify:  func(s *corev1.Secret) { delete(s.Data, "tls.crt") },
+			tlsKeys: true,
+			wantErr: true,
+			wantNil: true,
+		},
+		{
+			name:    "without tls.key",
+			secret:  kubernetesTlsSecretFixture,
+			modify:  func(s *corev1.Secret) { delete(s.Data, "tls.key") },
+			tlsKeys: true,
+			wantErr: true,
+			wantNil: true,
+		},
+		{
+			name:    "without ca.crt",
+			secret:  kubernetesTlsSecretFixture,
+			modify:  func(s *corev1.Secret) { delete(s.Data, "ca.crt") },
+			tlsKeys: true,
+		},
+		{
+			name:    "empty secret",
+			secret:  corev1.Secret{},
+			tlsKeys: true,
+			wantNil: true,
+		},
+		{
+			name:    "invalid secret type",
+			secret:  corev1.Secret{Type: corev1.SecretTypeDockerConfigJson},
+			wantErr: true,
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			secret := tt.secret.DeepCopy()
+			if tt.modify != nil {
+				tt.modify(secret)
+			}
+
+			tlsConfig, _, err := tlsClientConfigFromSecret(*secret, tt.url, tt.tlsKeys)
+			g.Expect(err != nil).To(Equal(tt.wantErr), fmt.Sprintf("expected error: %v, got: %v", tt.wantErr, err))
+			g.Expect(tlsConfig == nil).To(Equal(tt.wantNil))
+			if tt.url != "" {
+				u, _ := url.Parse(tt.url)
+				g.Expect(u.Hostname()).To(Equal(tlsConfig.ServerName))
+			}
+		})
+	}
+}
+
+// validTlsSecret creates a secret containing key pair and CA certificate that are
+// valid from a syntax (minimum requirements) perspective.
+func validTlsSecret(t *testing.T, kubernetesTlsKeys bool) corev1.Secret {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal("Private key cannot be created.", err.Error())
+	}
+
+	certTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1337),
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal("Certificate cannot be created.", err.Error())
+	}
+
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(7331),
+		IsCA:         true,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		t.Fatal("CA private key cannot be created.", err.Error())
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		t.Fatal("CA certificate cannot be created.", err.Error())
+	}
+
+	keyPem := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	certPem := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	})
+
+	caPem := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	crtKey := corev1.TLSCertKey
+	pkKey := corev1.TLSPrivateKeyKey
+	caKey := CACrtKey
+	if !kubernetesTlsKeys {
+		crtKey = "certFile"
+		pkKey = "keyFile"
+		caKey = "caFile"
+	}
+	return corev1.Secret{
+		Data: map[string][]byte{
+			crtKey: []byte(certPem),
+			pkKey:  []byte(keyPem),
+			caKey:  []byte(caPem),
+		},
+	}
+}


### PR DESCRIPTION
Modify `.spec.certSecretRef` HelmRepository and OCIRepository to use the keys expected in a Kubernetes Secret of type TLS, `tls.crt` and `tls.key`. Furthermore use `ca.crt` for specifying the CA certificate.
Deprecate the usage of `certFile`, `keyFile` and `caFile` for OCIRepository. Both `caFile` and `ca.crt` are supported for GitRepository with the latter taking precedence.

Part of: https://github.com/fluxcd/flux2/issues/4137