### PR TITLE
azure-blob: Fix VisitObjects() in integration test

### DIFF
--- a/pkg/azure/blob_integration_test.go
+++ b/pkg/azure/blob_integration_test.go
@@ -361,7 +361,7 @@ func TestBlobClient_VisitObjects(t *testing.T) {
 	// Visit objects.
 	ctx, timeout = context.WithTimeout(context.Background(), testTimeout)
 	defer timeout()
-	got := client.VisitObjects(ctx, testContainer, func(path, etag string) error {
+	got := client.VisitObjects(ctx, testContainer, "", func(path, etag string) error {
 		visits[path] = etag
 		return nil
 	})
@@ -399,7 +399,7 @@ func TestBlobClient_VisitObjects_CallbackErr(t *testing.T) {
 	ctx, timeout = context.WithTimeout(context.Background(), testTimeout)
 	defer timeout()
 	mockErr := fmt.Errorf("mock")
-	err = client.VisitObjects(ctx, testContainer, func(path, etag string) error {
+	err = client.VisitObjects(ctx, testContainer, "", func(path, etag string) error {
 		return mockErr
 	})
 	g.Expect(err).To(HaveOccurred())


### PR DESCRIPTION
While reviewing https://github.com/fluxcd/source-controller/pull/1567, I noticed that the integration tests file had errors since the bucket prefix filtering was introduced in https://github.com/fluxcd/source-controller/pull/1228. Because we have disabled azure tests due to lack of an account, that file with `integration` build tag never gets executed in the CI. I believe even the IDEs don't detect it unless go build flag `-tags=integration` is set.