### PR TITLE
GitRepo: Remove provider default value from API

### DIFF
--- a/api/v1/gitrepository_types.go
+++ b/api/v1/gitrepository_types.go
@@ -91,7 +91,6 @@ type GitRepositorySpec struct {
 	// Provider used for authentication, can be 'azure', 'generic'.
 	// When not specified, defaults to 'generic'.
 	// +kubebuilder:validation:Enum=generic;azure
-	// +kubebuilder:default:=generic
 	// +optional
 	Provider string `json:"provider,omitempty"`
 
@@ -301,6 +300,14 @@ func (in GitRepository) GetRequeueAfter() time.Duration {
 // the status sub-resource.
 func (in *GitRepository) GetArtifact() *Artifact {
 	return in.Status.Artifact
+}
+
+// GetProvider returns the Git authentication provider.
+func (v *GitRepository) GetProvider() string {
+	if v.Spec.Provider == "" {
+		return GitProviderGeneric
+	}
+	return v.Spec.Provider
 }
 
 // GetMode returns the declared GitVerificationMode, or a ModeGitHEAD default.

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -104,7 +104,6 @@ spec:
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               provider:
-                default: generic
                 description: |-
                   Provider used for authentication, can be 'azure', 'generic'.
                   When not specified, defaults to 'generic'.

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -650,14 +650,12 @@ func (r *GitRepositoryReconciler) getAuthOpts(ctx context.Context, obj *sourcev1
 	}
 
 	// Configure provider authentication if specified in spec
-	if obj.Spec.Provider != "" && obj.Spec.Provider != sourcev1.GitProviderGeneric {
-		if obj.Spec.Provider == sourcev1.GitProviderAzure {
-			authOpts.ProviderOpts = &git.ProviderOptions{
-				Name: obj.Spec.Provider,
-				AzureOpts: []azure.OptFunc{
-					azure.WithAzureDevOpsScope(),
-				},
-			}
+	if obj.GetProvider() == sourcev1.GitProviderAzure {
+		authOpts.ProviderOpts = &git.ProviderOptions{
+			Name: obj.GetProvider(),
+			AzureOpts: []azure.OptFunc{
+				azure.WithAzureDevOpsScope(),
+			},
 		}
 	}
 


### PR DESCRIPTION
For backwards compatibility, remove the default value for GitRepository provider. An empty provider value will still be considered as the default generic provider.