### PR TITLE
Fix file descriptor leak in GCP FGetObject on error paths

### DIFF
--- a/internal/bucket/gcp/gcp.go
+++ b/internal/bucket/gcp/gcp.go
@@ -235,6 +235,9 @@ func (c *GCSClient) FGetObject(ctx context.Context, bucketName, objectName, loca
 		GenerationMatch: objAttr.Generation,
 	}).NewReader(ctx)
 	if err != nil {
+		if cerr := objectFile.Close(); cerr != nil {
+			ctrl.LoggerFrom(ctx).Error(cerr, "failed to close file after reader error")
+		}
 		return "", err
 	}
 	defer func() {
@@ -245,6 +248,9 @@ func (c *GCSClient) FGetObject(ctx context.Context, bucketName, objectName, loca
 
 	// Write Object to file.
 	if _, err := io.Copy(objectFile, objectReader); err != nil {
+		if cerr := objectFile.Close(); cerr != nil {
+			ctrl.LoggerFrom(ctx).Error(cerr, "failed to close file after copy error")
+		}
 		return "", err
 	}
 


### PR DESCRIPTION
## Summary

`objectFile` opened with `os.OpenFile` in `GCSClient.FGetObject` is only closed on the happy path. If `NewReader` or `io.Copy` fails, the file descriptor leaks.

## Fix

Close `objectFile` on each error path with checked close errors, matching the pattern used by the Azure `BlobClient.FGetObject` implementation (`blob.go:328-336`).

The initial version used `defer objectFile.Close()`, which CodeQL flagged as discarding the close error on a writable file handle ([code-scanning/6](https://github.com/fluxcd/source-controller/security/code-scanning/6)). The updated fix uses explicit close-on-error instead, consistent with the existing Azure pattern.

## Error paths fixed

| Error path | Before | After |
|---|---|---|
| `NewReader` fails | fd leaks | `objectFile.Close()` called, error logged |
| `io.Copy` fails | fd leaks | `objectFile.Close()` called, error logged |
| Happy path | `objectFile.Close()` checked | unchanged |

## Origin

The leak was introduced in #434 (2021-09-01) when GCS support was added.