### PR TITLE
Helm: Allow insecure registry login

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,7 @@
 name: tests
 
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - 'CHANGELOG.md'

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -171,7 +171,7 @@ func setupRegistryServer(ctx context.Context, workspaceDir string, opts registry
 		}
 		server.dnsServer.PatchNet(net.DefaultResolver)
 	} else {
-		server.registryHost = fmt.Sprintf("localhost:%d", port)
+		server.registryHost = fmt.Sprintf("127.0.0.1:%d", port)
 	}
 
 	config.HTTP.Addr = fmt.Sprintf(":%d", port)

--- a/internal/helm/getter/client_opts.go
+++ b/internal/helm/getter/client_opts.go
@@ -162,7 +162,7 @@ func GetClientOpts(ctx context.Context, c client.Client, obj *helmv1.HelmReposit
 			return nil, "", err
 		}
 		if loginOpt != nil {
-			hrOpts.RegLoginOpts = []helmreg.LoginOption{loginOpt}
+			hrOpts.RegLoginOpts = []helmreg.LoginOption{loginOpt, helmreg.LoginOptInsecure(obj.Spec.Insecure)}
 			tlsLoginOpt := registry.TLSLoginOption(certFile, keyFile, caFile)
 			if tlsLoginOpt != nil {
 				hrOpts.RegLoginOpts = append(hrOpts.RegLoginOpts, tlsLoginOpt)

--- a/internal/helm/getter/client_opts_test.go
+++ b/internal/helm/getter/client_opts_test.go
@@ -206,7 +206,7 @@ func TestGetClientOpts_registryTLSLoginOption(t *testing.T) {
 					"password": []byte("pass"),
 				},
 			},
-			loginOptsN: 2,
+			loginOptsN: 3,
 		},
 		{
 			name: "without caFile",
@@ -225,7 +225,7 @@ func TestGetClientOpts_registryTLSLoginOption(t *testing.T) {
 					"password": []byte("pass"),
 				},
 			},
-			loginOptsN: 1,
+			loginOptsN: 2,
 		},
 		{
 			name:       "without cert secret",
@@ -239,7 +239,7 @@ func TestGetClientOpts_registryTLSLoginOption(t *testing.T) {
 					"password": []byte("pass"),
 				},
 			},
-			loginOptsN: 1,
+			loginOptsN: 2,
 		},
 	}
 	for _, tt := range tests {
@@ -280,7 +280,7 @@ func TestGetClientOpts_registryTLSLoginOption(t *testing.T) {
 			}
 			if tt.loginOptsN != len(clientOpts.RegLoginOpts) {
 				// we should have a login option but no TLS option
-				t.Error("registryTLSLoginOption() != nil")
+				t.Errorf("expected length of %d for clientOpts.RegLoginOpts but got %d", tt.loginOptsN, len(clientOpts.RegLoginOpts))
 				return
 			}
 		})


### PR DESCRIPTION
Hello flux team! I am a maintainer for [Zarf](https://github.com/defenseunicorns/zarf), we want to allow users to create flux helm releases to our internal registry which will be within the cluster and over http. Currently this functionality does not work since the request is routed through https when we login to the registry. The error message on the helmrelease looks like: 
```bash 
HelmChart 'flux-system/flux-system-podinfo' is not ready: unknown build error: failed to login to OCI registry: Get "https://10.43.76.170:5000/v2/": http: server gave HTTP response to HTTPS client
```
Our helmrepo spec looks like the following:
```yaml
spec:
  type: oci
  interval: 30s
  insecure: true
  url:  oci://10.43.76.170:5000/stefanprodan/charts
  provider: generic
```
In order to solve this I've added the loginOptInsecure option when the repo.spec is insecure and the registry requires login. I've verified this works by building a local image and testing it out with my cluster. 

It does however break some of your tests. For example the test `TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy/HTTP_with_basic_auth_secret` breaks like this:
```bash
failed to login to OCI registry: insecure registry example.com:35993 is not valid: invalid host "example.com"
```
If I set this line to 127.0.0.1 rather than example.com it will work but https test cases will fail. I'm having trouble figuring out which package down the chain is flagging example.com as invalid given the error above. If you guys know the solution here it would be appreciated! 
[server.registryHost = fmt.Sprintf("example.com:%d", port)](https://github.com/fluxcd/source-controller/blob/565f6ee039bcf43e0012e0c88dd59e32d80d2c3f/internal/controller/suite_test.go#L159)

As an alternative I believe it would work if we changed the test layout to have the http tests use 127.0.0.1 and the https tests use example.com, but I will leave that up to y'all. 