### PR TITLE
helm: Remove TLS tmp dir logic for HelmRepository `type: oci`

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -6,14 +6,9 @@ CREATE_CLUSTER="${CREATE_CLUSTER:-true}"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 LOAD_IMG_INTO_KIND="${LOAD_IMG_INTO_KIND:-true}"
 BUILD_PLATFORM="${BUILD_PLATFORM:-linux/amd64}"
-MINIO_HELM_VER="${MINIO_HELM_VER:-12.10.3}"
 
 IMG=test/source-controller
 TAG=latest
-
-MC_RELEASE=mc.RELEASE.2023-11-20T16-30-59Z
-MC_AMD64_SHA256=fdd901a5169d676f32483f9a2de977b7ff3a4fe83e254dcbc35e7a1545591565
-MC_ARM64_SHA256=09816180f560875d344dc436ed4ec1348b3ff0c836ae9cf0415fef602489cc11
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 BUILD_DIR="${ROOT_DIR}/build"
@@ -39,8 +34,6 @@ function cleanup(){
         kubectl -n source-system get helmcharts -oyaml
         kubectl -n source-system get all
         kubectl -n source-system logs deploy/source-controller
-        kubectl -n minio get all
-        kubectl -n minio describe pods
     else
         echo "All E2E tests passed!"
     fi
@@ -82,58 +75,6 @@ kubectl -n source-system apply -f "${ROOT_DIR}/config/testdata/helmchart-valuesf
 kubectl -n source-system wait helmchart/podinfo --for=condition=ready --timeout=5m
 kubectl -n source-system wait helmchart/podinfo-git --for=condition=ready --timeout=5m
 kubectl -n source-system delete -f "${ROOT_DIR}/config/testdata/helmchart-valuesfile"
-
-echo "Setup Minio"
-kubectl create ns minio
-helm upgrade minio oci://registry-1.docker.io/bitnamicharts/minio --wait -i \
-    --version "${MINIO_HELM_VER}" \
-    --timeout 10m0s \
-    --namespace minio \
-    --set auth.rootUser=myaccesskey \
-    --set auth.rootPassword=mysecretkey \
-    --set resources.requests.memory=128Mi \
-    --set persistence.enable=false
-kubectl -n minio port-forward svc/minio 9000:9000 &>/dev/null &
-
-sleep 2
-
-if [ ! -f "${BUILD_DIR}/mc" ]; then
-    MC_SHA256="${MC_AMD64_SHA256}"
-    ARCH="amd64"
-    if [ "${BUILD_PLATFORM}" = "linux/arm64" ]; then
-        MC_SHA256="${MC_ARM64_SHA256}"
-        ARCH="arm64"
-    fi
-
-    mkdir -p "${BUILD_DIR}"
-    curl -o "${BUILD_DIR}/mc" -LO "https://dl.min.io/client/mc/release/linux-${ARCH}/archive/${MC_RELEASE}"
-    if ! echo "${MC_SHA256}  ${BUILD_DIR}/mc" | sha256sum --check; then
-        echo "Checksum failed for mc."
-        rm "${BUILD_DIR}/mc"
-        exit 1
-    fi
-
-    chmod +x "${BUILD_DIR}/mc"
-fi
-
-"${BUILD_DIR}/mc" alias set minio http://localhost:9000 myaccesskey mysecretkey --api S3v4
-kubectl -n source-system apply -f "${ROOT_DIR}/config/testdata/minio/secret.yaml"
-
-echo "Run Bucket tests"
-"${BUILD_DIR}/mc" mb minio/podinfo
-"${BUILD_DIR}/mc" mirror "${ROOT_DIR}/config/testdata/minio/manifests/" minio/podinfo
-
-kubectl -n source-system apply -f "${ROOT_DIR}/config/testdata/bucket/source.yaml"
-kubectl -n source-system wait bucket/podinfo --for=condition=ready --timeout=1m
-
-
-echo "Run HelmChart from Bucket tests"
-"${BUILD_DIR}/mc" mb minio/charts
-"${BUILD_DIR}/mc" mirror "${ROOT_DIR}/internal/controller/testdata/charts/helmchart/" minio/charts/helmchart
-
-kubectl -n source-system apply -f "${ROOT_DIR}/config/testdata/helmchart-from-bucket/source.yaml"
-kubectl -n source-system wait bucket/charts --for=condition=ready --timeout=1m
-kubectl -n source-system wait helmchart/helmchart-bucket --for=condition=ready --timeout=1m
 
 echo "Run large Git repo tests"
 kubectl -n source-system apply -f "${ROOT_DIR}/config/testdata/git/large-repo.yaml"

--- a/internal/controller/helmchart_controller.go
+++ b/internal/controller/helmchart_controller.go
@@ -524,7 +524,7 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 		return chartRepoConfigErrorReturn(err, obj)
 	}
 
-	clientOpts, certsTmpDir, err := getter.GetClientOpts(ctxTimeout, r.Client, repo, normalizedURL)
+	clientOpts, err := getter.GetClientOpts(ctxTimeout, r.Client, repo, normalizedURL)
 	if err != nil && !errors.Is(err, getter.ErrDeprecatedTLSConfig) {
 		e := serror.NewGeneric(
 			err,
@@ -532,14 +532,6 @@ func (r *HelmChartReconciler) buildFromHelmRepository(ctx context.Context, obj *
 		)
 		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
-	}
-	if certsTmpDir != "" {
-		defer func() {
-			if err := os.RemoveAll(certsTmpDir); err != nil {
-				r.eventLogf(ctx, obj, corev1.EventTypeWarning, meta.FailedReason,
-					"failed to delete temporary certificates directory: %s", err)
-			}
-		}()
 	}
 
 	getterOpts := clientOpts.GetterOpts
@@ -1019,7 +1011,7 @@ func (r *HelmChartReconciler) namespacedChartRepositoryCallback(ctx context.Cont
 		ctxTimeout, cancel := context.WithTimeout(ctx, obj.GetTimeout())
 		defer cancel()
 
-		clientOpts, certsTmpDir, err := getter.GetClientOpts(ctxTimeout, r.Client, obj, normalizedURL)
+		clientOpts, err := getter.GetClientOpts(ctxTimeout, r.Client, obj, normalizedURL)
 		if err != nil && !errors.Is(err, getter.ErrDeprecatedTLSConfig) {
 			return nil, err
 		}
@@ -1038,7 +1030,6 @@ func (r *HelmChartReconciler) namespacedChartRepositoryCallback(ctx context.Cont
 			ociChartRepo, err := repository.NewOCIChartRepository(normalizedURL, repository.WithOCIGetter(r.Getters),
 				repository.WithOCIGetterOptions(getterOpts),
 				repository.WithOCIRegistryClient(registryClient),
-				repository.WithCertificatesStore(certsTmpDir),
 				repository.WithCredentialsFile(credentialsFile))
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to create OCI chart repository: %w", err))

--- a/internal/controller/helmrepository_controller.go
+++ b/internal/controller/helmrepository_controller.go
@@ -416,7 +416,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 		return sreconcile.ResultEmpty, e
 	}
 
-	clientOpts, _, err := getter.GetClientOpts(ctx, r.Client, obj, normalizedURL)
+	clientOpts, err := getter.GetClientOpts(ctx, r.Client, obj, normalizedURL)
 	if err != nil {
 		if errors.Is(err, getter.ErrDeprecatedTLSConfig) {
 			ctrl.LoggerFrom(ctx).

--- a/internal/helm/getter/client_opts_test.go
+++ b/internal/helm/getter/client_opts_test.go
@@ -164,7 +164,7 @@ func TestGetClientOpts(t *testing.T) {
 			}
 			c := clientBuilder.Build()
 
-			clientOpts, _, err := GetClientOpts(context.TODO(), c, helmRepo, "https://ghcr.io/dummy")
+			clientOpts, err := GetClientOpts(context.TODO(), c, helmRepo, "https://ghcr.io/dummy")
 			if tt.err != nil {
 				g.Expect(err).To(Equal(tt.err))
 			} else {
@@ -207,7 +207,7 @@ func TestGetClientOpts_registryTLSLoginOption(t *testing.T) {
 					"password": []byte("pass"),
 				},
 			},
-			loginOptsN: 3,
+			loginOptsN: 2,
 		},
 		{
 			name: "without caFile",
@@ -271,7 +271,7 @@ func TestGetClientOpts_registryTLSLoginOption(t *testing.T) {
 			}
 			c := clientBuilder.Build()
 
-			clientOpts, tmpDir, err := GetClientOpts(context.TODO(), c, helmRepo, "https://ghcr.io/dummy")
+			clientOpts, err := GetClientOpts(context.TODO(), c, helmRepo, "https://ghcr.io/dummy")
 			if tt.wantErrMsg != "" {
 				if err == nil {
 					t.Errorf("GetClientOpts() expected error but got none")
@@ -286,9 +286,6 @@ func TestGetClientOpts_registryTLSLoginOption(t *testing.T) {
 			if err != nil {
 				t.Errorf("GetClientOpts() error = %v", err)
 				return
-			}
-			if tmpDir != "" {
-				defer os.RemoveAll(tmpDir)
 			}
 			if tt.loginOptsN != len(clientOpts.RegLoginOpts) {
 				// we should have a login option but no TLS option


### PR DESCRIPTION
fix: #1902 

Tests are now passing on macOS:

```
--- PASS: TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy/with_contextual_login_provider_and_secretRef (0.96s)
=== RUN   TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy/HTTPS_With_invalid_CA_cert
--- PASS: TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy/HTTPS_With_invalid_CA_cert (0.07s)
=== RUN   TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy/HTTPS_With_CA_cert_only
--- PASS: TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy/HTTPS_With_CA_cert_only (0.09s)
=== RUN   TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy/HTTPS_With_CA_cert_and_client_cert_auth
--- PASS: TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy/HTTPS_With_CA_cert_and_client_cert_auth (0.08s)
--- PASS: TestHelmChartReconciler_reconcileSourceFromOCI_authStrategy (7.00s)
```