### PR TITLE
chore: adding more scenarios for processor_test.go

### DIFF
--- a/internal/reconcile/summarize/processor_test.go
+++ b/internal/reconcile/summarize/processor_test.go
@@ -65,6 +65,43 @@ func TestRecordReconcileReq(t *testing.T) {
 				t.Expect(obj).To(HaveStatusLastHandledReconcileAt("now"))
 			},
 		},
+		{
+			name: "empty reconcile annotation value",
+			beforeFunc: func(obj client.Object) {
+				annotations := map[string]string{
+					meta.ReconcileRequestAnnotation: "",
+				}
+				obj.SetAnnotations(annotations)
+			},
+			afterFunc: func(t *WithT, obj client.Object) {
+				t.Expect(obj).To(HaveStatusLastHandledReconcileAt(""))
+			},
+		},
+		{
+			name: "whitespace-only reconcile annotation value",
+			beforeFunc: func(obj client.Object) {
+				annotations := map[string]string{
+					meta.ReconcileRequestAnnotation: "   ",
+				}
+				obj.SetAnnotations(annotations)
+			},
+			afterFunc: func(t *WithT, obj client.Object) {
+				t.Expect(obj).To(HaveStatusLastHandledReconcileAt("   "))
+			},
+		},
+		{
+			name: "reconcile annotation overwrites existing status value",
+			beforeFunc: func(obj client.Object) {
+				object.SetStatusLastHandledReconcileAt(obj, "old-value")
+				annotations := map[string]string{
+					meta.ReconcileRequestAnnotation: "new-value",
+				}
+				obj.SetAnnotations(annotations)
+			},
+			afterFunc: func(t *WithT, obj client.Object) {
+				t.Expect(obj).To(HaveStatusLastHandledReconcileAt("new-value"))
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Added test scenarios:**

- Empty/whitespace annotation values Ensures that the func can handle edge cases where the annotation exists but has no meaningful content.
- Overwrite existing status value Added a test to verify that reconcile annotation updates correctly overwrite any existing status value.


This will overall address edge cases and help with better test coverage