### PR TITLE
Remove `genclient:Namespaced` tag

### DIFF
--- a/api/v1/gitrepository_types.go
+++ b/api/v1/gitrepository_types.go
@@ -309,7 +309,6 @@ func (v *GitRepositoryVerification) VerifyTag() bool {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=gitrepo

--- a/api/v1beta1/bucket_types.go
+++ b/api/v1beta1/bucket_types.go
@@ -193,7 +193,6 @@ func (in *Bucket) GetInterval() metav1.Duration {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`

--- a/api/v1beta1/gitrepository_types.go
+++ b/api/v1beta1/gitrepository_types.go
@@ -265,7 +265,6 @@ func (in *GitRepository) GetInterval() metav1.Duration {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=gitrepo
 // +kubebuilder:subresource:status

--- a/api/v1beta1/helmchart_types.go
+++ b/api/v1beta1/helmchart_types.go
@@ -231,7 +231,6 @@ func (in *HelmChart) GetValuesFiles() []string {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=hc
 // +kubebuilder:subresource:status

--- a/api/v1beta1/helmrepository_types.go
+++ b/api/v1beta1/helmrepository_types.go
@@ -181,7 +181,6 @@ func (in *HelmRepository) GetInterval() metav1.Duration {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=helmrepo
 // +kubebuilder:subresource:status

--- a/api/v1beta2/bucket_types.go
+++ b/api/v1beta2/bucket_types.go
@@ -175,7 +175,6 @@ func (in *Bucket) GetArtifact() *apiv1.Artifact {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/api/v1beta2/gitrepository_types.go
+++ b/api/v1beta2/gitrepository_types.go
@@ -287,7 +287,6 @@ func (in *GitRepository) GetArtifact() *apiv1.Artifact {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=gitrepo
 // +kubebuilder:subresource:status

--- a/api/v1beta2/helmchart_types.go
+++ b/api/v1beta2/helmchart_types.go
@@ -203,7 +203,6 @@ func (in *HelmChart) GetValuesFiles() []string {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=hc

--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -198,7 +198,6 @@ func (in *HelmRepository) GetArtifact() *apiv1.Artifact {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=helmrepo

--- a/api/v1beta2/ocirepository_types.go
+++ b/api/v1beta2/ocirepository_types.go
@@ -308,7 +308,6 @@ func (in *OCIRepository) GetLayerOperation() string {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=ocirepo


### PR DESCRIPTION
This tag isn't used by controller-tools, only `nonNamespaced` is.

Context: https://cloud-native.slack.com/archives/CLAJ40HV3/p1708794732147909

Tested by running `make generate` and verifying that there is no diff.

Signed-off-by: Georg Molau [georg.molau@gmail.com](mailto:georg.molau@gmail.com)