### PR TITLE
Optionally allow lenient handling of tag versions for semver

### DIFF
--- a/api/v1beta2/ocirepository_types.go
+++ b/api/v1beta2/ocirepository_types.go
@@ -160,6 +160,12 @@ type OCIRepositoryRef struct {
 	// Tag is the image tag to pull, defaults to latest.
 	// +optional
 	Tag string `json:"tag,omitempty"`
+
+	// Enable lenient SemVer tag handling, supporting anything that
+	// the Masterminds/semver/v3 library can handle in it's lenient
+	// mode. Defaults to false.
+	// +optional
+	LenientSemVer bool `json:"lenient-semver"`
 }
 
 // OCILayerSelector specifies which layer should be extracted from an OCI Artifact


### PR DESCRIPTION
We use `git describe` style versioning, which is unfortunately close but nominally incompatible with semver. I propose adding a lenient option on the resource definition to enable parsing these versions.

The underlying semver library in use by the source-controller, Masterminds/semver, will safely and correctly interpret this style of versioning when using the `semver.NewVersion` constructor. source-controller uses the central flux pkg `version`, which in turn calls `semver.StrictNewVersion`.

Since this is my first contribution and I'm touching an API resource, I'm submitting a pretty sparse PR for feedback before enriching with tests. Existing tests cover that there are no regressions from this strictly additive change.
