### PR TITLE
Update Alpine to 3.21 and xx to 1.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 ARG BASE_VARIANT=alpine
 ARG GO_VERSION=1.23
-ARG XX_VERSION=1.4.0
+ARG XX_VERSION=1.6.1
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} as gostable
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS gostable
 
 FROM gostable AS go-linux
 
@@ -17,7 +17,7 @@ RUN apk add --no-cache clang lld
 COPY --from=xx / /
 
 # build-go-mod can still be cached at build platform architecture.
-FROM build-base as build
+FROM build-base AS build
 
 ARG TARGETPLATFORM
 
@@ -60,7 +60,7 @@ RUN export CGO_LDFLAGS="-static -fuse-ld=lld" && \
 # Ensure that the binary was cross-compiled correctly to the target platform.
 RUN xx-verify --static /source-controller
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 ARG TARGETPLATFORM
 RUN apk --no-cache add ca-certificates \


### PR DESCRIPTION
Use latest `xx-apk` to fix the nightly build error:

```
ERROR: failed to solve: process "/bin/sh -c xx-apk add musl-dev gcc clang lld" did not complete successfully: exit code: 1
```