### PR TITLE
[RFC-0010] Add multi-tenant workload identity support for Azure Blob Storage

### DIFF
--- a/api/v1/bucket_types.go
+++ b/api/v1/bucket_types.go
@@ -52,7 +52,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="self.provider != 'generic' || !has(self.sts) || self.sts.provider == 'ldap'", message="'ldap' is the only supported STS provider for the 'generic' Bucket provider"
 // +kubebuilder:validation:XValidation:rule="!has(self.sts) || self.sts.provider != 'aws' || !has(self.sts.secretRef)", message="spec.sts.secretRef is not required for the 'aws' STS provider"
 // +kubebuilder:validation:XValidation:rule="!has(self.sts) || self.sts.provider != 'aws' || !has(self.sts.certSecretRef)", message="spec.sts.certSecretRef is not required for the 'aws' STS provider"
-// +kubebuilder:validation:XValidation:rule="self.provider == 'gcp' || self.provider == 'aws' || !has(self.serviceAccountName)", message="ServiceAccountName is only supported for the 'gcp' and 'aws' Bucket providers"
+// +kubebuilder:validation:XValidation:rule="self.provider != 'generic' || !has(self.serviceAccountName)", message="ServiceAccountName is not supported for the 'generic' Bucket provider"
 // +kubebuilder:validation:XValidation:rule="!has(self.secretRef) || !has(self.serviceAccountName)", message="cannot set both .spec.secretRef and .spec.serviceAccountName"
 type BucketSpec struct {
 	// Provider of the object storage bucket.

--- a/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
@@ -239,9 +239,9 @@ spec:
               rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
             - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
               rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
-            - message: ServiceAccountName is only supported for the 'gcp' and 'aws'
-                Bucket providers
-              rule: self.provider == 'gcp' || self.provider == 'aws' || !has(self.serviceAccountName)
+            - message: ServiceAccountName is not supported for the 'generic' Bucket
+                provider
+              rule: self.provider != 'generic' || !has(self.serviceAccountName)
             - message: cannot set both .spec.secretRef and .spec.serviceAccountName
               rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
           status:

--- a/internal/bucket/azure/blob_test.go
+++ b/internal/bucket/azure/blob_test.go
@@ -106,7 +106,8 @@ func TestNewClientAndBucketExistsWithProxy(t *testing.T) {
 				},
 			}
 
-			client, err := NewClient(bucket,
+			client, err := NewClient(t.Context(),
+				bucket,
 				WithProxyURL(tt.proxyURL),
 				withoutCredentials(),
 				withoutRetries())
@@ -472,7 +473,7 @@ func Test_sasTokenFromSecret(t *testing.T) {
 func Test_chainCredentialWithSecret(t *testing.T) {
 	g := NewWithT(t)
 
-	got, err := chainCredentialWithSecret(nil)
+	got, err := chainCredentialWithSecret(t.Context(), nil)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(got).To(BeAssignableToTypeOf(&azidentity.ChainedTokenCredential{}))
 }

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -920,7 +920,8 @@ func (r *BucketReconciler) createBucketProvider(ctx context.Context, obj *source
 		if creds.proxyURL != nil {
 			opts = append(opts, azure.WithProxyURL(creds.proxyURL))
 		}
-		return azure.NewClient(obj, opts...)
+		opts = append(opts, azure.WithAuth(authOpts...))
+		return azure.NewClient(ctx, obj, opts...)
 
 	default:
 		if err := minio.ValidateSecret(creds.secret); err != nil {


### PR DESCRIPTION
Part of: https://github.com/fluxcd/source-controller/pull/1871

Changes include: 

- Use `auth` pkg to create Azure token credential to enable controller/object-level workload identity and pass this to Azure SDK.
- Doc update to remove deprecated AAD pod identity docs for buckets. 

Tested controller-level/object-level scenario, caching - metrics shared below.

1. If object level workload identity feature gate is disabled, the Bucket source goes into a Stalled state. 

```
Status:
  Conditions:
    Last Transition Time:  2025-08-26T16:52:35Z
    Message:               to use spec.serviceAccountName for provider authentication please enable the ObjectLevelWorkloadIdentity feature gate in the controller
    Observed Generation:   6
    Reason:                FeatureGateDisabled
    Status:                True
    Type:                  Stalled
    Last Transition Time:  2025-08-26T16:52:35Z
    Message:               to use spec.serviceAccountName for provider authentication please enable the ObjectLevelWorkloadIdentity feature gate in the controller
    Observed Generation:   6
    Reason:                FeatureGateDisabled
    Status:                False
    Type:                  Ready
    Last Transition Time:  2025-08-26T16:52:35Z
    Message:               to use spec.serviceAccountName for provider authentication please enable the ObjectLevelWorkloadIdentity feature gate in the controller
    Observed Generation:   6
    Reason:                FeatureGateDisabled
    Status:                True
    Type:                  FetchFailed
```
2. Cache metrics for success scenarios.

```
# TYPE gotk_token_cache_events_total counter
gotk_token_cache_events_total{event_type="cache_hit",kind="Bucket",name="azure-public",namespace="default",operation="reconcile"} 42
gotk_token_cache_events_total{event_type="cache_miss",kind="Bucket",name="azure-public",namespace="default",operation="reconcile"} 1
```