### PR TITLE
Rename make target `build` to `manager` 

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,6 +46,11 @@ jobs:
           SKIP_COSIGN_VERIFICATION: true
           CREATE_CLUSTER: false
         run: make e2e
+      - name: Print controller logs
+        if: always()
+        continue-on-error: true
+        run: |
+          kubectl -n source-system logs -l app=source-controller
 
   kind-linux-arm64:
     # Hosted on Equinix

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,10 @@ ifeq ($(shell uname -s),Darwin)
 ENVTEST_ARCH=amd64
 endif
 
-all: build
+all: manager
 
-build: ## Build manager binary
+# Build manager binary
+manager: generate fmt vet
 	go build $(GO_STATIC_FLAGS) -o $(BUILD_DIR)/bin/manager main.go
 
 KUBEBUILDER_ASSETS?="$(shell $(ENVTEST) --arch=$(ENVTEST_ARCH) use -i $(ENVTEST_KUBERNETES_VERSION) --bin-dir=$(ENVTEST_ASSETS_DIR) -p path)"


### PR DESCRIPTION
Due to the existence of `BUILD_DIR` directory called `build` at the project root, the `build` make target never works.
Rename the make target as `manager`, in alignment with other makefiles in other repos and not conflict with the `build`
directory.
