### PR TITLE
Fix links in API docs

### DIFF
--- a/docs/spec/v1beta2/helmrepositories.md
+++ b/docs/spec/v1beta2/helmrepositories.md
@@ -713,7 +713,7 @@ specific HelmRepository, e.g. `flux logs --level=error --kind=HelmRepository --n
 
 ### Artifact
 
-**Note:** This section does not apply to [OCI Helm Repositories](#oci-helm-repositories), they do not emit artifacts.
+**Note:** This section does not apply to [OCI Helm Repositories](#helm-oci-repositories), they do not emit artifacts.
 
 The HelmRepository reports the last fetched repository index as an Artifact
 object in the `.status.artifact` of the resource.

--- a/docs/spec/v1beta2/ocirepositories.md
+++ b/docs/spec/v1beta2/ocirepositories.md
@@ -624,7 +624,7 @@ flux reconcile source oci <repository-name>
 ### Waiting for `Ready`
 
 When a change is applied, it is possible to wait for the OCIRepository to reach
-a [ready state](#ready-gitrepository) using `kubectl`:
+a [ready state](#ready-ocirepository) using `kubectl`:
 
 ```sh
 kubectl wait gitrepository/<repository-name> --for=condition=ready --timeout=1m
@@ -881,8 +881,8 @@ following attributes in the OCIRepository's `.status.conditions`:
 - `reason: Succeeded`
 
 This `Ready` Condition will retain a status value of `"True"` until the
-OCIRepository is marked as [reconciling](#reconciling-gitrepository), or e.g. a
-[transient error](#failed-gitrepository) occurs due to a temporary network issue.
+OCIRepository is marked as [reconciling](#reconciling-ocirepository), or e.g. a
+[transient error](#failed-ocirepository) occurs due to a temporary network issue.
 
 When the OCIRepository Artifact is archived in the controller's Artifact
 storage, the controller sets a Condition with the following attributes in the


### PR DESCRIPTION
These changes all go together:

* https://github.com/fluxcd/website/pull/1621
* https://github.com/fluxcd/image-automation-controller/pull/573
* https://github.com/fluxcd/notification-controller/pull/602
* https://github.com/fluxcd/community/pull/317

I will add any further ancillary PRs to this one, and we can coordinate the merges from here. Now we are closing in on the end of the list of changes we needed, in order to finalize fluxcd/website#1573 without creating any regressions.