### PR TITLE
Add backport:release/v1.9.x label

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -43,3 +43,6 @@
 - name: backport:release/v1.8.x
   description: To be backported to release/v1.8.x
   color: '#ffd700'
+- name: backport:release/v1.9.x
+  description: To be backported to release/v1.9.x
+  color: '#ffd700'


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/5942