### PR TITLE
Correct HelmChart status.url description

### DIFF
--- a/api/v1/helmchart_types.go
+++ b/api/v1/helmchart_types.go
@@ -144,7 +144,7 @@ type HelmChartStatus struct {
 
 	// URL is the dynamic fetch link for the latest Artifact.
 	// It is provided on a "best effort" basis, and using the precise
-	// BucketStatus.Artifact data is recommended.
+	// HelmChartStatus.Artifact data is recommended.
 	// +optional
 	URL string `json:"url,omitempty"`
 

--- a/api/v1beta2/helmchart_types.go
+++ b/api/v1beta2/helmchart_types.go
@@ -160,7 +160,7 @@ type HelmChartStatus struct {
 
 	// URL is the dynamic fetch link for the latest Artifact.
 	// It is provided on a "best effort" basis, and using the precise
-	// BucketStatus.Artifact data is recommended.
+	// HelmChartStatus.Artifact data is recommended.
 	// +optional
 	URL string `json:"url,omitempty"`
 

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -344,7 +344,7 @@ spec:
                 description: |-
                   URL is the dynamic fetch link for the latest Artifact.
                   It is provided on a "best effort" basis, and using the precise
-                  BucketStatus.Artifact data is recommended.
+                  HelmChartStatus.Artifact data is recommended.
                 type: string
             type: object
         type: object


### PR DESCRIPTION
The `HelmChartStatus.URL` doc-comment recommends consulting `BucketStatus.Artifact`, which belongs to the `Bucket` API, not `HelmChart`. The generated `helmcharts` CRD inherits this wrong reference in the `status.url` field description.

Point the comment at `HelmChartStatus.Artifact` in both `api/v1` and `api/v1beta2`, and regenerate the CRD. Comment-only change with the regenerated manifest; no functional or schema-shape impact.

This is the source-controller portion of fluxcd/flux2#5941 (the image-reflector-controller and image-automation-controller findings in that issue live in their own repos).

Verified with `make manifests fmt vet` and the api module tests.

Assisted-by: Claude Code/claude-opus-4-8