### PR TITLE
helmchart: support ExternalArtifact as a HelmChart source reference

### DIFF
--- a/api/v1/helmchart_types.go
+++ b/api/v1/helmchart_types.go
@@ -105,8 +105,8 @@ type LocalHelmChartSourceReference struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 
 	// Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
-	// 'Bucket').
-	// +kubebuilder:validation:Enum=HelmRepository;GitRepository;Bucket
+	// 'Bucket', 'ExternalArtifact').
+	// +kubebuilder:validation:Enum=HelmRepository;GitRepository;Bucket;ExternalArtifact
 	// +required
 	Kind string `json:"kind"`
 

--- a/internal/controller/helmchart_controller.go
+++ b/internal/controller/helmchart_controller.go
@@ -201,6 +201,11 @@ func (r *HelmChartReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 			handler.EnqueueRequestsFromMapFunc(r.requestsForBucketChange),
 			builder.WithPredicates(SourceRevisionChangePredicate{}),
 		).
+		Watches(
+			&sourcev1.ExternalArtifact{},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForExternalArtifactChange),
+			builder.WithPredicates(SourceRevisionChangePredicate{}),
+		).
 		WithOptions(controller.Options{
 			RateLimiter: opts.RateLimiter,
 		}).
@@ -507,6 +512,8 @@ func (r *HelmChartReconciler) reconcileSource(ctx context.Context, sp *patch.Ser
 	case *sourcev1.HelmRepository:
 		return r.buildFromHelmRepository(ctx, obj, typedSource, build)
 	case *sourcev1.GitRepository, *sourcev1.Bucket:
+		return r.buildFromTarballArtifact(ctx, obj, *typedSource.GetArtifact(), build)
+	case *sourcev1.ExternalArtifact:
 		return r.buildFromTarballArtifact(ctx, obj, *typedSource.GetArtifact(), build)
 	default:
 		// Ending up here should generally not be possible
@@ -931,9 +938,15 @@ func (r *HelmChartReconciler) getSource(ctx context.Context, obj *sourcev1.HelmC
 			return nil, err
 		}
 		s = &bucket
+	case sourcev1.ExternalArtifactKind:
+		var ea sourcev1.ExternalArtifact
+		if err := r.Client.Get(ctx, namespacedName, &ea); err != nil {
+			return nil, err
+		}
+		s = &ea
 	default:
 		return nil, fmt.Errorf("unsupported source kind '%s', must be one of: %v", obj.Spec.SourceRef.Kind, []string{
-			sourcev1.HelmRepositoryKind, sourcev1.GitRepositoryKind, sourcev1.BucketKind})
+			sourcev1.HelmRepositoryKind, sourcev1.GitRepositoryKind, sourcev1.BucketKind, sourcev1.ExternalArtifactKind})
 	}
 	return s, nil
 }
@@ -1196,6 +1209,36 @@ func (r *HelmChartReconciler) requestsForBucketChange(ctx context.Context, o cli
 	var reqs []reconcile.Request
 	for i, v := range list.Items {
 		if !bucket.GetArtifact().HasRevision(v.Status.ObservedSourceArtifactRevision) {
+			reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&list.Items[i])})
+		}
+	}
+	return reqs
+}
+
+func (r *HelmChartReconciler) requestsForExternalArtifactChange(ctx context.Context, o client.Object) []reconcile.Request {
+	ea, ok := o.(*sourcev1.ExternalArtifact)
+	if !ok {
+		ctrl.LoggerFrom(ctx).Error(fmt.Errorf("expected an ExternalArtifact, got %T", o),
+			"failed to get reconcile requests for ExternalArtifact change")
+		return nil
+	}
+
+	// If we do not have an artifact, we have no requests to make
+	if ea.GetArtifact() == nil {
+		return nil
+	}
+
+	var list sourcev1.HelmChartList
+	if err := r.List(ctx, &list, client.MatchingFields{
+		indexKeyHelmChartSource: fmt.Sprintf("%s/%s", sourcev1.ExternalArtifactKind, ea.Name),
+	}); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "failed to list HelmCharts for ExternalArtifact change")
+		return nil
+	}
+
+	var reqs []reconcile.Request
+	for i, v := range list.Items {
+		if !ea.GetArtifact().HasRevision(v.Status.ObservedSourceArtifactRevision) {
 			reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&list.Items[i])})
 		}
 	}


### PR DESCRIPTION
## Problem

`ExternalArtifact` was introduced as a first-class source kind in v1.7.0, but it was never wired into the `HelmChart` controller. Any attempt to reference it produces:

```
HelmChart 'infra/infra-diagnostic-tools' is not ready: failed to get source: unsupported source kind 'ExternalArtifact', must be one of: [HelmRepository GitRepository Bucket]
```

There are three independent blocking points:

1. **API validation** — `LocalHelmChartSourceReference.Kind` has a kubebuilder enum that only allows `HelmRepository`, `GitRepository`, and `Bucket`. A manifest with `kind: ExternalArtifact` is rejected at apply time.
2. **`getSource()`** — a `switch` with a `default` case returns the error above at reconcile time.
3. **`reconcileSource()`** — a second `switch` with a `default` case returns an empty result without building the chart.

Additionally, there is no `Watches` registration for `ExternalArtifact`, so revision changes would never trigger HelmChart reconciliation even if the above were fixed.

## Solution

`ExternalArtifact` already satisfies the `Source` interface and exposes a tarball artifact with the same structure as `Bucket` and `GitRepository` (via `GetArtifact()` returning `*meta.Artifact`). This means the existing `buildFromTarballArtifact` path can be reused directly — **no new builder code is required**.

This PR makes the minimum set of changes to fully unlock `ExternalArtifact` as a HelmChart source.

## Changes

| File | Change |
|------|--------|
| `api/v1/helmchart_types.go` | Extend `+kubebuilder:validation:Enum` on `LocalHelmChartSourceReference.Kind` to include `ExternalArtifact` |
| `internal/controller/helmchart_controller.go` | Register `Watches(&sourcev1.ExternalArtifact{}, ...)` in `SetupWithManager` |
| `internal/controller/helmchart_controller.go` | Add `case sourcev1.ExternalArtifactKind:` to `getSource()` |
| `internal/controller/helmchart_controller.go` | Add `case *sourcev1.ExternalArtifact:` to `reconcileSource()` |
| `internal/controller/helmchart_controller.go` | Add `requestsForExternalArtifactChange()` reconcile-trigger helper, mirroring `requestsForBucketChange` |

## Testing

```
go build ./...
go vet ./internal/controller/...
```

Both pass cleanly. I can add integration/unit tests if that would help the review — let me know the preferred approach.
