### PR TITLE
Fix issue preventing `include`ed sources from being mapped to the repo root

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -64,7 +64,7 @@ var (
 )
 
 // CopyDir recursively copies a directory tree, attempting to preserve permissions.
-// Source directory must exist, destination directory must *not* exist.
+// Source directory must exist.
 func CopyDir(src, dst string) error {
 	src = filepath.Clean(src)
 	dst = filepath.Clean(dst)
@@ -82,9 +82,6 @@ func CopyDir(src, dst string) error {
 	_, err = os.Stat(dst)
 	if err != nil && !os.IsNotExist(err) {
 		return err
-	}
-	if err == nil {
-		return errDstExist
 	}
 
 	if err = os.MkdirAll(dst, fi.Mode()); err != nil {

--- a/internal/fs/rename.go
+++ b/internal/fs/rename.go
@@ -20,10 +20,12 @@ func renameFallback(err error, src, dst string) error {
 	// copy if we detect that case. syscall.EXDEV is the common name for the
 	// cross device link error which has varying output text across different
 	// operating systems.
+	// Rename may also fail if the directory already exists, which occurs when
+	// mapping to the root of another repo. Copy should still succeed.
 	terr, ok := err.(*os.LinkError)
 	if !ok {
 		return err
-	} else if terr.Err != syscall.EXDEV {
+	} else if terr.Err != syscall.EXDEV && terr.Err != syscall.EEXIST {
 		return fmt.Errorf("link error: cannot rename %s to %s: %w", src, dst, terr)
 	}
 


### PR DESCRIPTION
This PR fixes https://github.com/fluxcd/source-controller/issues/1657. With this change, it should be possible to configure a `GitRepository` like so:

```yaml
apiVersion: source.toolkit.fluxcd.io/v1
kind: GitRepository
metadata:
  name: example
spec:
  # Omitting boilerplate for brevity
  include:
    - repository:
        name: some-other-repo
      fromPath: /some/other/repos/path
      toPath: /  # This line does not work without this patch
```

This approach is nice because `Kustomizations` using the `example` `GitRepository` can now set the `path` field to `/some/subdirectory` instead of `/some/other/repos/path/some/subdirectory`, making it easier to read. I've deployed this change and an example of its usage [here](https://github.com/solidDoWant/infra-mk3/blob/259bc338e5b5b852343d0fdeb1d6de0b9c65a64f/cluster/gitops/flux-system/flux/sources/git/infra-mk3-repo.yaml). An image is available to test this [here](https://github.com/users/solidDoWant/packages/container/package/flux%2Fsource-controller).