### PR TITLE
helmrepo: Remove migration log/event

### DIFF
--- a/internal/controller/helmrepository_controller.go
+++ b/internal/controller/helmrepository_controller.go
@@ -727,7 +727,5 @@ func (r *HelmRepositoryReconciler) migrationToStatic(ctx context.Context, sp *pa
 		return ctrl.Result{}, err
 	}
 
-	r.eventLogf(ctx, obj, eventv1.EventTypeTrace, "Migration",
-		"removed artifact and finalizer to migrate to static HelmRepository of type OCI")
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
This will be logged/event emitted forever once in the lifecycle of HelmRepository OCI object because all new objects have to remove the `.status.observedGeneration` which is set to -1 by the API defaults. Better to perform the object conversion internally without any log or event.