### PR TITLE
Add `--oci-skip-registry-validation` flag for custom registry proxies

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,27 +96,28 @@ func main() {
 	)
 
 	var (
-		metricsAddr            string
-		eventsAddr             string
-		healthAddr             string
-		concurrent             int
-		requeueDependency      time.Duration
-		helmIndexLimit         int64
-		helmChartLimit         int64
-		helmChartFileLimit     int64
-		artifactOptions        artcfg.Options
-		clientOptions          client.Options
-		logOptions             logger.Options
-		leaderElectionOptions  leaderelection.Options
-		rateLimiterOptions     helper.RateLimiterOptions
-		featureGates           feathelper.FeatureGates
-		watchOptions           helper.WatchOptions
-		intervalJitterOptions  jitter.IntervalOptions
-		helmCacheMaxSize       int
-		helmCacheTTL           string
-		helmCachePurgeInterval string
-		tokenCacheOptions      pkgcache.TokenFlags
-		defaultServiceAccount  string
+		metricsAddr               string
+		eventsAddr                string
+		healthAddr                string
+		concurrent                int
+		requeueDependency         time.Duration
+		helmIndexLimit            int64
+		helmChartLimit            int64
+		helmChartFileLimit        int64
+		artifactOptions           artcfg.Options
+		clientOptions             client.Options
+		logOptions                logger.Options
+		leaderElectionOptions     leaderelection.Options
+		rateLimiterOptions        helper.RateLimiterOptions
+		featureGates              feathelper.FeatureGates
+		watchOptions              helper.WatchOptions
+		intervalJitterOptions     jitter.IntervalOptions
+		helmCacheMaxSize          int
+		helmCacheTTL              string
+		helmCachePurgeInterval    string
+		tokenCacheOptions         pkgcache.TokenFlags
+		defaultServiceAccount     string
+		ociSkipRegistryValidation bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", envOrDefault("METRICS_ADDR", ":8080"),
@@ -145,6 +146,9 @@ func main() {
 		"The list of hostkey algorithms to use for ssh connections, arranged from most preferred to the least.")
 	flag.StringVar(&defaultServiceAccount, auth.ControllerFlagDefaultServiceAccount,
 		"", "Default service account to use for workload identity when not specified in resources.")
+	flag.BoolVar(&ociSkipRegistryValidation, auth.ControllerFlagOCISkipRegistryValidation, false,
+		"Skip OCI registry domain validation for cloud provider authentication. "+
+			"Enables using custom registry proxies/gateways with workload identity.")
 
 	artifactOptions.BindFlags(flag.CommandLine)
 	clientOptions.BindFlags(flag.CommandLine)
@@ -162,6 +166,10 @@ func main() {
 
 	if defaultServiceAccount != "" {
 		auth.SetDefaultServiceAccount(defaultServiceAccount)
+	}
+
+	if ociSkipRegistryValidation {
+		auth.SetOCISkipRegistryValidation(true)
 	}
 
 	if err := featureGates.WithLogger(setupLog).SupportedFeatures(features.FeatureGates()); err != nil {


### PR DESCRIPTION
### Summary

This PR adds the `--oci-skip-registry-validation` flag to source-controller, enabling the use of custom OCI registry proxies/gateways with cloud provider workload identity authentication.

### Problem

Organizations using custom OCI registry proxies cannot use cloud provider authentication (GCP, AWS, Azure) because the auth package validates that registry domains match official patterns.

Example error:
```
HelmChart 'xxx' is not ready: unknown build error:
failed to get credential from 'gcp': failed to parse artifact repository
'oci-gateway.example.org/oci/charts/': invalid GCP registry:
'oci-gateway.example.org'. must match ^(((.+\.)?gcr\.io)|(.+-docker\.pkg\.dev))$
```

### Solution

Add support for the new `--oci-skip-registry-validation` flag from `fluxcd/pkg/auth` that bypasses domain validation for all cloud providers.

### Changes

#### `main.go`
- Added `ociSkipRegistryValidation` variable
- Added flag binding for `--oci-skip-registry-validation`
- Added call to `auth.SetOCISkipRegistryValidation(true)` when flag is enabled

### Usage

Deploy source-controller with:
```yaml
spec:
  containers:
    - name: manager
      args:
        - --oci-skip-registry-validation=true
```

Or via Helm values:
```yaml
extraArgs:
  - --oci-skip-registry-validation=true
```

### Security Considerations

- This flag should only be enabled when using trusted registry proxies
- The proxy is responsible for validating upstream registry access
- Cloud provider credentials will be sent to the configured registry endpoint
- Consider network policies to restrict egress to known proxy endpoints

### Dependencies

- Requires fluxcd/pkg/auth with `ControllerFlagOCISkipRegistryValidation` support (https://github.com/fluxcd/pkg/pull/1083)

### Related

- Closes https://github.com/fluxcd/source-controller/issues/1974
- Depends on https://github.com/fluxcd/pkg/pull/1083
