### PR TITLE
docs: add debugging tips to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,6 +54,62 @@ Run the controller locally:
 make run
 ```
 
+### Debugging tips
+
+**Limit watched namespaces**
+
+Set `RUNTIME_NAMESPACE` to restrict the controller to a single namespace,
+which reduces noise when debugging a specific issue:
+
+```sh
+export RUNTIME_NAMESPACE=flux-system
+make run
+```
+
+**Decrease concurrency**
+
+Lower `--concurrent` to `1` so that reconcile loops run sequentially,
+making it easier to follow logs and reproduce ordering issues:
+
+```sh
+make run ARGS="--concurrent=1"
+```
+
+**Set the controller hostname**
+
+The controller uses the `HOSTNAME` environment variable as its identity
+for leader election. When running locally, set it to match the
+in-cluster deployment name to avoid lease conflicts:
+
+```sh
+export HOSTNAME=source-controller
+make run
+```
+
+**Suspend irrelevant objects**
+
+Suspend Flux objects that are unrelated to the issue you are
+investigating so that their reconciliation does not add log noise:
+
+```sh
+kubectl -n flux-system patch gitrepository <name> \
+  --type=merge -p '{"spec":{"suspend":true}}'
+```
+
+Replace `gitrepository` with `helmrepository`, `ocirepository`, or
+`bucket` as appropriate.
+
+**Scale down the in-cluster controller**
+
+If `source-controller` is already running in your cluster, scale it
+down before running locally to avoid competing reconciliations:
+
+```sh
+kubectl -n flux-system scale deployment/source-controller --replicas=0
+# restore when done:
+kubectl -n flux-system scale deployment/source-controller --replicas=1
+```
+
 ## How to install the controller
 
 ### Building the container image

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,10 +69,13 @@ make run
 **Decrease concurrency**
 
 Lower `--concurrent` to `1` so that reconcile loops run sequentially,
-making it easier to follow logs and reproduce ordering issues:
+making it easier to follow logs and reproduce ordering issues. The `run`
+target does not pass extra arguments through, so invoke `go run` directly
+with the same flags it uses:
 
 ```sh
-make run ARGS="--concurrent=1"
+mkdir -p bin/data
+go run ./main.go --storage-adv-addr=:0 --storage-path=$(pwd)/bin/data --concurrent=1
 ```
 
 **Set the controller hostname**


### PR DESCRIPTION
## What this PR does

Expands `DEVELOPMENT.md` with a **Debugging tips** section under "How to run the controller locally", covering the items listed in #666:

- **`RUNTIME_NAMESPACE`** — restrict watched namespaces to reduce noise
- **`--concurrent=1`** — serialise reconcile loops for easier tracing
- **`HOSTNAME`** — set controller identity for local leader election
- **Suspending irrelevant objects** — patch `spec.suspend: true` on unrelated resources
- **Scaling down the in-cluster controller** — avoid competing reconciliations

Fixes #666.

Assisted-by: Claude/claude-opus-4-7