### PR TITLE
Fix HelmChartStatus.URL doc-comment referencing BucketStatus

### DIFF
--- a/api/v1/helmchart_types.go
+++ b/api/v1/helmchart_types.go
@@ -144,7 +144,7 @@ type HelmChartStatus struct {
 
 	// URL is the dynamic fetch link for the latest Artifact.
 	// It is provided on a "best effort" basis, and using the precise
-	// BucketStatus.Artifact data is recommended.
+	// HelmChartStatus.Artifact data is recommended.
 	// +optional
 	URL string `json:"url,omitempty"`
 

--- a/api/v1beta2/helmchart_types.go
+++ b/api/v1beta2/helmchart_types.go
@@ -160,7 +160,7 @@ type HelmChartStatus struct {
 
 	// URL is the dynamic fetch link for the latest Artifact.
 	// It is provided on a "best effort" basis, and using the precise
-	// BucketStatus.Artifact data is recommended.
+	// HelmChartStatus.Artifact data is recommended.
 	// +optional
 	URL string `json:"url,omitempty"`
 

--- a/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -349,7 +349,7 @@ spec:
                 description: |-
                   URL is the dynamic fetch link for the latest Artifact.
                   It is provided on a "best effort" basis, and using the precise
-                  BucketStatus.Artifact data is recommended.
+                  HelmChartStatus.Artifact data is recommended.
                 type: string
             type: object
         type: object

--- a/docs/api/v1/source.md
+++ b/docs/api/v1/source.md
@@ -2751,7 +2751,7 @@ string
 <em>(Optional)</em>
 <p>URL is the dynamic fetch link for the latest Artifact.
 It is provided on a &ldquo;best effort&rdquo; basis, and using the precise
-BucketStatus.Artifact data is recommended.</p>
+HelmChartStatus.Artifact data is recommended.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary

Part of fluxcd/flux2#5941 (item 1) — the `URL` field on `HelmChartStatus` had a doc-comment copy-pasted from `BucketStatus.URL`, telling users to prefer `BucketStatus.Artifact` data instead of `HelmChartStatus.Artifact`. Fixed in both `api/v1` and `api/v1beta2`, and regenerated the CRD via `make manifests`.

Cosmetic/documentation only — no functional or behavioral change.

## Test plan

- `go build ./...` and `cd api && go build ./...` — clean.
- `gofmt -l` on changed files — no output (already formatted).
- `go vet` in both the root module and `api` submodule — clean.
- `make manifests` regenerated `config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml`; diff confirmed to be exactly the one corrected description string, nothing else changed.