### PR TITLE
Add support for `.spec.proxySecretRef` for generic provider of Bucket API

### DIFF
--- a/api/v1beta2/bucket_types.go
+++ b/api/v1beta2/bucket_types.go
@@ -100,6 +100,13 @@ type BucketSpec struct {
 	// +optional
 	CertSecretRef *meta.LocalObjectReference `json:"certSecretRef,omitempty"`
 
+	// ProxySecretRef specifies the Secret containing the proxy configuration
+	// to use while communicating with the Bucket server.
+	//
+	// Only supported for the generic provider.
+	// +optional
+	ProxySecretRef *meta.LocalObjectReference `json:"proxySecretRef,omitempty"`
+
 	// Interval at which the Bucket Endpoint is checked for updates.
 	// This interval is approximate and may be subject to jitter to ensure
 	// efficient use of resources.

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -128,6 +128,11 @@ func (in *BucketSpec) DeepCopyInto(out *BucketSpec) {
 		*out = new(meta.LocalObjectReference)
 		**out = **in
 	}
+	if in.ProxySecretRef != nil {
+		in, out := &in.ProxySecretRef, &out.ProxySecretRef
+		*out = new(meta.LocalObjectReference)
+		**out = **in
+	}
 	out.Interval = in.Interval
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout

--- a/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
@@ -391,6 +391,20 @@ spec:
                 - gcp
                 - azure
                 type: string
+              proxySecretRef:
+                description: |-
+                  ProxySecretRef specifies the Secret containing the proxy configuration
+                  to use while communicating with the Bucket server.
+
+
+                  Only supported for the generic provider.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
               region:
                 description: Region of the Endpoint where the BucketName is located
                   in.

--- a/docs/api/v1beta2/source.md
+++ b/docs/api/v1beta2/source.md
@@ -191,6 +191,22 @@ be of type <code>Opaque</code> or <code>kubernetes.io/tls</code>.</p>
 </tr>
 <tr>
 <td>
+<code>proxySecretRef</code><br>
+<em>
+<a href="https://pkg.go.dev/github.com/fluxcd/pkg/apis/meta#LocalObjectReference">
+github.com/fluxcd/pkg/apis/meta.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ProxySecretRef specifies the Secret containing the proxy configuration
+to use while communicating with the Bucket server.</p>
+<p>Only supported for the generic provider.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>interval</code><br>
 <em>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
@@ -1537,6 +1553,22 @@ authenticating with a certificate; the CA cert is useful if
 you are using a self-signed server certificate. The Secret must
 be of type <code>Opaque</code> or <code>kubernetes.io/tls</code>.</p>
 <p>This field is only supported for the <code>generic</code> provider.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>proxySecretRef</code><br>
+<em>
+<a href="https://pkg.go.dev/github.com/fluxcd/pkg/apis/meta#LocalObjectReference">
+github.com/fluxcd/pkg/apis/meta.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ProxySecretRef specifies the Secret containing the proxy configuration
+to use while communicating with the Bucket server.</p>
+<p>Only supported for the generic provider.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta2/buckets.md
+++ b/docs/spec/v1beta2/buckets.md
@@ -824,6 +824,41 @@ stringData:
   ca.crt: <PEM-encoded cert>
 ```
 
+### Proxy secret reference
+
+`.spec.proxySecretRef.name` is an optional field used to specify the name of a
+Secret that contains the proxy settings for the object. These settings are used
+for all the remote operations related to the Bucket.
+The Secret can contain three keys:
+
+- `address`, to specify the address of the proxy server. This is a required key.
+- `username`, to specify the username to use if the proxy server is protected by
+   basic authentication. This is an optional key.
+- `password`, to specify the password to use if the proxy server is protected by
+   basic authentication. This is an optional key.
+
+This API is only supported for the `generic` [provider](#provider).
+
+Example:
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: http-proxy
+type: Opaque
+stringData:
+  address: http://proxy.com
+  username: mandalorian
+  password: grogu
+```
+
+Proxying can also be configured in the source-controller Deployment directly by
+using the standard environment variables such as `HTTPS_PROXY`, `ALL_PROXY`, etc.
+
+`.spec.proxySecretRef.name` takes precedence over all environment variables.
+
 ### Insecure
 
 `.spec.insecure` is an optional field to allow connecting to an insecure (HTTP)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/distribution/distribution/v3 v3.0.0-alpha.1
 	github.com/docker/cli v24.0.9+incompatible
 	github.com/docker/go-units v0.5.0
+	github.com/elazarl/goproxy v0.0.0-20231117061959-7cc037d33fb5
 	github.com/fluxcd/cli-utils v0.36.0-flux.7
 	github.com/fluxcd/pkg/apis/event v0.9.0
 	github.com/fluxcd/pkg/apis/meta v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -311,6 +311,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elazarl/goproxy v0.0.0-20231117061959-7cc037d33fb5 h1:m62nsMU279qRD9PQSWD1l66kmkXzuYcnVJqL4XLeV2M=
 github.com/elazarl/goproxy v0.0.0-20231117061959-7cc037d33fb5/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful/v3 v3.12.0 h1:y2DdzBAURM29NFF94q6RaY4vjIH1rtwDapwQtU84iWk=
 github.com/emicklei/go-restful/v3 v3.12.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/proto v1.12.1 h1:6n/Z2pZAnBwuhU66Gs8160B8rrrYKo7h2F2sCOnNceE=
@@ -831,6 +833,7 @@ github.com/redis/go-redis/v9 v9.5.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -21,6 +21,7 @@ import (
 	stdtls "crypto/tls"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -468,7 +469,23 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
 			return sreconcile.ResultEmpty, e
 		}
-		if provider, err = minio.NewClient(obj, secret, tlsConfig); err != nil {
+		proxyURL, err := r.getProxyURL(ctx, obj)
+		if err != nil {
+			e := serror.NewGeneric(err, sourcev1.AuthenticationFailedReason)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
+			return sreconcile.ResultEmpty, e
+		}
+		var opts []minio.Option
+		if secret != nil {
+			opts = append(opts, minio.WithSecret(secret))
+		}
+		if tlsConfig != nil {
+			opts = append(opts, minio.WithTLSConfig(tlsConfig))
+		}
+		if proxyURL != nil {
+			opts = append(opts, minio.WithProxyURL(proxyURL))
+		}
+		if provider, err = minio.NewClient(obj, opts...); err != nil {
 			e := serror.NewGeneric(err, "ClientError")
 			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
 			return sreconcile.ResultEmpty, e
@@ -701,6 +718,30 @@ func (r *BucketReconciler) getTLSConfig(ctx context.Context, obj *bucketv1.Bucke
 		return nil, fmt.Errorf("certificate secret does not contain any TLS configuration")
 	}
 	return tlsConfig, nil
+}
+
+func (r *BucketReconciler) getProxyURL(ctx context.Context, obj *bucketv1.Bucket) (*url.URL, error) {
+	namespace := obj.GetNamespace()
+	proxySecret, err := r.getSecret(ctx, obj.Spec.ProxySecretRef, namespace)
+	if err != nil || proxySecret == nil {
+		return nil, err
+	}
+	proxyData := proxySecret.Data
+	address, ok := proxyData["address"]
+	if !ok {
+		return nil, fmt.Errorf("invalid proxy secret '%s/%s': key 'address' is missing",
+			obj.Spec.ProxySecretRef.Name, namespace)
+	}
+	proxyURL, err := url.Parse(string(address))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse proxy address '%s': %w", address, err)
+	}
+	user, hasUser := proxyData["username"]
+	password, hasPassword := proxyData["password"]
+	if hasUser || hasPassword {
+		proxyURL.User = url.UserPassword(string(user), string(password))
+	}
+	return proxyURL, nil
 }
 
 // eventLogf records events, and logs at the same time.


### PR DESCRIPTION
Fixes #1493 