### PR TITLE
Handle symlinks within GitRespository

### DIFF
--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -1391,6 +1391,12 @@ func resolveSymlinks(rootDir string) error {
 			}
 
 			// Security check: ensure target is within root directory
+			// First check: target must be an absolute path that starts with rootDir
+			if !strings.HasPrefix(target, rootDir+string(filepath.Separator)) && target != rootDir {
+				// Symlink points outside root directory - skip it
+				return nil
+			}
+			// Second check: use filepath.Rel to catch edge cases with ../
 			relPath, err := filepath.Rel(rootDir, target)
 			if err != nil || strings.HasPrefix(relPath, "..") {
 				// Symlink points outside root directory - skip it

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -860,6 +860,16 @@ func (r *GitRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 	}
 	defer unlock()
 
+	// Resolve symlinks before archiving to ensure their content is included
+	if err := resolveSymlinks(dir); err != nil {
+		e := serror.NewGeneric(
+			fmt.Errorf("failed to resolve symlinks in repository: %w", err),
+			sourcev1.ArchiveOperationFailedReason,
+		)
+		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
+		return sreconcile.ResultEmpty, e
+	}
+
 	// Load ignore rules for archiving
 	ignoreDomain := strings.Split(dir, string(filepath.Separator))
 	ps, err := sourceignore.LoadIgnorePatterns(dir, ignoreDomain)
@@ -1333,6 +1343,193 @@ func commitReference(obj *sourcev1.GitRepository, commit *git.Commit) string {
 		return commit.AbsoluteReference()
 	}
 	return commit.String()
+}
+
+// resolveSymlinks recursively resolves symlinks in the given directory by replacing
+// them with copies of their target files/directories. This ensures that symlink
+// content is included in the archive, as the Archive function skips symlinks.
+// Symlinks pointing outside the root directory are skipped for security reasons.
+func resolveSymlinks(rootDir string) error {
+	rootDir, err := filepath.Abs(rootDir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	// First pass: collect all symlinks
+	type symlinkInfo struct {
+		path   string
+		target string
+	}
+	var symlinks []symlinkInfo
+
+	err = filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Use Lstat to check for symlinks
+		lstatInfo, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+
+		// Check if this is a symlink
+		if lstatInfo.Mode()&os.ModeSymlink != 0 {
+			// Resolve the symlink target
+			target, err := os.Readlink(path)
+			if err != nil {
+				return fmt.Errorf("failed to read symlink %s: %w", path, err)
+			}
+
+			// Make target path absolute if it's relative
+			if !filepath.IsAbs(target) {
+				target = filepath.Join(filepath.Dir(path), target)
+			}
+			target, err = filepath.Abs(target)
+			if err != nil {
+				return fmt.Errorf("failed to resolve symlink target %s: %w", target, err)
+			}
+
+			// Security check: ensure target is within root directory
+			relPath, err := filepath.Rel(rootDir, target)
+			if err != nil || strings.HasPrefix(relPath, "..") {
+				// Symlink points outside root directory - skip it
+				return nil
+			}
+
+			symlinks = append(symlinks, symlinkInfo{
+				path:   path,
+				target: target,
+			})
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Second pass: resolve symlinks (process in reverse order to handle nested symlinks)
+	for i := len(symlinks) - 1; i >= 0; i-- {
+		sym := symlinks[i]
+
+		// Check if target still exists
+		targetInfo, err := os.Lstat(sym.target)
+		if err != nil {
+			// Target doesn't exist - skip broken symlink
+			continue
+		}
+
+		// Remove the symlink
+		if err := os.Remove(sym.path); err != nil {
+			return fmt.Errorf("failed to remove symlink %s: %w", sym.path, err)
+		}
+
+		// Copy target to symlink location
+		if targetInfo.IsDir() {
+			// Copy directory recursively
+			if err := copyDir(sym.target, sym.path); err != nil {
+				return fmt.Errorf("failed to copy directory from %s to %s: %w", sym.target, sym.path, err)
+			}
+		} else {
+			// Copy file
+			if err := copyFile(sym.target, sym.path); err != nil {
+				return fmt.Errorf("failed to copy file from %s to %s: %w", sym.target, sym.path, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// copyFile copies a file from src to dst.
+func copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = destFile.ReadFrom(sourceFile)
+	if err != nil {
+		return err
+	}
+
+	// Preserve file mode
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(dst, srcInfo.Mode())
+}
+
+// copyDir recursively copies a directory from src to dst.
+func copyDir(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dst, srcInfo.Mode()); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			// Check if it's a symlink
+			info, err := os.Lstat(srcPath)
+			if err != nil {
+				return err
+			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				// Resolve symlink recursively
+				target, err := os.Readlink(srcPath)
+				if err != nil {
+					return err
+				}
+				if !filepath.IsAbs(target) {
+					target = filepath.Join(filepath.Dir(srcPath), target)
+				}
+				targetInfo, err := os.Lstat(target)
+				if err != nil {
+					continue // Skip broken symlink
+				}
+				if targetInfo.IsDir() {
+					if err := copyDir(target, dstPath); err != nil {
+						return err
+					}
+				} else {
+					if err := copyFile(target, dstPath); err != nil {
+						return err
+					}
+				}
+			} else {
+				if err := copyFile(srcPath, dstPath); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 // requiresVerification inspects a GitRepository's verification spec and its status


### PR DESCRIPTION
- **Handle symlinks within GitRespository**
- **Improve security for symlinks within GitRepository**

Helm charts may include symlinks to common library charts under /charts. Currently, these are not handled.
This PR adds functionality to properly handle symlinks within a GitRepository, ensuring that all Helm charts using this approach are prepared correctly.
It also introduces a check to prevent users from including files outside their repository.

Example:

```yaml
apiVersion: source.toolkit.fluxcd.io/v1
kind: GitRepository
metadata:
  name: cozy-git
  namespace: cozy-public
spec:
  interval: 1m0s
  ref:
    tag: v0.37.5
  timeout: 60s
  url: https://github.com/cozystack/cozystack.git
  ignore: |
    # exclude all
    /*
    # include packages dir
    !/packages
---
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  name: virtual-machine-asd2
  namespace: tenant-user
spec:
  interval: 5m
  targetNamespace: cozy-system
  chart:
    spec:
      chart: ./packages/apps/virtual-machine
      sourceRef:
        kind: GitRepository
        name: cozy-git
        namespace: cozy-public
      version: '>= 0.0.0-0'
  install:
    remediation:
      retries: -1
  upgrade:
    remediation:
      retries: -1
  values:
    cloudInit: ""
    cloudInitSeed: ""
    external: false
    externalMethod: PortList
    externalPorts:
    - 22
    instanceProfile: ubuntu
    instanceType: u1.medium
    running: true
    systemDisk:
      image: ubuntu
      storage: 5Gi
      storageClass: replicated
```