### PR TITLE
build(deps): bump the ci group with 1 update

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -40,13 +40,13 @@ jobs:
             **/go.sum
             **/go.mod
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@04daf014b50eaf774287bf3f0f1869d4b4c4b913 # v2.21.7
+        uses: github/codeql-action/init@2cb752a87e96af96708ab57187ab6372ee1973ab # v2.22.0
         with:
           languages: go
           # xref: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # xref: https://codeql.github.com/codeql-query-help/go/
           queries: security-and-quality
       - name: Autobuild
-        uses: github/codeql-action/autobuild@04daf014b50eaf774287bf3f0f1869d4b4c4b913 # v2.21.7
+        uses: github/codeql-action/autobuild@2cb752a87e96af96708ab57187ab6372ee1973ab # v2.22.0
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@04daf014b50eaf774287bf3f0f1869d4b4c4b913 # v2.21.7
+        uses: github/codeql-action/analyze@2cb752a87e96af96708ab57187ab6372ee1973ab # v2.22.0


### PR DESCRIPTION
Bumps the ci group with 1 update: [github/codeql-action](https://github.com/github/codeql-action).

- [Release notes](https://github.com/github/codeql-action/releases)
- [Changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/github/codeql-action/compare/6a28655e3dcb49cb0840ea372fd6d17733edd8a4...2cb752a87e96af96708ab57187ab6372ee1973ab)

Signed-off-by: Max Jonas Werner <mail@makk.es>

---
updated-dependencies:
- dependency-name: github/codeql-action dependency-type: direct:production update-type: version-update:semver-minor dependency-group: ci ...

Signed-off-by: dependabot[bot] <support@github.com>
(cherry picked from commit 9d64b462b120db565a3e43bf74deca5dfbbd8d97)