### PR TITLE
Update go toolchain to 1.22.6 [CVE-2024-24790 - 9.8 CVSS]

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/source-controller/api
 
-go 1.22.0
+go 1.22.6
 
 require (
 	github.com/fluxcd/pkg/apis/acl v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/source-controller
 
-go 1.22.0
+go 1.22.6
 
 replace github.com/fluxcd/source-controller/api => ./api
 


### PR DESCRIPTION
To fix  https://nvd.nist.gov/vuln/detail/CVE-2024-24790 / https://pkg.go.dev/vuln/GO-2024-2887

Full disclosure: Running into some issues with the tests timing out, but I'm hoping it's just my laptop cosplaying as a toaster and it'll run fine on your CI : /

