### PR TITLE
helmrepo: only configure tls login option when required

### DIFF
--- a/internal/helm/getter/client_opts.go
+++ b/internal/helm/getter/client_opts.go
@@ -162,10 +162,10 @@ func GetClientOpts(ctx context.Context, c client.Client, obj *helmv1.HelmReposit
 		}
 		if loginOpt != nil {
 			hrOpts.RegLoginOpts = []helmreg.LoginOption{loginOpt}
-		}
-		tlsLoginOpt := registry.TLSLoginOption(certFile, keyFile, caFile)
-		if tlsLoginOpt != nil {
-			hrOpts.RegLoginOpts = append(hrOpts.RegLoginOpts, tlsLoginOpt)
+			tlsLoginOpt := registry.TLSLoginOption(certFile, keyFile, caFile)
+			if tlsLoginOpt != nil {
+				hrOpts.RegLoginOpts = append(hrOpts.RegLoginOpts, tlsLoginOpt)
+			}
 		}
 	}
 	if deprecatedTLSConfig {


### PR DESCRIPTION
Modify `GetHelmClientOpts()` to only configure the TLS login option when an authentication login option is configured. This prevents the reconciler from trying to authenticate against public registries.

Fixes #1268 