### PR TITLE
Preserve url encoded path in normalized helm repository URL

### DIFF
--- a/internal/helm/repository/utils.go
+++ b/internal/helm/repository/utils.go
@@ -47,10 +47,16 @@ func NormalizeURL(repositoryURL string) (string, error) {
 
 	if u.Scheme == helmreg.OCIScheme {
 		u.Path = strings.TrimRight(u.Path, "/")
+		// we perform the same operation on u.RawPath so that it will be a valid encoding
+		// of u.Path. This allows u.EscapedPath() (which is used in computing u.String()) to return
+		// the correct value when the path is url encoded.
+		// ref: https://pkg.go.dev/net/url#URL.EscapedPath
+		u.RawPath = strings.TrimRight(u.RawPath, "/")
 		return u.String(), nil
 	}
 
 	u.Path = strings.TrimRight(u.Path, "/") + "/"
+	u.RawPath = strings.TrimRight(u.RawPath, "/") + "/"
 	return u.String(), nil
 }
 

--- a/internal/helm/repository/utils_test.go
+++ b/internal/helm/repository/utils_test.go
@@ -65,6 +65,16 @@ func TestNormalizeURL(t *testing.T) {
 			want: "http://example.com/?st=pr",
 		},
 		{
+			name: "url with encoded path",
+			url:  "http://example.com/next%2Fpath",
+			want: "http://example.com/next%2Fpath/",
+		},
+		{
+			name: "url with encoded path and slash",
+			url:  "http://example.com/next%2Fpath/",
+			want: "http://example.com/next%2Fpath/",
+		},
+		{
 			name: "empty url",
 			url:  "",
 			want: "",


### PR DESCRIPTION
This pull request ensures that the URL encoded path in the URL is preserved when using `NormalizedURL`

Previously:
```
repository.NormalizeURL(http://example.com/next%2Fpath) => http://example.com/next/path/
```

Now
```
repository.NormalizeURL(http://example.com/next%2Fpath) => http://example.com/next%2Fpath/
```

Fix: https://github.com/fluxcd/source-controller/issues/1206