### PR TITLE
Add support for layer extraction from OCI artifacts with `ImageIndex`

### DIFF
--- a/api/v1beta2/ocirepository_types.go
+++ b/api/v1beta2/ocirepository_types.go
@@ -183,6 +183,10 @@ type OCILayerSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	Offset *int `json:"offset,omitempty"`
+
+	// TODO: next API version should probably use artifact media types
+	// at the top level and make layer selector optional
+	ArtifactMediaType string `json:"artifactMediaType,omitempty"`
 }
 
 // OCIRepositoryVerification verifies the authenticity of an OCI Artifact

--- a/api/v1beta2/ocirepository_types.go
+++ b/api/v1beta2/ocirepository_types.go
@@ -166,7 +166,8 @@ type OCIRepositoryRef struct {
 type OCILayerSelector struct {
 	// MediaType specifies the OCI media type of the layer
 	// which should be extracted from the OCI Artifact. The
-	// first layer matching this type is selected.
+	// first layer matching this type is selected by default,
+	// otherwise 'offest' needs to be specified.
 	// +optional
 	MediaType string `json:"mediaType,omitempty"`
 
@@ -177,6 +178,11 @@ type OCILayerSelector struct {
 	// +kubebuilder:validation:Enum=extract;copy
 	// +optional
 	Operation string `json:"operation,omitempty"`
+
+	// Offset specifies the index of the layer which should be extracted.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Offset *int `json:"offset,omitempty"`
 }
 
 // OCIRepositoryVerification verifies the authenticity of an OCI Artifact
@@ -305,6 +311,14 @@ func (in *OCIRepository) GetLayerOperation() string {
 	}
 
 	return in.Spec.LayerSelector.Operation
+}
+
+func (in *OCIRepository) GetLayerOffset() int {
+	if in.Spec.LayerSelector == nil || in.Spec.LayerSelector.Offset == nil {
+		return 0
+	}
+
+	return *in.Spec.LayerSelector.Offset
 }
 
 // +genclient

--- a/internal/controller/ocirepository_controller.go
+++ b/internal/controller/ocirepository_controller.go
@@ -408,7 +408,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 	// Mark observations about the revision on the object
 	defer func() {
 		if !obj.GetArtifact().HasRevision(revision) {
-			message := fmt.Sprintf("new revision '%s' for '%s'", revision, ref)
+			message := fmt.Sprintf("new revision '%s' for '%s'", revision, obj.Spec.URL)
 			if obj.GetArtifact() != nil {
 				conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "NewRevision", message)
 			}

--- a/internal/controller/ocirepository_controller_test.go
+++ b/internal/controller/ocirepository_controller_test.go
@@ -1575,12 +1575,13 @@ func TestOCIRepository_reconcileSource_verifyOCISourceSignature_keyless(t *testi
 					Reference: tt.reference,
 				},
 			}
-			url := strings.TrimPrefix(obj.Spec.URL, "oci://") + ":" + tt.reference.Tag
+
+			url := strings.TrimPrefix(obj.Spec.URL, "oci://")
 
 			assertConditions := tt.assertConditions
 			for k := range assertConditions {
 				assertConditions[k].Message = strings.ReplaceAll(assertConditions[k].Message, "<revision>", tt.revision)
-				assertConditions[k].Message = strings.ReplaceAll(assertConditions[k].Message, "<url>", url)
+				assertConditions[k].Message = strings.ReplaceAll(assertConditions[k].Message, "<url>", obj.Spec.URL)
 				assertConditions[k].Message = strings.ReplaceAll(assertConditions[k].Message, "<provider>", "cosign")
 			}
 


### PR DESCRIPTION
This change makes fetching of OCI artifacts compatible with a wider range of images, namely where the top-level object is an index. Once the index is fetched, the media type selector and (optionally) a numeric offset will be applied to determine what blob to use.


Towards #1247.