### PR TITLE
Build controller without CGO

### DIFF
--- a/config/testdata/git/large-repo.yaml
+++ b/config/testdata/git/large-repo.yaml
@@ -1,13 +1,10 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: large-repo
 spec:
   interval: 10m
   timeout: 2m
-  url: https://github.com/hashgraph/hedera-mirror-node.git
+  url: https://github.com/nodejs/node.git
   ref:
     branch: main
-  ignore: |
-    /*
-    !/charts


### PR DESCRIPTION
This PR normalises the multi-arch build of source-controller with all the other Flux controllers. We no longer need to build with CGO for the SHA1 collision detection (this was fixed in go-git).