### PR TITLE
Add `.spec.serviceAccountName` to HelmRepository

### DIFF
--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -108,6 +108,7 @@ type HelmRepositorySpec struct {
 	// the OCI image pull if the service account has attached pull secrets. For more information:
 	// https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
 	// +optional
+	// This field is only considered for Helm Repositories of type oci
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.

--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -104,6 +104,12 @@ type HelmRepositorySpec struct {
 	// +optional
 	Type string `json:"type,omitempty"`
 
+	// ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+	// the OCI image pull if the service account has attached pull secrets. For more information:
+	// https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
 	// Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
 	// This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
 	// When not specified, defaults to 'generic'.

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -345,6 +345,11 @@ spec:
                 required:
                 - name
                 type: object
+              serviceAccountName:
+                description: 'ServiceAccountName is the name of the Kubernetes ServiceAccount
+                  used to authenticate the OCI image pull if the service account has
+                  attached pull secrets. For more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account'
+                type: string
               suspend:
                 description: Suspend tells the controller to suspend the reconciliation
                   of this HelmRepository.

--- a/docs/spec/v1beta2/helmrepositories.md
+++ b/docs/spec/v1beta2/helmrepositories.md
@@ -509,6 +509,16 @@ data:
   caFile: <BASE64>
 ```
 
+
+### Service Account Name
+
+*Note:* This field is only taken into account for Helm Repository of
+type `oci`.
+
+`.spec.serviceAccountName` is an optional field to specify a name of a
+ServiceAccount in the same namespace as the HelmRepository, which has image
+pull secrets that can be used for authentication to the OCI image repository.
+
 ### Pass credentials
 
 `.spec.passCredentials` is an optional field to allow the credentials from the


### PR DESCRIPTION
This pull request adds `.spec.serviceAccountName` field to HelmRepository. 
This allows the use of the serviceaccount pull secret to pull OCI (helm repository) images.

Ref: https://github.com/fluxcd/source-controller/issues/953