### PR TITLE
docs: clarify that .spec.ignore extends defaults rather than overriding

### DIFF
--- a/api/v1/bucket_types.go
+++ b/api/v1/bucket_types.go
@@ -140,7 +140,7 @@ type BucketSpec struct {
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
-	// Ignore overrides the set of excluded patterns in the .sourceignore format
+	// Ignore extends the set of excluded patterns in the .sourceignore format
 	// (which is the same as .gitignore). If not provided, a default will be used,
 	// consult the documentation for your version to find out what those are.
 	// +optional

--- a/api/v1/gitrepository_types.go
+++ b/api/v1/gitrepository_types.go
@@ -138,7 +138,7 @@ type GitRepositorySpec struct {
 	// +optional
 	ProxySecretRef *meta.LocalObjectReference `json:"proxySecretRef,omitempty"`
 
-	// Ignore overrides the set of excluded patterns in the .sourceignore format
+	// Ignore extends the set of excluded patterns in the .sourceignore format
 	// (which is the same as .gitignore). If not provided, a default will be used,
 	// consult the documentation for your version to find out what those are.
 	// +optional

--- a/api/v1/ocirepository_types.go
+++ b/api/v1/ocirepository_types.go
@@ -131,7 +131,7 @@ type OCIRepositorySpec struct {
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
-	// Ignore overrides the set of excluded patterns in the .sourceignore format
+	// Ignore extends the set of excluded patterns in the .sourceignore format
 	// (which is the same as .gitignore). If not provided, a default will be used,
 	// consult the documentation for your version to find out what those are.
 	// +optional

--- a/docs/api/v1/source.md
+++ b/docs/api/v1/source.md
@@ -274,7 +274,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Ignore overrides the set of excluded patterns in the .sourceignore format
+<p>Ignore extends the set of excluded patterns in the .sourceignore format
 (which is the same as .gitignore). If not provided, a default will be used,
 consult the documentation for your version to find out what those are.</p>
 </td>
@@ -507,7 +507,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Ignore overrides the set of excluded patterns in the .sourceignore format
+<p>Ignore extends the set of excluded patterns in the .sourceignore format
 (which is the same as .gitignore). If not provided, a default will be used,
 consult the documentation for your version to find out what those are.</p>
 </td>
@@ -1279,7 +1279,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Ignore overrides the set of excluded patterns in the .sourceignore format
+<p>Ignore extends the set of excluded patterns in the .sourceignore format
 (which is the same as .gitignore). If not provided, a default will be used,
 consult the documentation for your version to find out what those are.</p>
 </td>
@@ -1631,7 +1631,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Ignore overrides the set of excluded patterns in the .sourceignore format
+<p>Ignore extends the set of excluded patterns in the .sourceignore format
 (which is the same as .gitignore). If not provided, a default will be used,
 consult the documentation for your version to find out what those are.</p>
 </td>
@@ -2220,7 +2220,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Ignore overrides the set of excluded patterns in the .sourceignore format
+<p>Ignore extends the set of excluded patterns in the .sourceignore format
 (which is the same as .gitignore). If not provided, a default will be used,
 consult the documentation for your version to find out what those are.</p>
 </td>
@@ -3451,7 +3451,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Ignore overrides the set of excluded patterns in the .sourceignore format
+<p>Ignore extends the set of excluded patterns in the .sourceignore format
 (which is the same as .gitignore). If not provided, a default will be used,
 consult the documentation for your version to find out what those are.</p>
 </td>

--- a/docs/spec/v1/buckets.md
+++ b/docs/spec/v1/buckets.md
@@ -1022,7 +1022,7 @@ as a more efficient way of excluding files.
 pattern format](https://git-scm.com/docs/gitignore#_pattern_format). Storage
 objects which keys match the defined rules are excluded while fetching.
 
-When specified, `.spec.ignore` overrides the [default exclusion
+When specified, `.spec.ignore` extends the [default exclusion
 list](#default-exclusions), and may overrule the [`.sourceignore` file
 exclusions](#sourceignore-file). See [excluding files](#excluding-files)
 for more information.

--- a/docs/spec/v1/gitrepositories.md
+++ b/docs/spec/v1/gitrepositories.md
@@ -701,7 +701,7 @@ kubectl create secret generic pgp-public-keys \
 pattern format](https://git-scm.com/docs/gitignore#_pattern_format). Paths
 matching the defined rules are excluded while archiving.
 
-When specified, `.spec.ignore` overrides the [default exclusion
+When specified, `.spec.ignore` extends the [default exclusion
 list](#default-exclusions), and may overrule the [`.sourceignore` file
 exclusions](#sourceignore-file). See [excluding files](#excluding-files)
 for more information.
@@ -851,7 +851,7 @@ placed in the repository root or in subdirectories.
 #### Ignore spec
 
 Another option is to define the exclusions within the GitRepository spec, using
-the [`.spec.ignore` field](#ignore). Specified rules override the [default
+the [`.spec.ignore` field](#ignore). Specified rules extend the [default
 exclusion list](#default-exclusions), and may overrule `.sourceignore` file
 exclusions.
 

--- a/docs/spec/v1/ocirepositories.md
+++ b/docs/spec/v1/ocirepositories.md
@@ -538,7 +538,7 @@ keeping the original content unaltered.
 pattern format](https://git-scm.com/docs/gitignore#_pattern_format). Paths
 matching the defined rules are excluded while archiving.
 
-When specified, `.spec.ignore` overrides the [default exclusion
+When specified, `.spec.ignore` extends the [default exclusion
 list](#default-exclusions), and may overrule the [`.sourceignore` file
 exclusions](#sourceignore-file). See [excluding files](#excluding-files)
 for more information.


### PR DESCRIPTION
## Summary

Both the v1 API godoc and the v1 spec docs say that `.spec.ignore` *overrides* the default exclusion list, but the controller actually *appends* the spec patterns to the defaults (see [`gitrepository_controller.go:887`](https://github.com/fluxcd/source-controller/blob/main/internal/controller/gitrepository_controller.go#L887), [`ocirepository_controller.go:1163`](https://github.com/fluxcd/source-controller/blob/main/internal/controller/ocirepository_controller.go#L1163), [`bucket_controller.go:708`](https://github.com/fluxcd/source-controller/blob/main/internal/controller/bucket_controller.go#L708)). Setting `spec.ignore: ".git/"` therefore still drops the rest of the default exclusions (`.gitignore`, `.gitmodules`, `.gitattributes`), which is *extend* semantics, not *override*.

This is the docs-only side of #429 (the issue's option 1). Behaviour is unchanged; just the wording in:

- `api/v1/{gitrepository,bucket,ocirepository}_types.go` (godoc)
- `docs/api/v1/source.md` (regenerated from the godoc)
- `docs/spec/v1/{gitrepositories,buckets,ocirepositories}.md` (prose)

is updated from *overrides* → *extends*. v1beta1/v1beta2 / v1alpha1 docs are deprecated and left untouched.

Fixes #429

Assisted-by: Claude/claude-opus-4-7