### PR TITLE
Add `.spec.insecureSkipVerify` to `HelmRepository` for type: `oci`

### DIFF
--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -98,6 +98,12 @@ type HelmRepositorySpec struct {
 	// +optional
 	Insecure bool `json:"insecure,omitempty"`
 
+	// InsecureSkipVerify allows connecting to a HTTPS container registry without
+	// verifying the server's certificate chain and host name.
+	// This field is only taken into account if the .spec.type field is set to 'oci'.
+	// +optional
+	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
+
 	// Timeout is used for the index fetch operation for an HTTPS helm repository,
 	// and for remote OCI Repository operations like pulling for an OCI helm
 	// chart by the associated HelmChart.

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -318,6 +318,11 @@ spec:
                   registry. This field is only taken into account if the .spec.type
                   field is set to 'oci'.
                 type: boolean
+              insecureSkipVerify:
+                description: Insecure allows connecting to a HTTPS container registry
+                  without verifying the server's certificate chain and host name.
+                  This field is only taken into account if the .spec.type field is set to 'oci'.
+                type: boolean
               interval:
                 description: Interval at which the HelmRepository URL is checked for
                   updates. This interval is approximate and may be subject to jitter

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -319,7 +319,7 @@ spec:
                   field is set to 'oci'.
                 type: boolean
               insecureSkipVerify:
-                description: Insecure allows connecting to a HTTPS container registry
+                description: InsecureSkipVerify allows connecting to a HTTPS container registry
                   without verifying the server's certificate chain and host name.
                   This field is only taken into account if the .spec.type field is set to 'oci'.
                 type: boolean

--- a/docs/api/v1beta2/source.md
+++ b/docs/api/v1beta2/source.md
@@ -887,6 +887,20 @@ This field is only taken into account if the .spec.type field is set to &lsquo;o
 </tr>
 <tr>
 <td>
+<code>insecureskipverify</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InsecureSkipVerify allows connecting to a HTTPS container registry without
+verifying the server&rsquo;s certificate chain and host name.
+This field is only taken into account if the .spec.type field is set to &lsquo;oci&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>timeout</code><br>
 <em>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
@@ -2614,6 +2628,20 @@ bool
 <td>
 <em>(Optional)</em>
 <p>Insecure allows connecting to a non-TLS HTTP container registry.
+This field is only taken into account if the .spec.type field is set to &lsquo;oci&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>insecureskipverify</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InsecureSkipVerify allows connecting to a HTTPS container registry without
+verifying the server&rsquo;s certificate chain and host name.
 This field is only taken into account if the .spec.type field is set to &lsquo;oci&rsquo;.</p>
 </td>
 </tr>

--- a/docs/api/v1beta2/source.md
+++ b/docs/api/v1beta2/source.md
@@ -887,7 +887,7 @@ This field is only taken into account if the .spec.type field is set to &lsquo;o
 </tr>
 <tr>
 <td>
-<code>insecureskipverify</code><br>
+<code>insecureSkipVerify</code><br>
 <em>
 bool
 </em>
@@ -2633,7 +2633,7 @@ This field is only taken into account if the .spec.type field is set to &lsquo;o
 </tr>
 <tr>
 <td>
-<code>insecureskipverify</code><br>
+<code>insecureSkipVerify</code><br>
 <em>
 bool
 </em>

--- a/docs/spec/v1beta2/helmrepositories.md
+++ b/docs/spec/v1beta2/helmrepositories.md
@@ -354,6 +354,15 @@ denying insecure non-TLS connections when fetching Helm chart OCI artifacts.
 **Note**: The insecure field is supported only for Helm OCI repositories.
 The `spec.type` field must be set to `oci`.
 
+### InsecureSkipVerify
+
+`.spec.insecureSkipVerify` is an optional field to allow connecting to a secure (HTTPS)
+container registry server without verifying the server's certificate chain and host name,
+if set to `true`. The default value is `false`,
+
+**Note**: The insecureSkipVerify field is supported only for Helm OCI repositories.
+The `spec.type` field must be set to `oci`.
+
 ### Interval
 
 **Note:** This field is ineffectual for [OCI Helm

--- a/internal/helm/getter/client_opts.go
+++ b/internal/helm/getter/client_opts.go
@@ -88,7 +88,11 @@ func GetClientOpts(ctx context.Context, c client.Client, obj *helmv1.HelmReposit
 		err        error
 	)
 	// Check `.spec.certSecretRef` first for any TLS auth data.
-	if obj.Spec.CertSecretRef != nil {
+	if obj.Spec.InsecureSkipVerify {
+		hrOpts.TlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	} else if obj.Spec.CertSecretRef != nil {
 		certSecret, err = fetchSecret(ctx, c, obj.Spec.CertSecretRef.Name, obj.GetNamespace())
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to get TLS authentication secret '%s/%s': %w", obj.GetNamespace(), obj.Spec.CertSecretRef.Name, err)


### PR DESCRIPTION
Allow connecting to Helm OCI HTTPs repositories without verifying the server's certificate chain and host name.

Example:

```yaml
apiVersion: source.toolkit.fluxcd.io/v1beta2
kind: HelmRepository
metadata:
  name: myhelmrepo
  namespace: default
spec:
  type: oci
  interval: 1h
  insecureSkipVerify: true
  url: oci://my-self-signed-helm-repo-url:5000/charts
```