### PR TITLE
sourcev1: align CRD validation with v1beta2

### DIFF
--- a/api/v1/helmchart_types.go
+++ b/api/v1/helmchart_types.go
@@ -28,6 +28,7 @@ import (
 const HelmChartKind = "HelmChart"
 
 // HelmChartSpec specifies the desired state of a Helm chart.
+// +kubebuilder:validation:XValidation:rule="!has(self.verify) || self.sourceRef.kind == 'HelmRepository'",message="spec.verify is only supported when spec.sourceRef.kind is 'HelmRepository'"
 type HelmChartSpec struct {
 	// Chart is the name or path the Helm chart is available at in the
 	// SourceRef.

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -198,6 +198,9 @@ spec:
             - interval
             - sourceRef
             type: object
+            x-kubernetes-validations:
+            - message: spec.verify is only supported when spec.sourceRef.kind is 'HelmRepository'
+              rule: '!has(self.verify) || self.sourceRef.kind == ''HelmRepository'''
           status:
             default:
               observedGeneration: -1


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/2993

Summary

Align source.toolkit.fluxcd.io/v1 CRD validation with the existing v1beta2 behavior and documentation.

Changes

HelmChart
- Add XValidation so .spec.verify is only allowed when .spec.sourceRef.kind is "HelmRepository", consistent with v1beta2 semantics.

No controller logic changes, only schema-level validation so invalid specs fail at admission instead of at reconciliation.

Testing

On an Ubuntu VM:

- make manifests
- cd api && go test ./...
- export KUBEBUILDER_ASSETS=/home/kevin/src/github.com/kthurman59/source-controller/build/testbin/k8s/1.34.1-linux-amd64
- go test ./...
