### PR TITLE
[RFC-0010] Add multi-tenant workload identity support for Azure GitRepository

### DIFF
--- a/api/v1/gitrepository_types.go
+++ b/api/v1/gitrepository_types.go
@@ -77,6 +77,7 @@ const (
 
 // GitRepositorySpec specifies the required configuration to produce an
 // Artifact for a Git repository.
+// +kubebuilder:validation:XValidation:rule="!has(self.serviceAccountName) || (has(self.provider) && self.provider == 'azure')",message="serviceAccountName can only be set when provider is 'azure'"
 type GitRepositorySpec struct {
 	// URL specifies the Git repository URL, it can be an HTTP/S or SSH address.
 	// +kubebuilder:validation:Pattern="^(http|https|ssh)://.*$"
@@ -97,6 +98,11 @@ type GitRepositorySpec struct {
 	// +kubebuilder:validation:Enum=generic;azure;github
 	// +optional
 	Provider string `json:"provider,omitempty"`
+
+	// ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+	// authenticate to the GitRepository. This field is only supported for 'azure' provider.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// Interval at which the GitRepository URL is checked for updates.
 	// This interval is approximate and may be subject to jitter to ensure

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -174,6 +174,11 @@ spec:
                 required:
                 - name
                 type: object
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+                  authenticate to the GitRepository. This field is only supported for 'azure' provider.
+                type: string
               sparseCheckout:
                 description: |-
                   SparseCheckout specifies a list of directories to checkout when cloning
@@ -235,6 +240,10 @@ spec:
             - interval
             - url
             type: object
+            x-kubernetes-validations:
+            - message: serviceAccountName can only be set when provider is 'azure'
+              rule: '!has(self.serviceAccountName) || (has(self.provider) && self.provider
+                == ''azure'')'
           status:
             default:
               observedGeneration: -1

--- a/docs/api/v1/source.md
+++ b/docs/api/v1/source.md
@@ -413,6 +413,19 @@ When not specified, defaults to &lsquo;generic&rsquo;.</p>
 </tr>
 <tr>
 <td>
+<code>serviceAccountName</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+authenticate to the GitRepository. This field is only supported for &lsquo;azure&rsquo; provider.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>interval</code><br>
 <em>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
@@ -2063,6 +2076,19 @@ string
 <em>(Optional)</em>
 <p>Provider used for authentication, can be &lsquo;azure&rsquo;, &lsquo;github&rsquo;, &lsquo;generic&rsquo;.
 When not specified, defaults to &lsquo;generic&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+authenticate to the GitRepository. This field is only supported for &lsquo;azure&rsquo; provider.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1/gitrepositories.md
+++ b/docs/spec/v1/gitrepositories.md
@@ -393,6 +393,24 @@ flux create secret githubapp ghapp-secret \
     --app-private-key=~/private-key.pem    
 ```
 
+### Service Account reference
+
+`.spec.serviceAccountName` is an optional field to specify a Service Account
+in the same namespace as GitRepository with purpose depending on the value of
+the `.spec.provider` field:
+
+- When `.spec.provider` is set to `azure`, the Service Account
+  will be used for Workload Identity authentication. In this case, the controller
+  feature gate `ObjectLevelWorkloadIdentity` must be enabled, otherwise the
+  controller will error out. For Azure DevOps specific setup, see the
+  [Azure DevOps integration guide](https://fluxcd.io/flux/integrations/azure/#for-azure-devops).
+
+**Note:** that for a publicly accessible git repository, you don't need to
+provide a `secretRef` nor `serviceAccountName`.
+
+For a complete guide on how to set up authentication for cloud providers,
+see the integration [docs](/flux/integrations/).
+
 ### Interval
 
 `.spec.interval` is a required field that specifies the interval at which the

--- a/internal/controller/gitrepository_controller_test.go
+++ b/internal/controller/gitrepository_controller_test.go
@@ -48,6 +48,7 @@ import (
 
 	kstatus "github.com/fluxcd/cli-utils/pkg/kstatus/status"
 	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/auth"
 	"github.com/fluxcd/pkg/git"
 	"github.com/fluxcd/pkg/git/github"
 	"github.com/fluxcd/pkg/gittestserver"
@@ -918,6 +919,15 @@ func TestGitRepositoryReconciler_getAuthOpts_provider(t *testing.T) {
 				obj.Spec.Provider = sourcev1.GitProviderAzure
 			},
 			wantErr: "ManagedIdentityCredential",
+		},
+		{
+			name: "azure provider with service account and feature gate for object-level identity disabled",
+			url:  "https://dev.azure.com/foo/bar/_git/baz",
+			beforeFunc: func(obj *sourcev1.GitRepository) {
+				obj.Spec.Provider = sourcev1.GitProviderAzure
+				obj.Spec.ServiceAccountName = "azure-sa"
+			},
+			wantErr: auth.FeatureGateObjectLevelWorkloadIdentity,
 		},
 		{
 			name: "github provider with no secret ref",


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/5022

Changes include :

- Add `.spec.serviceAccountName` field to `GitRepository`
- Controller changes to set the service account to use object-level workload identity
- Docs and unit tests

Test Behavior

1. Feature gate disabled

```
  status:
    conditions:
    - lastTransitionTime: "2025-08-14T23:26:40Z"
      message: to use spec.serviceAccountName for provider authentication please enable
        the ObjectLevelWorkloadIdentity feature gate in the controller
      observedGeneration: 5
      reason: FeatureGateDisabled
      status: "True"
      type: Stalled
    - lastTransitionTime: "2025-08-14T23:26:40Z"
      message: to use spec.serviceAccountName for provider authentication please enable
        the ObjectLevelWorkloadIdentity feature gate in the controller
      observedGeneration: 5
      reason: FeatureGateDisabled
      status: "False"
      type: Ready
    - lastTransitionTime: "2025-08-14T23:26:40Z"
      message: to use spec.serviceAccountName for provider authentication please enable
        the ObjectLevelWorkloadIdentity feature gate in the controller
      observedGeneration: 5
      reason: FeatureGateDisabled
      status: "True"
      type: FetchFailed
    lastHandledReconcileAt: "2025-08-08T00:32:04.177906951Z"
    observedGeneration: 5
```

2. Controller does not have permissions to create access tokens

```
    - lastTransitionTime: "2025-08-14T22:41:41Z"
      message: 'failed to configure authentication options: failed to create kubernetes
        token for service account ''adoconfig/az-mi-user'': serviceaccounts "az-mi-user"
        is forbidden: User "system:serviceaccount:flux-system:source-controller" cannot
        create resource "serviceaccounts/token" in API group "" in the namespace "adoconfig"'
```

To fix this, the clusterrole should have the following access.

```
- apiGroups:
  - ""
  resources:
  - serviceaccounts/token
  verbs:
  - create
```

3. Success case 

```
  status:
    artifact:
    - lastTransitionTime: "2025-08-14T23:29:09Z"
      message: stored artifact for revision 'main@sha1:b7d5a1fa643e65b98a11828ddc1de47b61fba654'
      observedGeneration: 5
      reason: Succeeded
      status: "True"
      type: ArtifactInStorage
    lastHandledReconcileAt: "2025-08-08T00:32:04.177906951Z"
    observedGeneration: 5
```