### PR TITLE
Fix podinfo URL in source_v1_helmrepository.yaml

### DIFF
--- a/config/samples/source_v1_helmrepository.yaml
+++ b/config/samples/source_v1_helmrepository.yaml
@@ -4,4 +4,4 @@ metadata:
   name: helmrepository-sample
 spec:
   interval: 1m
-  url: https://stefanprodan.github.io/podinfo
+  url: https://github.com/stefanprodan/podinfo


### PR DESCRIPTION
The URL in `config/samples/source_v1_helmrepository.yaml` seems to be pointing to an old URL returning an HTTP 404. This commit points this URL to what seems to be its new location.