### PR TITLE
Implement core pkg/runtime/secrets migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/fluxcd/pkg/lockedfile v0.6.0
 	github.com/fluxcd/pkg/masktoken v0.7.0
 	github.com/fluxcd/pkg/oci v0.49.0
-	github.com/fluxcd/pkg/runtime v0.60.0
+	github.com/fluxcd/pkg/runtime v0.63.0
 	github.com/fluxcd/pkg/sourceignore v0.12.0
 	github.com/fluxcd/pkg/ssh v0.19.0
 	github.com/fluxcd/pkg/tar v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,8 @@ github.com/fluxcd/pkg/masktoken v0.7.0 h1:pitmyOg2pUVdW+nn2Lk/xqm2TaA08uxvOC0ns3
 github.com/fluxcd/pkg/masktoken v0.7.0/go.mod h1:Lc1uoDjO1GY6+YdkK+ZqqBIBWquyV58nlSJ5S1N1IYU=
 github.com/fluxcd/pkg/oci v0.49.0 h1:L8/dmNSIzqu6X8vzIkPLrW8NAF7Et/SnOuI8WJkXeq8=
 github.com/fluxcd/pkg/oci v0.49.0/go.mod h1:iZkF4bQTpc6YOU5IJWMBp0Q8voGm7bkMYiAarJ9407U=
-github.com/fluxcd/pkg/runtime v0.60.0 h1:d++EkV3FlycB+bzakB5NumwY4J8xts8i7lbvD6jBLeU=
-github.com/fluxcd/pkg/runtime v0.60.0/go.mod h1:UeU0/eZLErYC/1bTmgzBfNXhiHy9fuQzjfLK0HxRgxY=
+github.com/fluxcd/pkg/runtime v0.63.0 h1:55J7ascGmXyTXWGwhD21N9fU7jC1l5rhdzjgNXs6aZg=
+github.com/fluxcd/pkg/runtime v0.63.0/go.mod h1:7pxGvaU0Yy1cDIUhiHAHhCx2yCLnkcVsplbYZG6j4JY=
 github.com/fluxcd/pkg/sourceignore v0.12.0 h1:jCIe6d50rQ3wdXPF0+PhhqN0XrTRIq3upMomPelI8Mw=
 github.com/fluxcd/pkg/sourceignore v0.12.0/go.mod h1:dc0zvkuXM5OgL/b3IkrVuwvPjj1zJn4NBUMH45uJ4Y0=
 github.com/fluxcd/pkg/ssh v0.19.0 h1:njSwNJQZ+3TGhBXshU/2TbqvooMbf6lQzFn7w6vuaKI=

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -481,7 +481,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			wantErr:     true,
 			assertIndex: index.NewDigester(),
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to get secret '/dummy': secrets \"dummy\" not found"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "secret 'default/dummy' not found"),
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
 			},
@@ -491,8 +491,10 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			bucketName: "dummy",
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "dummy",
+					Name:      "dummy",
+					Namespace: "default",
 				},
+				Data: map[string][]byte{},
 			},
 			beforeFunc: func(obj *sourcev1.Bucket) {
 				obj.Spec.SecretRef = &meta.LocalObjectReference{
@@ -504,7 +506,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			wantErr:     true,
 			assertIndex: index.NewDigester(),
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "invalid 'dummy' secret data: required fields 'accesskey' and 'secretkey'"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "secret 'default/dummy': key 'accesskey' not found"),
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
 			},
@@ -522,7 +524,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			wantErr:     true,
 			assertIndex: index.NewDigester(),
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to get secret '/dummy': secrets \"dummy\" not found"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to create TLS config: secret 'default/dummy' not found"),
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
 			},
@@ -532,7 +534,8 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			bucketName: "dummy",
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "dummy",
+					Name:      "dummy",
+					Namespace: "default",
 				},
 			},
 			beforeFunc: func(obj *sourcev1.Bucket) {
@@ -547,7 +550,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			assertConditions: []metav1.Condition{
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "certificate secret does not contain any TLS configuration"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to create TLS config: secret 'default/dummy' must contain either 'ca.crt' or both 'tls.crt' and 'tls.key'"),
 			},
 		},
 		{
@@ -563,7 +566,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			wantErr:     true,
 			assertIndex: index.NewDigester(),
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to get secret '/dummy': secrets \"dummy\" not found"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "secret 'default/dummy' not found"),
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
 			},
@@ -573,7 +576,8 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			bucketName: "dummy",
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "dummy",
+					Name:      "dummy",
+					Namespace: "default",
 				},
 			},
 			beforeFunc: func(obj *sourcev1.Bucket) {
@@ -588,7 +592,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			assertConditions: []metav1.Condition{
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "invalid proxy secret '/dummy': key 'address' is missing"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "secret 'default/dummy': key 'address' not found"),
 			},
 		},
 		{
@@ -604,7 +608,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			wantErr:     true,
 			assertIndex: index.NewDigester(),
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to get secret '/dummy': secrets \"dummy\" not found"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "secret 'default/dummy' not found"),
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
 			},
@@ -614,8 +618,10 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			bucketName: "dummy",
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "dummy",
+					Name:      "dummy",
+					Namespace: "default",
 				},
+				Data: map[string][]byte{},
 			},
 			beforeFunc: func(obj *sourcev1.Bucket) {
 				obj.Spec.Provider = "generic"
@@ -632,7 +638,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			assertConditions: []metav1.Condition{
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "invalid 'dummy' secret data for 'ldap' STS provider: required fields username, password"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "secret 'default/dummy': key 'username' not found"),
 			},
 		},
 		{
@@ -648,7 +654,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			wantErr:     true,
 			assertIndex: index.NewDigester(),
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to get secret '/dummy': secrets \"dummy\" not found"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to get STS TLS config: secret 'default/dummy' not found"),
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
 			},
@@ -658,7 +664,8 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			bucketName: "dummy",
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "dummy",
+					Name:      "dummy",
+					Namespace: "default",
 				},
 			},
 			beforeFunc: func(obj *sourcev1.Bucket) {
@@ -676,7 +683,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 			assertConditions: []metav1.Condition{
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to get STS TLS config: certificate secret does not contain any TLS configuration"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to get STS TLS config: secret 'default/dummy' must contain either 'ca.crt' or both 'tls.crt' and 'tls.key'"),
 			},
 		},
 		{
@@ -921,6 +928,7 @@ func TestBucketReconciler_reconcileSource_generic(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-bucket-",
 					Generation:   1,
+					Namespace:    "default",
 				},
 				Spec: sourcev1.BucketSpec{
 					Timeout: &metav1.Duration{Duration: timeout},
@@ -994,7 +1002,8 @@ func TestBucketReconciler_reconcileSource_gcs(t *testing.T) {
 			},
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "dummy",
+					Name:      "dummy",
+					Namespace: "default",
 				},
 				Data: map[string][]byte{
 					"accesskey":      []byte("key"),
@@ -1030,7 +1039,7 @@ func TestBucketReconciler_reconcileSource_gcs(t *testing.T) {
 			wantErr:     true,
 			assertIndex: index.NewDigester(),
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to get secret '/dummy': secrets \"dummy\" not found"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "secret 'default/dummy' not found"),
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
 			},
@@ -1040,8 +1049,10 @@ func TestBucketReconciler_reconcileSource_gcs(t *testing.T) {
 			bucketName: "dummy",
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "dummy",
+					Name:      "dummy",
+					Namespace: "default",
 				},
+				Data: map[string][]byte{},
 			},
 			beforeFunc: func(obj *sourcev1.Bucket) {
 				obj.Spec.SecretRef = &meta.LocalObjectReference{
@@ -1054,7 +1065,7 @@ func TestBucketReconciler_reconcileSource_gcs(t *testing.T) {
 			wantErr:     true,
 			assertIndex: index.NewDigester(),
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "invalid 'dummy' secret data: required fields"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "secret 'default/dummy': key 'serviceaccount' not found"),
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
 			},
@@ -1073,7 +1084,7 @@ func TestBucketReconciler_reconcileSource_gcs(t *testing.T) {
 			wantErr:     true,
 			assertIndex: index.NewDigester(),
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "failed to get secret '/dummy': secrets \"dummy\" not found"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "secret 'default/dummy' not found"),
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
 			},
@@ -1083,7 +1094,8 @@ func TestBucketReconciler_reconcileSource_gcs(t *testing.T) {
 			bucketName: "dummy",
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "dummy",
+					Name:      "dummy",
+					Namespace: "default",
 				},
 			},
 			beforeFunc: func(obj *sourcev1.Bucket) {
@@ -1097,7 +1109,7 @@ func TestBucketReconciler_reconcileSource_gcs(t *testing.T) {
 			wantErr:     true,
 			assertIndex: index.NewDigester(),
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "invalid proxy secret '/dummy': key 'address' is missing"),
+				*conditions.TrueCondition(sourcev1.FetchFailedCondition, sourcev1.AuthenticationFailedReason, "secret 'default/dummy': key 'address' not found"),
 				*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 				*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
 			},
@@ -1309,6 +1321,7 @@ func TestBucketReconciler_reconcileSource_gcs(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-bucket-",
 					Generation:   1,
+					Namespace:    "default",
 				},
 				Spec: sourcev1.BucketSpec{
 					BucketName: tt.bucketName,
@@ -1746,191 +1759,6 @@ func TestBucketReconciler_notify(t *testing.T) {
 				if tt.wantEvent != "" {
 					t.Errorf("expected some event to be emitted")
 				}
-			}
-		})
-	}
-}
-
-func TestBucketReconciler_getProxyURL(t *testing.T) {
-	tests := []struct {
-		name        string
-		bucket      *sourcev1.Bucket
-		objects     []client.Object
-		expectedURL string
-		expectedErr string
-	}{
-		{
-			name: "empty proxySecretRef",
-			bucket: &sourcev1.Bucket{
-				Spec: sourcev1.BucketSpec{
-					ProxySecretRef: nil,
-				},
-			},
-		},
-		{
-			name: "non-existing proxySecretRef",
-			bucket: &sourcev1.Bucket{
-				Spec: sourcev1.BucketSpec{
-					ProxySecretRef: &meta.LocalObjectReference{
-						Name: "non-existing",
-					},
-				},
-			},
-			expectedErr: "failed to get secret '/non-existing': secrets \"non-existing\" not found",
-		},
-		{
-			name: "missing address in proxySecretRef",
-			bucket: &sourcev1.Bucket{
-				Spec: sourcev1.BucketSpec{
-					ProxySecretRef: &meta.LocalObjectReference{
-						Name: "dummy",
-					},
-				},
-			},
-			objects: []client.Object{
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "dummy",
-					},
-					Data: map[string][]byte{},
-				},
-			},
-			expectedErr: "invalid proxy secret '/dummy': key 'address' is missing",
-		},
-		{
-			name: "invalid address in proxySecretRef",
-			bucket: &sourcev1.Bucket{
-				Spec: sourcev1.BucketSpec{
-					ProxySecretRef: &meta.LocalObjectReference{
-						Name: "dummy",
-					},
-				},
-			},
-			objects: []client.Object{
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "dummy",
-					},
-					Data: map[string][]byte{
-						"address": {0x7f},
-					},
-				},
-			},
-			expectedErr: "failed to parse proxy address '\x7f': parse \"\\x7f\": net/url: invalid control character in URL",
-		},
-		{
-			name: "no user, no password",
-			bucket: &sourcev1.Bucket{
-				Spec: sourcev1.BucketSpec{
-					ProxySecretRef: &meta.LocalObjectReference{
-						Name: "dummy",
-					},
-				},
-			},
-			objects: []client.Object{
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "dummy",
-					},
-					Data: map[string][]byte{
-						"address": []byte("http://proxy.example.com"),
-					},
-				},
-			},
-			expectedURL: "http://proxy.example.com",
-		},
-		{
-			name: "user, no password",
-			bucket: &sourcev1.Bucket{
-				Spec: sourcev1.BucketSpec{
-					ProxySecretRef: &meta.LocalObjectReference{
-						Name: "dummy",
-					},
-				},
-			},
-			objects: []client.Object{
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "dummy",
-					},
-					Data: map[string][]byte{
-						"address":  []byte("http://proxy.example.com"),
-						"username": []byte("user"),
-					},
-				},
-			},
-			expectedURL: "http://user:@proxy.example.com",
-		},
-		{
-			name: "no user, password",
-			bucket: &sourcev1.Bucket{
-				Spec: sourcev1.BucketSpec{
-					ProxySecretRef: &meta.LocalObjectReference{
-						Name: "dummy",
-					},
-				},
-			},
-			objects: []client.Object{
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "dummy",
-					},
-					Data: map[string][]byte{
-						"address":  []byte("http://proxy.example.com"),
-						"password": []byte("password"),
-					},
-				},
-			},
-			expectedURL: "http://:password@proxy.example.com",
-		},
-		{
-			name: "user, password",
-			bucket: &sourcev1.Bucket{
-				Spec: sourcev1.BucketSpec{
-					ProxySecretRef: &meta.LocalObjectReference{
-						Name: "dummy",
-					},
-				},
-			},
-			objects: []client.Object{
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "dummy",
-					},
-					Data: map[string][]byte{
-						"address":  []byte("http://proxy.example.com"),
-						"username": []byte("user"),
-						"password": []byte("password"),
-					},
-				},
-			},
-			expectedURL: "http://user:password@proxy.example.com",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-
-			c := fakeclient.NewClientBuilder().
-				WithScheme(testEnv.Scheme()).
-				WithObjects(tt.objects...).
-				Build()
-
-			r := &BucketReconciler{
-				Client: c,
-			}
-
-			u, err := r.getProxyURL(ctx, tt.bucket)
-			if tt.expectedErr == "" {
-				g.Expect(err).To(BeNil())
-			} else {
-				g.Expect(err.Error()).To(ContainSubstring(tt.expectedErr))
-			}
-			if tt.expectedURL == "" {
-				g.Expect(u).To(BeNil())
-			} else {
-				g.Expect(u.String()).To(Equal(tt.expectedURL))
 			}
 		})
 	}

--- a/internal/controller/helmchart_controller.go
+++ b/internal/controller/helmchart_controller.go
@@ -1342,8 +1342,8 @@ func (r *HelmChartReconciler) makeVerifiers(ctx context.Context, obj *sourcev1.H
 				Name:      secretRef.Name,
 			}
 
-			pubSecret, err := r.retrieveSecret(ctx, verifySecret)
-			if err != nil {
+			var pubSecret corev1.Secret
+			if err := r.Get(ctx, verifySecret, &pubSecret); err != nil {
 				return nil, err
 			}
 
@@ -1393,8 +1393,8 @@ func (r *HelmChartReconciler) makeVerifiers(ctx context.Context, obj *sourcev1.H
 			Name:      secretRef.Name,
 		}
 
-		pubSecret, err := r.retrieveSecret(ctx, verifySecret)
-		if err != nil {
+		var pubSecret corev1.Secret
+		if err := r.Get(ctx, verifySecret, &pubSecret); err != nil {
 			return nil, err
 		}
 
@@ -1441,16 +1441,4 @@ func (r *HelmChartReconciler) makeVerifiers(ctx context.Context, obj *sourcev1.H
 	default:
 		return nil, fmt.Errorf("unsupported verification provider: %s", obj.Spec.Verify.Provider)
 	}
-}
-
-// retrieveSecret retrieves a secret from the specified namespace with the given secret name.
-// It returns the retrieved secret and any error encountered during the retrieval process.
-func (r *HelmChartReconciler) retrieveSecret(ctx context.Context, verifySecret types.NamespacedName) (corev1.Secret, error) {
-
-	var pubSecret corev1.Secret
-
-	if err := r.Get(ctx, verifySecret, &pubSecret); err != nil {
-		return corev1.Secret{}, err
-	}
-	return pubSecret, nil
 }

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 
 	gcpstorage "cloud.google.com/go/storage"
+	"github.com/fluxcd/pkg/runtime/secrets"
 	"github.com/go-logr/logr"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
@@ -151,7 +152,7 @@ func ValidateSecret(secret *corev1.Secret) error {
 		return nil
 	}
 	if _, exists := secret.Data["serviceaccount"]; !exists {
-		return fmt.Errorf("invalid '%s' secret data: required fields 'serviceaccount'", secret.Name)
+		return &secrets.KeyNotFoundError{Key: "serviceaccount", Secret: secret}
 	}
 	return nil
 }

--- a/pkg/gcp/gcp_test.go
+++ b/pkg/gcp/gcp_test.go
@@ -356,7 +356,7 @@ func TestValidateSecret(t *testing.T) {
 			t.Parallel()
 			err := ValidateSecret(tt.secret)
 			if tt.error {
-				assert.Error(t, err, fmt.Sprintf("invalid '%v' secret data: required fields 'serviceaccount'", tt.secret.Name))
+				assert.Error(t, err, fmt.Sprintf("secret '%s/%s': key 'serviceaccount' not found", tt.secret.Namespace, tt.secret.Name))
 			} else {
 				assert.NilError(t, err)
 			}

--- a/pkg/minio/minio_test.go
+++ b/pkg/minio/minio_test.go
@@ -573,7 +573,7 @@ func TestValidateSecret(t *testing.T) {
 			t.Parallel()
 			err := ValidateSecret(tt.secret)
 			if tt.error {
-				assert.Error(t, err, fmt.Sprintf("invalid '%v' secret data: required fields 'accesskey' and 'secretkey'", tt.secret.Name))
+				assert.Error(t, err, "secret 'default/minio-secret': key 'accesskey' not found")
 			} else {
 				assert.NilError(t, err)
 			}
@@ -696,50 +696,54 @@ func TestValidateSTSSecret(t *testing.T) {
 		{
 			name:     "empty ldap secret",
 			provider: "ldap",
-			secret:   &corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: "ldap-secret"}},
-			err:      "invalid 'ldap-secret' secret data for 'ldap' STS provider: required fields username, password",
+			secret:   &corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: "ldap-secret", Namespace: "default"}},
+			err:      "secret 'default/ldap-secret': key 'username' not found",
 		},
 		{
 			name:     "ldap secret missing password",
 			provider: "ldap",
 			secret: &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{Name: "ldap-secret", Namespace: "default"},
 				Data: map[string][]byte{
 					"username": []byte("user"),
 				},
 			},
-			err: "invalid '' secret data for 'ldap' STS provider: required fields username, password",
+			err: "secret 'default/ldap-secret': key 'password' not found",
 		},
 		{
 			name:     "ldap secret missing username",
 			provider: "ldap",
 			secret: &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{Name: "ldap-secret", Namespace: "default"},
 				Data: map[string][]byte{
 					"password": []byte("pass"),
 				},
 			},
-			err: "invalid '' secret data for 'ldap' STS provider: required fields username, password",
+			err: "secret 'default/ldap-secret': key 'username' not found",
 		},
 		{
 			name:     "ldap secret with empty username",
 			provider: "ldap",
 			secret: &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{Name: "ldap-secret", Namespace: "default"},
 				Data: map[string][]byte{
 					"username": []byte(""),
 					"password": []byte("pass"),
 				},
 			},
-			err: "invalid '' secret data for 'ldap' STS provider: required fields username, password",
+			err: "secret 'default/ldap-secret': key 'username' not found",
 		},
 		{
 			name:     "ldap secret with empty password",
 			provider: "ldap",
 			secret: &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{Name: "ldap-secret", Namespace: "default"},
 				Data: map[string][]byte{
 					"username": []byte("user"),
 					"password": []byte(""),
 				},
 			},
-			err: "invalid '' secret data for 'ldap' STS provider: required fields username, password",
+			err: "secret 'default/ldap-secret': key 'password' not found",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Implements core migration to pkg/runtime/secrets v0.63.0 for source-controller as part of https://github.com/fluxcd/flux2/issues/5433. 
Migrates basic auth, TLS config, and OCI registry authentication while removing internal wrapper functions.

- Update pkg/runtime from v0.60.0 to v0.63.0  
- Migrate Bucket and OCIRepository controllers to use pkg/runtime/secrets
- Remove internal/helm/getter wrapper functions
- Add OCI registry authentication using pkg/runtime/secrets

## Follow-up Work

Remaining controllers (GitRepository, HelmRepository) and cloud provider authentication will be migrated in subsequent PRs.