### PR TITLE
docs: Add missing pem-encoding reference

### DIFF
--- a/docs/spec/v1beta2/helmrepositories.md
+++ b/docs/spec/v1beta2/helmrepositories.md
@@ -896,5 +896,6 @@ annotation value it acted on in the `.status.lastHandledReconcileAt` field.
 For practical information about this field, see [triggering a
 reconcile](#triggering-a-reconcile).
 
+[pem-encoding]: https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail
 [typical-status-properties]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 [kstatus-spec]: https://github.com/kubernetes-sigs/cli-utils/tree/master/pkg/kstatus


### PR DESCRIPTION
In the Helm Repository document, `[PEM-encoding][pem-encoding]` is displayed because of the related reference is missing.

See the link below:
https://fluxcd.io/flux/components/source/helmrepositories/#cert-secret-reference:~:text=%5BPEM%2Dencoded%5D%5Bpem%2Dencoding%5D

This PR fixes that issue by copying the reference from the OCI Repository document.