### PR TITLE
fix: close OCI blob reader and wrap errors consistently across controllers

### DIFF
--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -568,7 +568,7 @@ func (r *BucketReconciler) reconcileArtifact(ctx context.Context, sp *patch.Seri
 	// Archive directory to storage
 	if err := r.Storage.Archive(&artifact, dir, nil); err != nil {
 		e := serror.NewGeneric(
-			fmt.Errorf("unable to archive artifact to storage: %s", err),
+			fmt.Errorf("unable to archive artifact to storage: %w", err),
 			sourcev1.ArchiveOperationFailedReason,
 		)
 		conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)
@@ -622,7 +622,7 @@ func (r *BucketReconciler) garbageCollect(ctx context.Context, obj *sourcev1.Buc
 	if !obj.DeletionTimestamp.IsZero() {
 		if deleted, err := r.Storage.RemoveAll(r.Storage.NewArtifactFor(obj.Kind, obj.GetObjectMeta(), "", "*")); err != nil {
 			return serror.NewGeneric(
-				fmt.Errorf("garbage collection for deleted resource failed: %s", err),
+				fmt.Errorf("garbage collection for deleted resource failed: %w", err),
 				"GarbageCollectionFailed",
 			)
 		} else if deleted != "" {

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -559,7 +559,7 @@ func (r *GitRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 		// Check if the content config contributing to the artifact has changed.
 		if !gitContentConfigChanged(obj, includes) {
 			ge := serror.NewGeneric(
-				fmt.Errorf("no changes since last reconcilation: observed revision '%s'",
+				fmt.Errorf("no changes since last reconciliation: observed revision '%s'",
 					commitReference(obj, commit)), sourcev1.GitOperationSucceedReason,
 			)
 			ge.Notification = false

--- a/internal/controller/ocirepository_controller.go
+++ b/internal/controller/ocirepository_controller.go
@@ -537,6 +537,7 @@ func (r *OCIRepositoryReconciler) reconcileSource(ctx context.Context, sp *patch
 		conditions.MarkTrue(obj, sourcev1.FetchFailedCondition, e.Reason, "%s", e)
 		return sreconcile.ResultEmpty, e
 	}
+	defer blob.Close()
 
 	// Persist layer content to storage using the specified operation
 	switch obj.GetLayerOperation() {
@@ -1201,7 +1202,7 @@ func (r *OCIRepositoryReconciler) reconcileArtifact(ctx context.Context, sp *pat
 
 		if err := r.Storage.Archive(&artifact, dir, storage.SourceIgnoreFilter(ps, ignoreDomain)); err != nil {
 			e := serror.NewGeneric(
-				fmt.Errorf("unable to archive artifact to storage: %s", err),
+				fmt.Errorf("unable to archive artifact to storage: %w", err),
 				sourcev1.ArchiveOperationFailedReason,
 			)
 			conditions.MarkTrue(obj, sourcev1.StorageOperationFailedCondition, e.Reason, "%s", e)


### PR DESCRIPTION
3 small fixes:

1. `selectLayer()` returns `io.ReadCloser` but the caller never closes it. `tar.Untar` wraps it in `io.NopCloser` so the registry connection leaks on every reconcile. Added `defer blob.Close()`.

2. `bucket_controller` and `ocirepository_controller` use `%s` in `fmt.Errorf`, breaking `errors.Is`/`errors.As`. `gitrepository_controller` already uses `%w` for the same message -- making the others consistent.

3. Typo: `reconcilation` -> `reconciliation` in a user-visible message.

**Reproduce the leak:** run with many `OCIRepository` resources on a short interval and watch `lsof -p <pid> | grep -c socket` climb without dropping between reconciles. Related: #1867.