### PR TITLE
Fix incorrect use of format strings with the `conditions` package.

### DIFF
--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -286,7 +286,7 @@ func (r *BucketReconciler) reconcile(ctx context.Context, sp *patch.SerialPatche
 			fmt.Errorf("failed to create temporary working directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	defer func() {
@@ -427,7 +427,7 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 	secret, err := r.getSecret(ctx, obj.Spec.SecretRef, obj.GetNamespace())
 	if err != nil {
 		e := serror.NewGeneric(err, sourcev1.AuthenticationFailedReason)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		// Return error as the world as observed may change
 		return sreconcile.ResultEmpty, e
 	}
@@ -438,35 +438,35 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 	case bucketv1.GoogleBucketProvider:
 		if err = gcp.ValidateSecret(secret); err != nil {
 			e := serror.NewGeneric(err, sourcev1.AuthenticationFailedReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 		if provider, err = gcp.NewClient(ctx, secret); err != nil {
 			e := serror.NewGeneric(err, "ClientError")
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	case bucketv1.AzureBucketProvider:
 		if err = azure.ValidateSecret(secret); err != nil {
 			e := serror.NewGeneric(err, sourcev1.AuthenticationFailedReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 		if provider, err = azure.NewClient(obj, secret); err != nil {
 			e := serror.NewGeneric(err, "ClientError")
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	default:
 		if err = minio.ValidateSecret(secret); err != nil {
 			e := serror.NewGeneric(err, sourcev1.AuthenticationFailedReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 		tlsConfig, err := r.getTLSConfig(ctx, obj)
 		if err != nil {
 			e := serror.NewGeneric(err, sourcev1.AuthenticationFailedReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 		proxyURL, err := r.getProxyURL(ctx, obj)
@@ -487,7 +487,7 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 		}
 		if provider, err = minio.NewClient(obj, opts...); err != nil {
 			e := serror.NewGeneric(err, "ClientError")
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -495,7 +495,7 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 	// Fetch etag index
 	if err = fetchEtagIndex(ctx, provider, obj, index, dir); err != nil {
 		e := serror.NewGeneric(err, bucketv1.BucketOperationFailedReason)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -527,7 +527,7 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 
 		if err = fetchIndexFiles(ctx, provider, obj, index, dir); err != nil {
 			e := serror.NewGeneric(err, bucketv1.BucketOperationFailedReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -579,14 +579,14 @@ func (r *BucketReconciler) reconcileArtifact(ctx context.Context, sp *patch.Seri
 			fmt.Errorf("failed to stat source path: %w", err),
 			sourcev1.StatOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	} else if !f.IsDir() {
 		e := serror.NewGeneric(
 			fmt.Errorf("source path '%s' is not a directory", dir),
 			sourcev1.InvalidPathReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -596,7 +596,7 @@ func (r *BucketReconciler) reconcileArtifact(ctx context.Context, sp *patch.Seri
 			fmt.Errorf("failed to create artifact directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	unlock, err := r.Storage.Lock(artifact)
@@ -614,7 +614,7 @@ func (r *BucketReconciler) reconcileArtifact(ctx context.Context, sp *patch.Seri
 			fmt.Errorf("unable to archive artifact to storage: %s", err),
 			sourcev1.ArchiveOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -286,7 +286,7 @@ func (r *BucketReconciler) reconcile(ctx context.Context, sp *patch.SerialPatche
 			fmt.Errorf("failed to create temporary working directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	defer func() {
@@ -427,7 +427,7 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 	secret, err := r.getSecret(ctx, obj.Spec.SecretRef, obj.GetNamespace())
 	if err != nil {
 		e := serror.NewGeneric(err, sourcev1.AuthenticationFailedReason)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		// Return error as the world as observed may change
 		return sreconcile.ResultEmpty, e
 	}
@@ -438,35 +438,35 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 	case bucketv1.GoogleBucketProvider:
 		if err = gcp.ValidateSecret(secret); err != nil {
 			e := serror.NewGeneric(err, sourcev1.AuthenticationFailedReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 		if provider, err = gcp.NewClient(ctx, secret); err != nil {
 			e := serror.NewGeneric(err, "ClientError")
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	case bucketv1.AzureBucketProvider:
 		if err = azure.ValidateSecret(secret); err != nil {
 			e := serror.NewGeneric(err, sourcev1.AuthenticationFailedReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 		if provider, err = azure.NewClient(obj, secret); err != nil {
 			e := serror.NewGeneric(err, "ClientError")
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	default:
 		if err = minio.ValidateSecret(secret); err != nil {
 			e := serror.NewGeneric(err, sourcev1.AuthenticationFailedReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 		tlsConfig, err := r.getTLSConfig(ctx, obj)
 		if err != nil {
 			e := serror.NewGeneric(err, sourcev1.AuthenticationFailedReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 		proxyURL, err := r.getProxyURL(ctx, obj)
@@ -487,7 +487,7 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 		}
 		if provider, err = minio.NewClient(obj, opts...); err != nil {
 			e := serror.NewGeneric(err, "ClientError")
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -495,7 +495,7 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 	// Fetch etag index
 	if err = fetchEtagIndex(ctx, provider, obj, index, dir); err != nil {
 		e := serror.NewGeneric(err, bucketv1.BucketOperationFailedReason)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -516,7 +516,7 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 
 			message := fmt.Sprintf("new upstream revision '%s'", revision)
 			if obj.GetArtifact() != nil {
-				conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "NewRevision", message)
+				conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "NewRevision", "%s", message)
 			}
 			rreconcile.ProgressiveStatus(true, obj, meta.ProgressingReason, "building artifact: %s", message)
 			if err := sp.Patch(ctx, obj, r.patchOptions...); err != nil {
@@ -527,7 +527,7 @@ func (r *BucketReconciler) reconcileSource(ctx context.Context, sp *patch.Serial
 
 		if err = fetchIndexFiles(ctx, provider, obj, index, dir); err != nil {
 			e := serror.NewGeneric(err, bucketv1.BucketOperationFailedReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -579,14 +579,14 @@ func (r *BucketReconciler) reconcileArtifact(ctx context.Context, sp *patch.Seri
 			fmt.Errorf("failed to stat source path: %w", err),
 			sourcev1.StatOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	} else if !f.IsDir() {
 		e := serror.NewGeneric(
 			fmt.Errorf("source path '%s' is not a directory", dir),
 			sourcev1.InvalidPathReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -596,7 +596,7 @@ func (r *BucketReconciler) reconcileArtifact(ctx context.Context, sp *patch.Seri
 			fmt.Errorf("failed to create artifact directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	unlock, err := r.Storage.Lock(artifact)
@@ -614,7 +614,7 @@ func (r *BucketReconciler) reconcileArtifact(ctx context.Context, sp *patch.Seri
 			fmt.Errorf("unable to archive artifact to storage: %s", err),
 			sourcev1.ArchiveOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -279,7 +279,7 @@ func (r *GitRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Seria
 			fmt.Errorf("failed to create temporary working directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	defer func() {
@@ -486,7 +486,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to configure proxy options: %w", err),
 				sourcev1.AuthenticationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			// Return error as the world as observed may change
 			return sreconcile.ResultEmpty, e
 		}
@@ -498,7 +498,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to parse url '%s': %w", obj.Spec.URL, err),
 			sourcev1.URLInvalidReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -508,7 +508,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to configure authentication options: %w", err),
 			sourcev1.AuthenticationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		// Return error as the world as observed may change
 		return sreconcile.ResultEmpty, e
 	}
@@ -544,7 +544,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("git repository is empty"),
 			"EmptyGitRepository",
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	// Assign the commit to the shared commit reference.
@@ -703,14 +703,14 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 			fmt.Errorf("failed to stat target artifact path: %w", err),
 			sourcev1.StatOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	} else if !f.IsDir() {
 		e := serror.NewGeneric(
 			fmt.Errorf("invalid target path: '%s' is not a directory", dir),
 			sourcev1.InvalidPathReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -720,7 +720,7 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 			fmt.Errorf("failed to create artifact directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	unlock, err := r.Storage.Lock(artifact)
@@ -751,7 +751,7 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 			fmt.Errorf("unable to archive artifact to storage: %w", err),
 			sourcev1.ArchiveOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -800,7 +800,7 @@ func (r *GitRepositoryReconciler) reconcileInclude(ctx context.Context, sp *patc
 				fmt.Errorf("path calculation for include '%s' failed: %w", incl.GitRepositoryRef.Name, err),
 				"IllegalPath",
 			)
-			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 
@@ -821,7 +821,7 @@ func (r *GitRepositoryReconciler) reconcileInclude(ctx context.Context, sp *patc
 				fmt.Errorf("failed to copy '%s' include from %s to %s: %w", incl.GitRepositoryRef.Name, incl.GetFromPath(), incl.GetToPath(), err),
 				"CopyFailure",
 			)
-			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -872,7 +872,7 @@ func (r *GitRepositoryReconciler) gitCheckout(ctx context.Context, obj *sourcev1
 			fmt.Errorf("failed to create Git client: %w", err),
 			sourcev1.GitOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return nil, e
 	}
 	defer gitReader.Close()
@@ -883,7 +883,7 @@ func (r *GitRepositoryReconciler) gitCheckout(ctx context.Context, obj *sourcev1
 			fmt.Errorf("failed to checkout and determine revision: %w", err),
 			sourcev1.GitOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return nil, e
 	}
 
@@ -902,7 +902,7 @@ func (r *GitRepositoryReconciler) fetchIncludes(ctx context.Context, obj *source
 				"NotFound",
 			)
 			e.RequeueAfter = r.requeueDependency
-			conditions.MarkTrue(obj, sourcev1.IncludeUnavailableCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.IncludeUnavailableCondition, e.Reason, "%s", e)
 			return nil, e
 		}
 
@@ -913,7 +913,7 @@ func (r *GitRepositoryReconciler) fetchIncludes(ctx context.Context, obj *source
 				"NoArtifact",
 			)
 			e.RequeueAfter = r.requeueDependency
-			conditions.MarkTrue(obj, sourcev1.IncludeUnavailableCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.IncludeUnavailableCondition, e.Reason, "%s", e)
 			return nil, e
 		}
 
@@ -953,7 +953,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 			fmt.Errorf("PGP public keys secret error: %w", err),
 			"VerificationError",
 		)
-		conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%v", e)
+		conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -974,7 +974,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 				errors.New("cannot verify tag object's signature if a tag reference is not specified"),
 				"InvalidVerificationMode",
 			)
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, err.Reason, "%v", err)
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, err.Reason, "%s", err)
 			return sreconcile.ResultEmpty, err
 		}
 		if !git.IsSignedTag(*tag) {
@@ -985,7 +985,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 				fmt.Errorf("cannot verify signature of tag '%s' since it is not signed", commit.ReferencingTag.String()),
 				"InvalidGitObject",
 			)
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, err.Reason, "%v", err)
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, err.Reason, "%s", err)
 			return sreconcile.ResultEmpty, err
 		}
 
@@ -996,7 +996,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 				fmt.Errorf("signature verification of tag '%s' failed: %w", tag.String(), err),
 				"InvalidTagSignature",
 			)
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%v", e)
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%s", e)
 			// Return error in the hope the secret changes
 			return sreconcile.ResultEmpty, e
 		}
@@ -1012,7 +1012,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 				fmt.Errorf("signature verification of commit '%s' failed: %w", commit.Hash.String(), err),
 				"InvalidCommitSignature",
 			)
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%v", e)
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%s", e)
 			// Return error in the hope the secret changes
 			return sreconcile.ResultEmpty, e
 		}

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -279,7 +279,7 @@ func (r *GitRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Seria
 			fmt.Errorf("failed to create temporary working directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	defer func() {
@@ -486,7 +486,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to configure proxy options: %w", err),
 				sourcev1.AuthenticationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			// Return error as the world as observed may change
 			return sreconcile.ResultEmpty, e
 		}
@@ -498,7 +498,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to parse url '%s': %w", obj.Spec.URL, err),
 			sourcev1.URLInvalidReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -508,7 +508,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to configure authentication options: %w", err),
 			sourcev1.AuthenticationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		// Return error as the world as observed may change
 		return sreconcile.ResultEmpty, e
 	}
@@ -523,7 +523,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 	if artifacts.Diff(obj.Status.IncludedArtifacts) {
 		message := "included artifacts differ from last observed includes"
 		if obj.Status.IncludedArtifacts != nil {
-			conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "IncludeChange", message)
+			conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "IncludeChange", "%s", message)
 		}
 		rreconcile.ProgressiveStatus(true, obj, meta.ProgressingReason, "building artifact: %s", message)
 		if err := sp.Patch(ctx, obj, r.patchOptions...); err != nil {
@@ -544,7 +544,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("git repository is empty"),
 			"EmptyGitRepository",
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	// Assign the commit to the shared commit reference.
@@ -597,7 +597,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 	if !obj.GetArtifact().HasRevision(commitReference(obj, commit)) {
 		message := fmt.Sprintf("new upstream revision '%s'", commitReference(obj, commit))
 		if obj.GetArtifact() != nil {
-			conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "NewRevision", message)
+			conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "NewRevision", "%s", message)
 		}
 		rreconcile.ProgressiveStatus(true, obj, meta.ProgressingReason, "building artifact: %s", message)
 		if err := sp.Patch(ctx, obj, r.patchOptions...); err != nil {
@@ -703,14 +703,14 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 			fmt.Errorf("failed to stat target artifact path: %w", err),
 			sourcev1.StatOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	} else if !f.IsDir() {
 		e := serror.NewGeneric(
 			fmt.Errorf("invalid target path: '%s' is not a directory", dir),
 			sourcev1.InvalidPathReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -720,7 +720,7 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 			fmt.Errorf("failed to create artifact directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	unlock, err := r.Storage.Lock(artifact)
@@ -751,7 +751,7 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 			fmt.Errorf("unable to archive artifact to storage: %w", err),
 			sourcev1.ArchiveOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -800,7 +800,7 @@ func (r *GitRepositoryReconciler) reconcileInclude(ctx context.Context, sp *patc
 				fmt.Errorf("path calculation for include '%s' failed: %w", incl.GitRepositoryRef.Name, err),
 				"IllegalPath",
 			)
-			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 
@@ -821,7 +821,7 @@ func (r *GitRepositoryReconciler) reconcileInclude(ctx context.Context, sp *patc
 				fmt.Errorf("failed to copy '%s' include from %s to %s: %w", incl.GitRepositoryRef.Name, incl.GetFromPath(), incl.GetToPath(), err),
 				"CopyFailure",
 			)
-			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -872,7 +872,7 @@ func (r *GitRepositoryReconciler) gitCheckout(ctx context.Context, obj *sourcev1
 			fmt.Errorf("failed to create Git client: %w", err),
 			sourcev1.GitOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return nil, e
 	}
 	defer gitReader.Close()
@@ -883,7 +883,7 @@ func (r *GitRepositoryReconciler) gitCheckout(ctx context.Context, obj *sourcev1
 			fmt.Errorf("failed to checkout and determine revision: %w", err),
 			sourcev1.GitOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return nil, e
 	}
 
@@ -902,7 +902,7 @@ func (r *GitRepositoryReconciler) fetchIncludes(ctx context.Context, obj *source
 				"NotFound",
 			)
 			e.RequeueAfter = r.requeueDependency
-			conditions.MarkTrue(obj, sourcev1.IncludeUnavailableCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.IncludeUnavailableCondition, e.Reason, "%v", e)
 			return nil, e
 		}
 
@@ -913,7 +913,7 @@ func (r *GitRepositoryReconciler) fetchIncludes(ctx context.Context, obj *source
 				"NoArtifact",
 			)
 			e.RequeueAfter = r.requeueDependency
-			conditions.MarkTrue(obj, sourcev1.IncludeUnavailableCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.IncludeUnavailableCondition, e.Reason, "%v", e)
 			return nil, e
 		}
 
@@ -953,7 +953,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 			fmt.Errorf("PGP public keys secret error: %w", err),
 			"VerificationError",
 		)
-		conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, e.Err.Error())
+		conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -974,7 +974,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 				errors.New("cannot verify tag object's signature if a tag reference is not specified"),
 				"InvalidVerificationMode",
 			)
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, err.Reason, err.Err.Error())
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, err.Reason, "%v", err)
 			return sreconcile.ResultEmpty, err
 		}
 		if !git.IsSignedTag(*tag) {
@@ -985,7 +985,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 				fmt.Errorf("cannot verify signature of tag '%s' since it is not signed", commit.ReferencingTag.String()),
 				"InvalidGitObject",
 			)
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, err.Reason, err.Err.Error())
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, err.Reason, "%v", err)
 			return sreconcile.ResultEmpty, err
 		}
 
@@ -996,7 +996,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 				fmt.Errorf("signature verification of tag '%s' failed: %w", tag.String(), err),
 				"InvalidTagSignature",
 			)
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, e.Err.Error())
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%v", e)
 			// Return error in the hope the secret changes
 			return sreconcile.ResultEmpty, e
 		}
@@ -1012,7 +1012,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 				fmt.Errorf("signature verification of commit '%s' failed: %w", commit.Hash.String(), err),
 				"InvalidCommitSignature",
 			)
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, e.Err.Error())
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%v", e)
 			// Return error in the hope the secret changes
 			return sreconcile.ResultEmpty, e
 		}
@@ -1027,7 +1027,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 	reason := meta.SucceededReason
 	mode := obj.Spec.Verification.GetMode()
 	obj.Status.SourceVerificationMode = &mode
-	conditions.MarkTrue(obj, sourcev1.SourceVerifiedCondition, reason, message.String())
+	conditions.MarkTrue(obj, sourcev1.SourceVerifiedCondition, reason, "%v", message)
 	r.eventLogf(ctx, obj, eventv1.EventTypeTrace, reason, message.String())
 	return sreconcile.ResultSuccess, nil
 }

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -1027,7 +1027,7 @@ func (r *GitRepositoryReconciler) verifySignature(ctx context.Context, obj *sour
 	reason := meta.SucceededReason
 	mode := obj.Spec.Verification.GetMode()
 	obj.Status.SourceVerificationMode = &mode
-	conditions.MarkTrue(obj, sourcev1.SourceVerifiedCondition, reason, "%v", message)
+	conditions.MarkTrue(obj, sourcev1.SourceVerifiedCondition, reason, "%s", message.String())
 	r.eventLogf(ctx, obj, eventv1.EventTypeTrace, reason, message.String())
 	return sreconcile.ResultSuccess, nil
 }

--- a/internal/controller/helmchart_controller.go
+++ b/internal/controller/helmchart_controller.go
@@ -437,7 +437,7 @@ func (r *HelmChartReconciler) reconcileSource(ctx context.Context, sp *patch.Ser
 			fmt.Errorf("failed to get source: %w", err),
 			"SourceUnavailable",
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 
 		// Return Kubernetes client errors, but ignore others which can only be
 		// solved by a change in generation
@@ -533,7 +533,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 			err,
 			sourcev1.AuthenticationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	if certsTmpDir != "" {
@@ -566,7 +566,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 				fmt.Errorf("failed to construct Helm client: %w", err),
 				meta.FailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 
@@ -591,7 +591,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 					fmt.Errorf("failed to verify the signature using provider '%s': %w", provider, err),
 					sourcev1.VerificationError,
 				)
-				conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, e.Err.Error())
+				conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%v", e)
 				return sreconcile.ResultEmpty, e
 			}
 		}
@@ -622,7 +622,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 					fmt.Errorf("failed to login to OCI registry: %w", err),
 					sourcev1.AuthenticationFailedReason,
 				)
-				conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+				conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 				return sreconcile.ResultEmpty, e
 			}
 		}
@@ -708,7 +708,7 @@ func (r *HelmChartReconciler) buildFromTarballArtifact(ctx context.Context, obj 
 			fmt.Errorf("failed to create temporary working directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	defer os.RemoveAll(tmpDir)
@@ -720,7 +720,7 @@ func (r *HelmChartReconciler) buildFromTarballArtifact(ctx context.Context, obj 
 			fmt.Errorf("failed to create directory to untar source into: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -731,7 +731,7 @@ func (r *HelmChartReconciler) buildFromTarballArtifact(ctx context.Context, obj 
 			fmt.Errorf("failed to open source artifact: %w", err),
 			sourcev1.ReadOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	if err = tar.Untar(f, sourceDir, tar.WithMaxUntarSize(-1)); err != nil {
@@ -839,7 +839,7 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, _ *patch.Se
 	defer func() {
 		if obj.Status.ObservedChartName == b.Name && obj.GetArtifact().HasRevision(b.Version) {
 			conditions.Delete(obj, sourcev1.ArtifactOutdatedCondition)
-			conditions.MarkTrue(obj, sourcev1.ArtifactInStorageCondition, reasonForBuild(b), b.Summary())
+			conditions.MarkTrue(obj, sourcev1.ArtifactInStorageCondition, reasonForBuild(b), "%s", b.Summary())
 		}
 	}()
 
@@ -861,7 +861,7 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, _ *patch.Se
 			fmt.Errorf("failed to create artifact directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	unlock, err := r.Storage.Lock(artifact)
@@ -870,7 +870,7 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, _ *patch.Se
 			fmt.Errorf("failed to acquire lock for artifact: %w", err),
 			sourcev1.AcquireLockFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	defer unlock()
@@ -881,7 +881,7 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, _ *patch.Se
 			fmt.Errorf("unable to copy Helm chart to storage: %w", err),
 			sourcev1.ArchiveOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -1246,7 +1246,7 @@ func observeChartBuild(ctx context.Context, sp *patch.SerialPatcher, pOpts []pat
 	if build.HasMetadata() {
 		if build.Name != obj.Status.ObservedChartName || !obj.GetArtifact().HasRevision(build.Version) {
 			if obj.GetArtifact() != nil {
-				conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "NewChart", build.Summary())
+				conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "NewChart", "%s", build.Summary())
 			}
 			rreconcile.ProgressiveStatus(true, obj, meta.ProgressingReason, "building artifact: %s", build.Summary())
 			if err := sp.Patch(ctx, obj, pOpts...); err != nil {
@@ -1259,7 +1259,7 @@ func observeChartBuild(ctx context.Context, sp *patch.SerialPatcher, pOpts []pat
 		conditions.Delete(obj, sourcev1.FetchFailedCondition)
 		conditions.Delete(obj, sourcev1.BuildFailedCondition)
 		if build.VerifiedResult == oci.VerificationResultSuccess {
-			conditions.MarkTrue(obj, sourcev1.SourceVerifiedCondition, meta.SucceededReason, fmt.Sprintf("verified signature of version %s", build.Version))
+			conditions.MarkTrue(obj, sourcev1.SourceVerifiedCondition, meta.SucceededReason, "verified signature of version %s", build.Version)
 		}
 	}
 
@@ -1279,14 +1279,14 @@ func observeChartBuild(ctx context.Context, sp *patch.SerialPatcher, pOpts []pat
 		switch buildErr.Reason {
 		case chart.ErrChartMetadataPatch, chart.ErrValuesFilesMerge, chart.ErrDependencyBuild, chart.ErrChartPackage:
 			conditions.Delete(obj, sourcev1.FetchFailedCondition)
-			conditions.MarkTrue(obj, sourcev1.BuildFailedCondition, buildErr.Reason.Reason, buildErr.Error())
+			conditions.MarkTrue(obj, sourcev1.BuildFailedCondition, buildErr.Reason.Reason, "%v", buildErr)
 		case chart.ErrChartVerification:
 			conditions.Delete(obj, sourcev1.FetchFailedCondition)
-			conditions.MarkTrue(obj, sourcev1.BuildFailedCondition, buildErr.Reason.Reason, buildErr.Error())
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, sourcev1.VerificationError, buildErr.Error())
+			conditions.MarkTrue(obj, sourcev1.BuildFailedCondition, buildErr.Reason.Reason, "%v", buildErr)
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, sourcev1.VerificationError, "%v", buildErr)
 		default:
 			conditions.Delete(obj, sourcev1.BuildFailedCondition)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, buildErr.Reason.Reason, buildErr.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, buildErr.Reason.Reason, "%v", buildErr)
 		}
 		return
 	}
@@ -1309,14 +1309,14 @@ func chartRepoConfigErrorReturn(err error, obj *sourcev1.HelmChart) (sreconcile.
 			fmt.Errorf("invalid Helm repository URL: %w", err),
 			sourcev1.URLInvalidReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	default:
 		e := serror.NewStalling(
 			fmt.Errorf("failed to construct Helm client: %w", err),
 			meta.FailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 }

--- a/internal/controller/helmchart_controller.go
+++ b/internal/controller/helmchart_controller.go
@@ -437,7 +437,7 @@ func (r *HelmChartReconciler) reconcileSource(ctx context.Context, sp *patch.Ser
 			fmt.Errorf("failed to get source: %w", err),
 			"SourceUnavailable",
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 
 		// Return Kubernetes client errors, but ignore others which can only be
 		// solved by a change in generation
@@ -533,7 +533,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 			err,
 			sourcev1.AuthenticationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	if certsTmpDir != "" {
@@ -566,7 +566,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 				fmt.Errorf("failed to construct Helm client: %w", err),
 				meta.FailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 
@@ -591,7 +591,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 					fmt.Errorf("failed to verify the signature using provider '%s': %w", provider, err),
 					sourcev1.VerificationError,
 				)
-				conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%v", e)
+				conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%s", e)
 				return sreconcile.ResultEmpty, e
 			}
 		}
@@ -622,7 +622,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 					fmt.Errorf("failed to login to OCI registry: %w", err),
 					sourcev1.AuthenticationFailedReason,
 				)
-				conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+				conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 				return sreconcile.ResultEmpty, e
 			}
 		}
@@ -708,7 +708,7 @@ func (r *HelmChartReconciler) buildFromTarballArtifact(ctx context.Context, obj 
 			fmt.Errorf("failed to create temporary working directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	defer os.RemoveAll(tmpDir)
@@ -720,7 +720,7 @@ func (r *HelmChartReconciler) buildFromTarballArtifact(ctx context.Context, obj 
 			fmt.Errorf("failed to create directory to untar source into: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -731,7 +731,7 @@ func (r *HelmChartReconciler) buildFromTarballArtifact(ctx context.Context, obj 
 			fmt.Errorf("failed to open source artifact: %w", err),
 			sourcev1.ReadOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	if err = tar.Untar(f, sourceDir, tar.WithMaxUntarSize(-1)); err != nil {
@@ -861,7 +861,7 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, _ *patch.Se
 			fmt.Errorf("failed to create artifact directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	unlock, err := r.Storage.Lock(artifact)
@@ -870,7 +870,7 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, _ *patch.Se
 			fmt.Errorf("failed to acquire lock for artifact: %w", err),
 			sourcev1.AcquireLockFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	defer unlock()
@@ -881,7 +881,7 @@ func (r *HelmChartReconciler) reconcileArtifact(ctx context.Context, _ *patch.Se
 			fmt.Errorf("unable to copy Helm chart to storage: %w", err),
 			sourcev1.ArchiveOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -1279,14 +1279,14 @@ func observeChartBuild(ctx context.Context, sp *patch.SerialPatcher, pOpts []pat
 		switch buildErr.Reason {
 		case chart.ErrChartMetadataPatch, chart.ErrValuesFilesMerge, chart.ErrDependencyBuild, chart.ErrChartPackage:
 			conditions.Delete(obj, sourcev1.FetchFailedCondition)
-			conditions.MarkTrue(obj, sourcev1.BuildFailedCondition, buildErr.Reason.Reason, "%v", buildErr)
+			conditions.MarkTrue(obj, sourcev1.BuildFailedCondition, buildErr.Reason.Reason, "%s", buildErr)
 		case chart.ErrChartVerification:
 			conditions.Delete(obj, sourcev1.FetchFailedCondition)
-			conditions.MarkTrue(obj, sourcev1.BuildFailedCondition, buildErr.Reason.Reason, "%v", buildErr)
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, sourcev1.VerificationError, "%v", buildErr)
+			conditions.MarkTrue(obj, sourcev1.BuildFailedCondition, buildErr.Reason.Reason, "%s", buildErr)
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, sourcev1.VerificationError, "%s", buildErr)
 		default:
 			conditions.Delete(obj, sourcev1.BuildFailedCondition)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, buildErr.Reason.Reason, "%v", buildErr)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, buildErr.Reason.Reason, "%s", buildErr)
 		}
 		return
 	}
@@ -1309,14 +1309,14 @@ func chartRepoConfigErrorReturn(err error, obj *sourcev1.HelmChart) (sreconcile.
 			fmt.Errorf("invalid Helm repository URL: %w", err),
 			sourcev1.URLInvalidReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	default:
 		e := serror.NewStalling(
 			fmt.Errorf("failed to construct Helm client: %w", err),
 			meta.FailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 }

--- a/internal/controller/helmrepository_controller.go
+++ b/internal/controller/helmrepository_controller.go
@@ -402,7 +402,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 			fmt.Errorf("invalid Helm repository URL: %w", err),
 			sourcev1.URLInvalidReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -412,7 +412,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 			fmt.Errorf("invalid Helm repository URL: %w", err),
 			sourcev1.URLInvalidReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -426,7 +426,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 				err,
 				sourcev1.AuthenticationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -440,14 +440,14 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 				fmt.Errorf("invalid Helm repository URL: %w", err),
 				sourcev1.URLInvalidReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		default:
 			e := serror.NewStalling(
 				fmt.Errorf("failed to construct Helm client: %w", err),
 				meta.FailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -458,7 +458,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 			fmt.Errorf("failed to fetch Helm repository index: %w", err),
 			meta.FailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		// Coin flip on transient or persistent error, return error and hope for the best
 		return sreconcile.ResultEmpty, e
 	}
@@ -484,7 +484,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 			fmt.Errorf("failed to load Helm repository from index YAML: %w", err),
 			sourcev1.IndexationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	// Delete any stale failure observation
@@ -497,14 +497,14 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 			fmt.Errorf("failed to calculate revision: %w", err),
 			sourcev1.IndexationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
 	// Mark observations about the revision on the object.
 	message := fmt.Sprintf("new index revision '%s'", revision)
 	if obj.GetArtifact() != nil {
-		conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "NewRevision", message)
+		conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "NewRevision", "%s", message)
 	}
 	rreconcile.ProgressiveStatus(true, obj, meta.ProgressingReason, "building artifact: %s", message)
 	if err := sp.Patch(ctx, obj, r.patchOptions...); err != nil {
@@ -559,7 +559,7 @@ func (r *HelmRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pa
 			fmt.Errorf("failed to create artifact directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -580,7 +580,7 @@ func (r *HelmRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pa
 			fmt.Errorf("unable to get JSON index from chart repo: %w", err),
 			sourcev1.ArchiveOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	if err = r.Storage.Copy(artifact, bytes.NewBuffer(b)); err != nil {
@@ -588,7 +588,7 @@ func (r *HelmRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pa
 			fmt.Errorf("unable to save artifact to storage: %w", err),
 			sourcev1.ArchiveOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 

--- a/internal/controller/helmrepository_controller.go
+++ b/internal/controller/helmrepository_controller.go
@@ -402,7 +402,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 			fmt.Errorf("invalid Helm repository URL: %w", err),
 			sourcev1.URLInvalidReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -412,7 +412,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 			fmt.Errorf("invalid Helm repository URL: %w", err),
 			sourcev1.URLInvalidReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -426,7 +426,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 				err,
 				sourcev1.AuthenticationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -440,14 +440,14 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 				fmt.Errorf("invalid Helm repository URL: %w", err),
 				sourcev1.URLInvalidReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		default:
 			e := serror.NewStalling(
 				fmt.Errorf("failed to construct Helm client: %w", err),
 				meta.FailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -458,7 +458,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 			fmt.Errorf("failed to fetch Helm repository index: %w", err),
 			meta.FailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		// Coin flip on transient or persistent error, return error and hope for the best
 		return sreconcile.ResultEmpty, e
 	}
@@ -484,7 +484,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 			fmt.Errorf("failed to load Helm repository from index YAML: %w", err),
 			sourcev1.IndexationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	// Delete any stale failure observation
@@ -497,7 +497,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 			fmt.Errorf("failed to calculate revision: %w", err),
 			sourcev1.IndexationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -559,7 +559,7 @@ func (r *HelmRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pa
 			fmt.Errorf("failed to create artifact directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -580,7 +580,7 @@ func (r *HelmRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pa
 			fmt.Errorf("unable to get JSON index from chart repo: %w", err),
 			sourcev1.ArchiveOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	if err = r.Storage.Copy(artifact, bytes.NewBuffer(b)); err != nil {
@@ -588,7 +588,7 @@ func (r *HelmRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pa
 			fmt.Errorf("unable to save artifact to storage: %w", err),
 			sourcev1.ArchiveOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 

--- a/internal/controller/ocirepository_controller.go
+++ b/internal/controller/ocirepository_controller.go
@@ -286,7 +286,7 @@ func (r *OCIRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Seria
 			fmt.Errorf("failed to create temporary working directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	defer func() {
@@ -349,7 +349,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to get credential: %w", err),
 			sourcev1.AuthenticationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -361,7 +361,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to get credential from %s: %w", obj.Spec.Provider, authErr),
 				sourcev1.AuthenticationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -373,7 +373,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to generate transport for '%s': %w", obj.Spec.URL, err),
 			sourcev1.AuthenticationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -386,14 +386,14 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			e := serror.NewStalling(
 				fmt.Errorf("URL validation failed for '%s': %w", obj.Spec.URL, err),
 				sourcev1.URLInvalidReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 
 		e := serror.NewGeneric(
 			fmt.Errorf("failed to determine the artifact tag for '%s': %w", obj.Spec.URL, err),
 			sourcev1.ReadOperationFailedReason)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -405,7 +405,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to determine artifact digest: %w", err),
 			ociv1.OCIPullFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	metaArtifact := &sourcev1.Artifact{Revision: revision}
@@ -447,7 +447,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to verify the signature using provider '%s': %w", provider, err),
 				sourcev1.VerificationError,
 			)
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%v", e)
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 
@@ -470,7 +470,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to pull artifact from '%s': %w", obj.Spec.URL, err),
 			ociv1.OCIPullFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -481,7 +481,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to parse artifact manifest: %w", err),
 			ociv1.OCILayerOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	metadata.Metadata = manifest.Annotations
@@ -490,7 +490,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 	blob, err := r.selectLayer(obj, img)
 	if err != nil {
 		e := serror.NewGeneric(err, ociv1.OCILayerOperationFailedReason)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -502,7 +502,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to extract layer contents from artifact: %w", err),
 				ociv1.OCILayerOperationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	case ociv1.OCILayerCopy:
@@ -513,7 +513,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to create file to copy layer to: %w", err),
 				ociv1.OCILayerOperationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 		defer file.Close()
@@ -524,7 +524,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to copy layer from artifact: %w", err),
 				ociv1.OCILayerOperationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	default:
@@ -532,7 +532,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("unsupported layer operation: %s", obj.GetLayerOperation()),
 			ociv1.OCILayerOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -1063,14 +1063,14 @@ func (r *OCIRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 			fmt.Errorf("failed to stat source path: %w", err),
 			sourcev1.StatOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	} else if !f.IsDir() {
 		e := serror.NewGeneric(
 			fmt.Errorf("source path '%s' is not a directory", dir),
 			sourcev1.InvalidPathReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -1080,7 +1080,7 @@ func (r *OCIRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 			fmt.Errorf("failed to create artifact directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
 	unlock, err := r.Storage.Lock(artifact)
@@ -1099,7 +1099,7 @@ func (r *OCIRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 				fmt.Errorf("unable to copy artifact to storage: %w", err),
 				sourcev1.ArchiveOperationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	default:
@@ -1121,7 +1121,7 @@ func (r *OCIRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 				fmt.Errorf("unable to archive artifact to storage: %s", err),
 				sourcev1.ArchiveOperationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
+			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}

--- a/internal/controller/ocirepository_controller.go
+++ b/internal/controller/ocirepository_controller.go
@@ -286,7 +286,7 @@ func (r *OCIRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Seria
 			fmt.Errorf("failed to create temporary working directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	defer func() {
@@ -349,7 +349,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to get credential: %w", err),
 			sourcev1.AuthenticationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -361,7 +361,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to get credential from %s: %w", obj.Spec.Provider, authErr),
 				sourcev1.AuthenticationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}
@@ -373,7 +373,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to generate transport for '%s': %w", obj.Spec.URL, err),
 			sourcev1.AuthenticationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -386,14 +386,14 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			e := serror.NewStalling(
 				fmt.Errorf("URL validation failed for '%s': %w", obj.Spec.URL, err),
 				sourcev1.URLInvalidReason)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 
 		e := serror.NewGeneric(
 			fmt.Errorf("failed to determine the artifact tag for '%s': %w", obj.Spec.URL, err),
 			sourcev1.ReadOperationFailedReason)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -405,7 +405,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to determine artifact digest: %w", err),
 			ociv1.OCIPullFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	metaArtifact := &sourcev1.Artifact{Revision: revision}
@@ -416,7 +416,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 		if !obj.GetArtifact().HasRevision(revision) {
 			message := fmt.Sprintf("new revision '%s' for '%s'", revision, ref)
 			if obj.GetArtifact() != nil {
-				conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "NewRevision", message)
+				conditions.MarkTrue(obj, sourcev1.ArtifactOutdatedCondition, "NewRevision", "%s", message)
 			}
 			rreconcile.ProgressiveStatus(true, obj, meta.ProgressingReason, "building artifact: %s", message)
 			if err := sp.Patch(ctx, obj, r.patchOptions...); err != nil {
@@ -447,7 +447,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to verify the signature using provider '%s': %w", provider, err),
 				sourcev1.VerificationError,
 			)
-			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, e.Err.Error())
+			conditions.MarkFalse(obj, sourcev1.SourceVerifiedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 
@@ -470,7 +470,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to pull artifact from '%s': %w", obj.Spec.URL, err),
 			ociv1.OCIPullFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -481,7 +481,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("failed to parse artifact manifest: %w", err),
 			ociv1.OCILayerOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	metadata.Metadata = manifest.Annotations
@@ -490,7 +490,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 	blob, err := r.selectLayer(obj, img)
 	if err != nil {
 		e := serror.NewGeneric(err, ociv1.OCILayerOperationFailedReason)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -502,7 +502,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to extract layer contents from artifact: %w", err),
 				ociv1.OCILayerOperationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	case ociv1.OCILayerCopy:
@@ -513,7 +513,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to create file to copy layer to: %w", err),
 				ociv1.OCILayerOperationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 		defer file.Close()
@@ -524,7 +524,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 				fmt.Errorf("failed to copy layer from artifact: %w", err),
 				ociv1.OCILayerOperationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	default:
@@ -532,7 +532,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 			fmt.Errorf("unsupported layer operation: %s", obj.GetLayerOperation()),
 			ociv1.OCILayerOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -1063,14 +1063,14 @@ func (r *OCIRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 			fmt.Errorf("failed to stat source path: %w", err),
 			sourcev1.StatOperationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	} else if !f.IsDir() {
 		e := serror.NewGeneric(
 			fmt.Errorf("source path '%s' is not a directory", dir),
 			sourcev1.InvalidPathReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 
@@ -1080,7 +1080,7 @@ func (r *OCIRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 			fmt.Errorf("failed to create artifact directory: %w", err),
 			sourcev1.DirCreationFailedReason,
 		)
-		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 		return sreconcile.ResultEmpty, e
 	}
 	unlock, err := r.Storage.Lock(artifact)
@@ -1099,7 +1099,7 @@ func (r *OCIRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 				fmt.Errorf("unable to copy artifact to storage: %w", err),
 				sourcev1.ArchiveOperationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	default:
@@ -1121,7 +1121,7 @@ func (r *OCIRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 				fmt.Errorf("unable to archive artifact to storage: %s", err),
 				sourcev1.ArchiveOperationFailedReason,
 			)
-			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, e.Err.Error())
+			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%v", e)
 			return sreconcile.ResultEmpty, e
 		}
 	}

--- a/internal/reconcile/summarize/summary.go
+++ b/internal/reconcile/summarize/summary.go
@@ -234,7 +234,7 @@ func (h *Helper) SummarizeAndPatch(ctx context.Context, obj conditions.Setter, o
 	}
 	if len(failedBiPolarity) > 0 {
 		topFailedBiPolarity := conditions.Get(obj, failedBiPolarity[0])
-		conditions.MarkFalse(obj, meta.ReadyCondition, topFailedBiPolarity.Reason, topFailedBiPolarity.Message)
+		conditions.MarkFalse(obj, meta.ReadyCondition, topFailedBiPolarity.Reason, "%s", topFailedBiPolarity.Message)
 	}
 
 	// If object is not stalled, result is success and runtime error is nil,


### PR DESCRIPTION
Many of the functions in the `conditions` package accept a format string and (optional) arguments, just like `fmt.Printf` and friends.

In many places, the code passed an error message as the format string, causing it to be interpreted by the `fmt` package. This leads to issues when the message contains percent signs, e.g. URL-encoded values.

Consider the following code:

```go
// internal/controller/ocirepository_controller.go
revision, err := r.getRevision(ref, opts)
if err != nil {
	e := serror.NewGeneric(
		fmt.Errorf("failed to determine artifact digest: %w", err),
		ociv1.OCIPullFailedReason,
	)
	conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, e.Err.Error())
	//                                                                ^^^^^^^^^^^^^
	return sreconcile.ResultEmpty, e
}
```

Since `getRevision()` includes the URL in the error message and the error message is used as a format string, the resulting condition reads:

```
failed to determine artifact digest: GET https://gitlab.com/jwt/auth?scope=repository%!A(MISSING)fforster%!F(MISSING)<REDACTED>%!F(MISSING)k8s-resource-manifests%!A(MISSING)pull&service=container_registry: DENIED: access forbidden
```

This PR adds an explicit format string and shortens `e.Error()` and `e.Err.Error()` to `e`, which yields the same output.

To the best of my knowledge, Go is safe from format string attacks. I **don't** think this is a security vulnerability, but I'm also not a security expert.