### PR TITLE
Improve error message for invalid Helm chart repository URLs

### DIFF
--- a/internal/controller/helmrepository_controller.go
+++ b/internal/controller/helmrepository_controller.go
@@ -450,7 +450,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 	// Fetch the repository index from remote.
 	if err := newChartRepo.CacheIndex(); err != nil {
 		e := serror.NewGeneric(
-			fmt.Errorf("failed to fetch Helm repository index: %w", err),
+			invalidChartRepoError(obj.Spec.URL, err),
 			meta.FailedReason,
 		)
 		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
@@ -476,7 +476,7 @@ func (r *HelmRepositoryReconciler) reconcileSource(ctx context.Context, sp *patc
 	// Load the cached repository index to ensure it passes validation.
 	if err := chartRepo.LoadFromPath(); err != nil {
 		e := serror.NewGeneric(
-			fmt.Errorf("failed to load Helm repository from index YAML: %w", err),
+			invalidChartRepoError(obj.Spec.URL, err),
 			sourcev1.IndexationFailedReason,
 		)
 		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
@@ -722,4 +722,11 @@ func (r *HelmRepositoryReconciler) migrationToStatic(ctx context.Context, sp *pa
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// invalidChartRepoError formats an error indicating the given URL is not
+// a valid Helm chart repository or cannot be reached, mirroring the
+// `helm repo add` CLI output.
+func invalidChartRepoError(repoURL string, err error) error {
+	return fmt.Errorf("looks like %q is not a valid chart repository or cannot be reached: %w", repoURL, err)
 }


### PR DESCRIPTION
## What's changed

Wrap the two error paths in the HelmRepository reconciler with a helm-CLI-style message that includes the repository URL:

```
looks like "https://example.com" is not a valid chart repository or cannot be reached: <underlying error>
```

**CacheIndex failure** (e.g. 404 from upstream): the underlying HTTPGetter error already carries the URL and status, but the operator event only showed `failed to fetch Helm repository index`. Users had to correlate the URL from the HelmRepository spec manually.

**LoadFromPath failure** (e.g. server returns HTML at 200): IndexFromBytes fails to unmarshal the index YAML, but the error only said `failed to load Helm repository from index YAML` with no URL context.

Both cases now surface:

```
looks like "https://my-repo.example.com" is not a valid chart repository or cannot be reached: <root cause>
```

The format mirrors what `helm repo add` emits and what was requested in #654.

## How to test

1. Create a HelmRepository pointing to a non-existent URL (404): the `Ready=False` condition message will include the repository URL.
2. Point to a URL that returns HTML instead of a YAML index: same format.

## Related

Closes #654

Precedent: #2013 / commit 790be384 (improved SSH key error message, same pattern).