### PR TITLE
api: Make ExternalArtifact conform to runtime Getter/Setter interface

### DIFF
--- a/api/v1/externalartifact_types.go
+++ b/api/v1/externalartifact_types.go
@@ -46,16 +46,26 @@ type ExternalArtifactStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// GetRequeueAfter returns the duration after which the ExternalArtifact
-// must be reconciled again.
-func (in ExternalArtifact) GetRequeueAfter() time.Duration {
-	return time.Minute
+// GetConditions returns the status conditions of the object.
+func (in *ExternalArtifact) GetConditions() []metav1.Condition {
+	return in.Status.Conditions
+}
+
+// SetConditions sets the status conditions on the object.
+func (in *ExternalArtifact) SetConditions(conditions []metav1.Condition) {
+	in.Status.Conditions = conditions
 }
 
 // GetArtifact returns the latest Artifact from the ExternalArtifact if
 // present in the status sub-resource.
 func (in *ExternalArtifact) GetArtifact() *meta.Artifact {
 	return in.Status.Artifact
+}
+
+// GetRequeueAfter returns the duration after which the ExternalArtifact
+// must be reconciled again.
+func (in *ExternalArtifact) GetRequeueAfter() time.Duration {
+	return time.Minute
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
Make the `ExternalArtifact` type conform to the following interfaces:
- `github.com/fluxcd/pkg/runtime/conditions.Getter`
- `github.com/fluxcd/pkg/runtime/conditions.Setter`

Part of: https://github.com/fluxcd/flux2/issues/5504