### PR TITLE
Fix HelmChart reconciler appending login options when they do not exist

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -6,14 +6,9 @@ CREATE_CLUSTER="${CREATE_CLUSTER:-true}"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 LOAD_IMG_INTO_KIND="${LOAD_IMG_INTO_KIND:-true}"
 BUILD_PLATFORM="${BUILD_PLATFORM:-linux/amd64}"
-MINIO_HELM_VER="${MINIO_HELM_VER:-12.10.3}"
 
 IMG=test/source-controller
 TAG=latest
-
-MC_RELEASE=mc.RELEASE.2023-11-20T16-30-59Z
-MC_AMD64_SHA256=fdd901a5169d676f32483f9a2de977b7ff3a4fe83e254dcbc35e7a1545591565
-MC_ARM64_SHA256=09816180f560875d344dc436ed4ec1348b3ff0c836ae9cf0415fef602489cc11
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 BUILD_DIR="${ROOT_DIR}/build"
@@ -39,8 +34,6 @@ function cleanup(){
         kubectl -n source-system get helmcharts -oyaml
         kubectl -n source-system get all
         kubectl -n source-system logs deploy/source-controller
-        kubectl -n minio get all
-        kubectl -n minio describe pods
     else
         echo "All E2E tests passed!"
     fi
@@ -82,58 +75,6 @@ kubectl -n source-system apply -f "${ROOT_DIR}/config/testdata/helmchart-valuesf
 kubectl -n source-system wait helmchart/podinfo --for=condition=ready --timeout=5m
 kubectl -n source-system wait helmchart/podinfo-git --for=condition=ready --timeout=5m
 kubectl -n source-system delete -f "${ROOT_DIR}/config/testdata/helmchart-valuesfile"
-
-echo "Setup Minio"
-kubectl create ns minio
-helm upgrade minio oci://registry-1.docker.io/bitnamicharts/minio --wait -i \
-    --version "${MINIO_HELM_VER}" \
-    --timeout 10m0s \
-    --namespace minio \
-    --set auth.rootUser=myaccesskey \
-    --set auth.rootPassword=mysecretkey \
-    --set resources.requests.memory=128Mi \
-    --set persistence.enable=false
-kubectl -n minio port-forward svc/minio 9000:9000 &>/dev/null &
-
-sleep 2
-
-if [ ! -f "${BUILD_DIR}/mc" ]; then
-    MC_SHA256="${MC_AMD64_SHA256}"
-    ARCH="amd64"
-    if [ "${BUILD_PLATFORM}" = "linux/arm64" ]; then
-        MC_SHA256="${MC_ARM64_SHA256}"
-        ARCH="arm64"
-    fi
-
-    mkdir -p "${BUILD_DIR}"
-    curl -o "${BUILD_DIR}/mc" -LO "https://dl.min.io/client/mc/release/linux-${ARCH}/archive/${MC_RELEASE}"
-    if ! echo "${MC_SHA256}  ${BUILD_DIR}/mc" | sha256sum --check; then
-        echo "Checksum failed for mc."
-        rm "${BUILD_DIR}/mc"
-        exit 1
-    fi
-
-    chmod +x "${BUILD_DIR}/mc"
-fi
-
-"${BUILD_DIR}/mc" alias set minio http://localhost:9000 myaccesskey mysecretkey --api S3v4
-kubectl -n source-system apply -f "${ROOT_DIR}/config/testdata/minio/secret.yaml"
-
-echo "Run Bucket tests"
-"${BUILD_DIR}/mc" mb minio/podinfo
-"${BUILD_DIR}/mc" mirror "${ROOT_DIR}/config/testdata/minio/manifests/" minio/podinfo
-
-kubectl -n source-system apply -f "${ROOT_DIR}/config/testdata/bucket/source.yaml"
-kubectl -n source-system wait bucket/podinfo --for=condition=ready --timeout=1m
-
-
-echo "Run HelmChart from Bucket tests"
-"${BUILD_DIR}/mc" mb minio/charts
-"${BUILD_DIR}/mc" mirror "${ROOT_DIR}/internal/controller/testdata/charts/helmchart/" minio/charts/helmchart
-
-kubectl -n source-system apply -f "${ROOT_DIR}/config/testdata/helmchart-from-bucket/source.yaml"
-kubectl -n source-system wait bucket/charts --for=condition=ready --timeout=1m
-kubectl -n source-system wait helmchart/helmchart-bucket --for=condition=ready --timeout=1m
 
 echo "Run large Git repo tests"
 kubectl -n source-system apply -f "${ROOT_DIR}/config/testdata/git/large-repo.yaml"

--- a/internal/helm/getter/client_opts.go
+++ b/internal/helm/getter/client_opts.go
@@ -195,14 +195,19 @@ func configureOCIRegistryWithSecrets(ctx context.Context, obj *sourcev1.HelmRepo
 	if err != nil {
 		return "", err
 	}
-
-	if loginOpt != nil {
-		opts.RegLoginOpts = []helmreg.LoginOption{loginOpt, helmreg.LoginOptInsecure(obj.Spec.Insecure)}
+	if loginOpt == nil {
+		return "", nil
 	}
+	opts.RegLoginOpts = []helmreg.LoginOption{loginOpt, helmreg.LoginOptInsecure(obj.Spec.Insecure)}
 
-	// Handle TLS certificate files for OCI
+	// Handle TLS for login options
 	var tempCertDir string
 	if opts.TlsConfig != nil {
+		// Until Helm 3.19 only a file-based login option for TLS is supported.
+		// In Helm 4 (or in Helm 3.20+ if it ever gets released), a simpler
+		// in-memory login option for TLS will be available:
+		// https://github.com/helm/helm/pull/31076
+
 		tempCertDir, err = os.MkdirTemp("", "helm-repo-oci-certs")
 		if err != nil {
 			return "", fmt.Errorf("cannot create temporary directory: %w", err)


### PR DESCRIPTION
Fixes: #1902

Supersedes: #1903 

This PR is restoring the code path from source-controller `v1.6.2` where the TLS login option was only specified if there were login credentials also specified.

@stefanprodan I prefer merging this version that is a straightforward fix restoring the code path from 1.6.2 instead of revisiting this old TLS login option code in a patch release. I propose we revisit this in Flux 2.8. Please test this fix in your MacOS :pray: 