### PR TITLE
[draft] Treat Azure buckets without a configured identity as public

### DIFF
--- a/internal/bucket/azure/blob.go
+++ b/internal/bucket/azure/blob.go
@@ -88,6 +88,7 @@ type options struct {
 	secret             *corev1.Secret
 	proxyURL           *url.URL
 	withoutCredentials bool
+	objectLevelIdentity bool
 	withoutRetries     bool
 	authOpts           []auth.Option
 }
@@ -96,6 +97,16 @@ type options struct {
 // This is a test-only option useful for testing the client with HTTP
 // endpoints (without TLS) alongside all the other options unrelated to
 // credentials.
+// WithObjectLevelIdentity signals that the Bucket requests object-level workload
+// identity, i.e. it sets .spec.serviceAccountName. Without this signal, and without
+// controller-level identity configured in the environment, no token credential is
+// added to the chain and the bucket is treated as publicly reachable.
+func WithObjectLevelIdentity() Option {
+	return func(o *options) {
+		o.objectLevelIdentity = true
+	}
+}
+
 func withoutCredentials() Option {
 	return func(o *options) {
 		o.withoutCredentials = true
@@ -202,7 +213,7 @@ func NewClient(ctx context.Context, obj *sourcev1.Bucket, opts ...Option) (c *Bl
 	// Compose token chain based on environment.
 	// This functions as a replacement for azidentity.NewDefaultAzureCredential
 	// to not shell out.
-	token, err = chainCredentialWithSecret(ctx, o.secret, o.authOpts...)
+	token, err = chainCredentialWithSecret(ctx, o.secret, o.objectLevelIdentity, o.authOpts...)
 	if err != nil {
 		err = fmt.Errorf("failed to create environment credential chain: %w", err)
 		return nil, err
@@ -502,7 +513,7 @@ func sasTokenFromSecret(ep string, secret *corev1.Secret) (string, error) {
 //   - azidentity.ManagedIdentityCredential with defaults.
 //
 // If no valid token is created, it returns nil.
-func chainCredentialWithSecret(ctx context.Context, secret *corev1.Secret, opts ...auth.Option) (azcore.TokenCredential, error) {
+func chainCredentialWithSecret(ctx context.Context, secret *corev1.Secret, objectLevelIdentity bool, opts ...auth.Option) (azcore.TokenCredential, error) {
 	var creds []azcore.TokenCredential
 
 	credOpts := &azidentity.EnvironmentCredentialOptions{}
@@ -515,8 +526,13 @@ func chainCredentialWithSecret(ctx context.Context, secret *corev1.Secret, opts 
 	if token, _ := azidentity.NewEnvironmentCredential(credOpts); token != nil {
 		creds = append(creds, token)
 	}
-	if token := azureauth.NewTokenCredential(ctx, opts...); token != nil {
-		creds = append(creds, token)
+	// azureauth.NewTokenCredential never returns nil, so its presence in the chain
+	// cannot signal that any identity is actually configured. Add it only when an
+	// identity has been requested, either per-object via .spec.serviceAccountName or
+	// controller-wide via the environment. Otherwise the chain stays empty and the
+	// caller falls back to an unauthenticated client, as documented for public buckets.
+	if objectLevelIdentity || hasControllerLevelIdentity() {
+		creds = append(creds, azureauth.NewTokenCredential(ctx, opts...))
 	}
 
 	if len(creds) > 0 {
@@ -524,6 +540,18 @@ func chainCredentialWithSecret(ctx context.Context, secret *corev1.Secret, opts 
 	}
 
 	return nil, nil
+}
+
+// hasControllerLevelIdentity reports whether the controller's environment carries an
+// Azure identity. These are the variables the workload and managed identity flows in
+// fluxcd/pkg/auth read; if none is set there is nothing for a token credential to use.
+func hasControllerLevelIdentity() bool {
+	for _, env := range []string{"AZURE_CLIENT_ID", "AZURE_FEDERATED_TOKEN_FILE"} {
+		if os.Getenv(env) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // extractAccountNameFromEndpoint extracts the Azure account name from the

--- a/internal/bucket/azure/blob_test.go
+++ b/internal/bucket/azure/blob_test.go
@@ -657,11 +657,34 @@ func TestBlobClient_VisitObjects_MissingFields(t *testing.T) {
 }
 
 func Test_chainCredentialWithSecret(t *testing.T) {
-	g := NewWithT(t)
+	t.Run("no secret and no identity yields no credential", func(t *testing.T) {
+		g := NewWithT(t)
 
-	got, err := chainCredentialWithSecret(t.Context(), nil)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(got).To(BeAssignableToTypeOf(&azidentity.ChainedTokenCredential{}))
+		// Documented behaviour: "If no chain can be established, the bucket is
+		// assumed to be publicly reachable." The caller relies on a nil credential
+		// to build an unauthenticated client.
+		got, err := chainCredentialWithSecret(t.Context(), nil, false)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).To(BeNil())
+	})
+
+	t.Run("object-level identity yields a credential", func(t *testing.T) {
+		g := NewWithT(t)
+
+		got, err := chainCredentialWithSecret(t.Context(), nil, true)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).To(BeAssignableToTypeOf(&azidentity.ChainedTokenCredential{}))
+	})
+
+	t.Run("controller-level identity yields a credential", func(t *testing.T) {
+		g := NewWithT(t)
+
+		t.Setenv("AZURE_CLIENT_ID", "00000000-0000-0000-0000-000000000000")
+
+		got, err := chainCredentialWithSecret(t.Context(), nil, false)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).To(BeAssignableToTypeOf(&azidentity.ChainedTokenCredential{}))
+	})
 }
 
 func Test_extractAccountNameFromEndpoint1(t *testing.T) {

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -925,6 +925,9 @@ func (r *BucketReconciler) createBucketProvider(ctx context.Context, obj *source
 		if creds.proxyURL != nil {
 			opts = append(opts, azure.WithProxyURL(creds.proxyURL))
 		}
+		if obj.Spec.ServiceAccountName != "" {
+			opts = append(opts, azure.WithObjectLevelIdentity())
+		}
 		opts = append(opts, azure.WithAuth(authOpts...))
 		return azure.NewClient(ctx, obj, opts...)
 


### PR DESCRIPTION
Draft, opened to give #2136 something concrete to react to rather than to presume the outcome. **Please treat the direction as an open question** — if you would rather remove the fallback and correct the docs, say so and I will close this and send that instead.

Refs #2136.

## Problem

`azureauth.NewTokenCredential` never returns nil, so the guard in `chainCredentialWithSecret` is always true, `creds` is never empty, and the documented `return nil, nil` is dead. At the caller that makes `azblob.NewClientWithNoCredential` unreachable, so a `Bucket` with `provider: azure` and no `secretRef` cannot read a public container.

`docs/spec/v1/buckets.md` documents the opposite:

> ...is attempted by default. If no chain can be established, the bucket is assumed to be publicly reachable.

and ships an `azure-public` example with no `secretRef`, and states that publicly accessible storage needs neither `secretRef` nor `serviceAccountName`.

Note this is **not** a regression from #1875, contrary to what I first wrote on the issue and have since corrected there. The previous chain ended in `azidentity.NewManagedIdentityCredential(nil)`, which also constructs successfully anywhere, so the fallback was already unreachable. This is a long-standing gap between the docs and the code.

## Change

Add the token credential only when an identity has actually been requested:

- per object, via `.spec.serviceAccountName`, signalled by a new `azure.WithObjectLevelIdentity()` set by the reconciler;
- controller-wide, via `AZURE_CLIENT_ID` or `AZURE_FEDERATED_TOKEN_FILE`.

Otherwise the chain stays empty, `chainCredentialWithSecret` returns nil as documented, and the caller builds an unauthenticated client.

`staticcheck` no longer reports SA4023 here, and `go vet` is clean. I could not run `make test` locally as it needs envtest assets, so the controller suite has not been exercised on my side — CI will be the real check.

## The trade-off you should weigh

**A user relying on system-assigned managed identity with no environment variables set would now fall back to anonymous access instead of attempting IMDS.** That is a real behaviour change and the main reason this is a draft. Detecting that case cheaply is not possible at construction time, since `NewManagedIdentityCredential` succeeds regardless of whether IMDS is reachable.

It is also worth noting `gcp.NewClient` has no anonymous path at all — when no secret is present it always uses a token source. If "cloud providers always authenticate" is the intended direction, then the correct change is the opposite of this one: delete the unreachable fallback and drop the public-bucket language from the Azure docs.

## Tests

`Test_chainCredentialWithSecret` previously asserted the buggy behaviour, expecting a credential for a nil secret. It now covers no identity, object-level identity and controller-level identity.

The pre-existing anonymous coverage runs through `withoutCredentials()`, which is unexported and only called from `blob_test.go`, so it exercises a path the reconciler cannot reach. This change gives the anonymous path production coverage; happy to add a reconciler-level test too if you want it.