### PR TITLE
helmrepo: fix Secret type check for TLS via `.spec.secretRef`

### DIFF
--- a/internal/helm/getter/client_opts.go
+++ b/internal/helm/getter/client_opts.go
@@ -115,10 +115,10 @@ func GetClientOpts(ctx context.Context, c client.Client, obj *helmv1.HelmReposit
 		}
 		hrOpts.GetterOpts = append(hrOpts.GetterOpts, opts...)
 
-		// If the TLS config is nil, i.e. one couldn't be constructed using `.spec.certSecretRef`
-		// then try to use `.spec.secretRef`.
+		// If the TLS config is nil, i.e. one couldn't be constructed using
+		// `.spec.certSecretRef`, then try to use `.spec.secretRef`.
 		if hrOpts.TlsConfig == nil && !ociRepo {
-			hrOpts.TlsConfig, tlsBytes, err = stls.TLSClientConfigFromSecret(*authSecret, url)
+			hrOpts.TlsConfig, tlsBytes, err = stls.LegacyTLSClientConfigFromSecret(*authSecret, url)
 			if err != nil {
 				return nil, "", fmt.Errorf("failed to construct Helm client's TLS config: %w", err)
 			}


### PR DESCRIPTION
This is a fix for a regression introduced in a302c71 which would wrongly check for the type of the Secret specified in `.spec.secretRef` while configuring TLS data.

This moves the Secret type check after checking whether the Secret has any TLS data, to avoid unnecessary type enforcement.

Fixes #1218 