### PR TITLE
Add categories to source-controller CRDs

### DIFF
--- a/api/v1/bucket_types.go
+++ b/api/v1/bucket_types.go
@@ -252,6 +252,7 @@ func (in *Bucket) GetArtifact() *meta.Artifact {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all;fluxcd;fluxcd-sources
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""

--- a/api/v1/externalartifact_types.go
+++ b/api/v1/externalartifact_types.go
@@ -69,6 +69,7 @@ func (in *ExternalArtifact) GetRequeueAfter() time.Duration {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=ea,categories=all;fluxcd;fluxcd-sources
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""

--- a/api/v1/gitrepository_types.go
+++ b/api/v1/gitrepository_types.go
@@ -359,7 +359,7 @@ func (v *GitRepositoryVerification) VerifyTag() bool {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=gitrepo
+// +kubebuilder:resource:shortName=gitrepo,categories=all;fluxcd;fluxcd-sources
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""

--- a/api/v1/helmchart_types.go
+++ b/api/v1/helmchart_types.go
@@ -195,7 +195,7 @@ func (in *HelmChart) GetValuesFiles() []string {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=hc
+// +kubebuilder:resource:shortName=hc,categories=all;fluxcd;fluxcd-sources
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Chart",type=string,JSONPath=`.spec.chart`
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.version`

--- a/api/v1/helmrepository_types.go
+++ b/api/v1/helmrepository_types.go
@@ -195,7 +195,7 @@ func (in *HelmRepository) GetArtifact() *meta.Artifact {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=helmrepo
+// +kubebuilder:resource:shortName=helmrepo,categories=all;fluxcd;fluxcd-sources
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""

--- a/api/v1/ocirepository_types.go
+++ b/api/v1/ocirepository_types.go
@@ -266,7 +266,7 @@ func (in *OCIRepository) GetLayerOperation() string {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=ocirepo
+// +kubebuilder:resource:shortName=ocirepo,categories=all;fluxcd;fluxcd-sources
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""

--- a/api/v1beta1/gitrepository_types.go
+++ b/api/v1beta1/gitrepository_types.go
@@ -266,7 +266,6 @@ func (in *GitRepository) GetInterval() metav1.Duration {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=gitrepo
 // +kubebuilder:skipversion
 
 // GitRepository is the Schema for the gitrepositories API

--- a/api/v1beta1/helmchart_types.go
+++ b/api/v1beta1/helmchart_types.go
@@ -232,7 +232,6 @@ func (in *HelmChart) GetValuesFiles() []string {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=hc
 // +kubebuilder:skipversion
 
 // HelmChart is the Schema for the helmcharts API

--- a/api/v1beta1/helmrepository_types.go
+++ b/api/v1beta1/helmrepository_types.go
@@ -182,7 +182,6 @@ func (in *HelmRepository) GetInterval() metav1.Duration {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=helmrepo
 // +kubebuilder:skipversion
 
 // HelmRepository is the Schema for the helmrepositories API

--- a/api/v1beta2/gitrepository_types.go
+++ b/api/v1beta2/gitrepository_types.go
@@ -286,7 +286,6 @@ func (in *GitRepository) GetArtifact() *meta.Artifact {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=gitrepo
 // +kubebuilder:skipversion
 
 // GitRepository is the Schema for the gitrepositories API.

--- a/api/v1beta2/helmchart_types.go
+++ b/api/v1beta2/helmchart_types.go
@@ -216,7 +216,6 @@ func (in *HelmChart) GetValuesFiles() []string {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=hc
 // +kubebuilder:skipversion
 
 // HelmChart is the Schema for the helmcharts API.

--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -197,7 +197,6 @@ func (in *HelmRepository) GetArtifact() *meta.Artifact {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=helmrepo
 // +kubebuilder:skipversion
 
 // HelmRepository is the Schema for the helmrepositories API.

--- a/api/v1beta2/ocirepository_types.go
+++ b/api/v1beta2/ocirepository_types.go
@@ -284,7 +284,6 @@ func (in *OCIRepository) GetLayerOperation() string {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=ocirepo
 // +kubebuilder:skipversion
 
 // OCIRepository is the Schema for the ocirepositories API

--- a/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: source.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-sources
     kind: Bucket
     listKind: BucketList
     plural: buckets

--- a/config/crd/bases/source.toolkit.fluxcd.io_externalartifacts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_externalartifacts.yaml
@@ -8,9 +8,15 @@ metadata:
 spec:
   group: source.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-sources
     kind: ExternalArtifact
     listKind: ExternalArtifactList
     plural: externalartifacts
+    shortNames:
+    - ea
     singular: externalartifact
   scope: Namespaced
   versions:

--- a/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: source.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-sources
     kind: GitRepository
     listKind: GitRepositoryList
     plural: gitrepositories

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: source.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-sources
     kind: HelmChart
     listKind: HelmChartList
     plural: helmcharts

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: source.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-sources
     kind: HelmRepository
     listKind: HelmRepositoryList
     plural: helmrepositories

--- a/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: source.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-sources
     kind: OCIRepository
     listKind: OCIRepositoryList
     plural: ocirepositories


### PR DESCRIPTION
This adds the standard Flux resource categories to every CRD in this
repository so users can list Flux resources with kubectl, for example:

```
kubectl get fluxcd            # all Flux resources
kubectl get fluxcd-sources    # all Flux source resources
kubectl get all               # now includes Flux resources
```

Each CRD gets exactly three categories:

```
all
fluxcd
fluxcd-sources
```

The `+kubebuilder:resource` markers were removed from the skipped older
API versions, since they interfere with CRD generation, and the CRDs
were regenerated with `make manifests`.

Part of fluxcd/flux2#5947
