### PR TITLE
refactor: cleanup GetArtifactRegistryCredentials error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/fluxcd/cli-utils v0.36.0-flux.13
 	github.com/fluxcd/pkg/apis/event v0.17.0
 	github.com/fluxcd/pkg/apis/meta v1.12.0
-	github.com/fluxcd/pkg/auth v0.17.0
+	github.com/fluxcd/pkg/auth v0.18.0
 	github.com/fluxcd/pkg/cache v0.9.0
 	github.com/fluxcd/pkg/git v0.32.0
 	github.com/fluxcd/pkg/git/gogit v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,8 @@ github.com/fluxcd/pkg/apis/event v0.17.0 h1:foEINE++pCJlWVhWjYDXfkVmGKu8mQ4BDBlb
 github.com/fluxcd/pkg/apis/event v0.17.0/go.mod h1:0fLhLFiHlRTDKPDXdRnv+tS7mCMIQ0fJxnEfmvGM/5A=
 github.com/fluxcd/pkg/apis/meta v1.12.0 h1:XW15TKZieC2b7MN8VS85stqZJOx+/b8jATQ/xTUhVYg=
 github.com/fluxcd/pkg/apis/meta v1.12.0/go.mod h1:+son1Va60x2eiDcTwd7lcctbI6C+K3gM7R+ULmEq1SI=
-github.com/fluxcd/pkg/auth v0.17.0 h1:jgum55f5K7Db6yI2bi4WeKojTzQS9KxlHCC0CsFs5x8=
-github.com/fluxcd/pkg/auth v0.17.0/go.mod h1:4h6s8VBNuec3tWd4xIReLw8BYPOKaIegjNMEbA4ikTU=
+github.com/fluxcd/pkg/auth v0.18.0 h1:71pGdKe0PVKWQvM3hEuyd3FD9dEUHtMuKMbUeiMl4aA=
+github.com/fluxcd/pkg/auth v0.18.0/go.mod h1:4h6s8VBNuec3tWd4xIReLw8BYPOKaIegjNMEbA4ikTU=
 github.com/fluxcd/pkg/cache v0.9.0 h1:EGKfOLMG3fOwWnH/4Axl5xd425mxoQbZzlZoLfd8PDk=
 github.com/fluxcd/pkg/cache v0.9.0/go.mod h1:jMwabjWfsC5lW8hE7NM3wtGNwSJ38Javx6EKbEi7INU=
 github.com/fluxcd/pkg/git v0.32.0 h1:agSE4Ia8saj5eg075qhLhZvjuTg/Hnj8mZU0meGKOyc=

--- a/internal/controller/ocirepository_controller.go
+++ b/internal/controller/ocirepository_controller.go
@@ -365,7 +365,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 		return sreconcile.ResultEmpty, e
 	}
 
-	if _, ok := keychain.(soci.Anonymous); obj.Spec.Provider != sourcev1.GenericOCIProvider && ok {
+	if _, ok := keychain.(soci.Anonymous); obj.Spec.Provider != "" && obj.Spec.Provider != sourcev1.GenericOCIProvider && ok {
 		var opts []auth.Option
 		if obj.Spec.ServiceAccountName != "" {
 			// Check object-level workload identity feature gate.

--- a/internal/helm/getter/client_opts.go
+++ b/internal/helm/getter/client_opts.go
@@ -134,14 +134,12 @@ func GetClientOpts(ctx context.Context, c client.Client, obj *sourcev1.HelmRepos
 				return nil, "", fmt.Errorf("failed to configure login options: %w", err)
 			}
 		}
-	} else if obj.Spec.Provider != sourcev1.GenericOCIProvider && obj.Spec.Type == sourcev1.HelmRepositoryTypeOCI && ociRepo {
+	} else if p := obj.Spec.Provider; p != "" && p != sourcev1.GenericOCIProvider && obj.Spec.Type == sourcev1.HelmRepositoryTypeOCI && ociRepo {
 		authenticator, authErr := soci.OIDCAuth(ctx, obj.Spec.URL, obj.Spec.Provider)
 		if authErr != nil {
 			return nil, "", fmt.Errorf("failed to get credential from '%s': %w", obj.Spec.Provider, authErr)
 		}
-		if authenticator != nil {
-			hrOpts.Authenticator = authenticator
-		}
+		hrOpts.Authenticator = authenticator
 	}
 
 	if ociRepo {


### PR DESCRIPTION
## Summary

This PR updates the error handling for `GetArtifactRegistryCredentials()` following the improvements in fluxcd/pkg/auth v0.18.0.

As mentioned in https://github.com/fluxcd/image-reflector-controller/pull/786#issuecomment-2993234261, this removes unnecessary nil checks
as the function now returns errors directly for unsupported providers.

## Changes

- Update fluxcd/pkg/auth to v0.18.0
- Remove unnecessary authenticator nil check in Helm OCI repository authentication

## Related

- Implements cleanup mentioned in fluxcd/image-reflector-controller#786
- Part of the broader effort to simplify error handling after fluxcd/pkg#946