### PR TITLE
Remove Azure Bucket public access from the docs and the code

### DIFF
--- a/docs/spec/v1/buckets.md
+++ b/docs/spec/v1/buckets.md
@@ -339,8 +339,7 @@ with:
   with the `AZURE_CLIENT_ID`
 - Managed Identity with a system-assigned identity
 
-is attempted by default. If no chain can be established, the bucket
-is assumed to be publicly reachable.
+is attempted by default.
 
 When a reference is specified, it expects a Secret with one of the following
 sets of `.data` fields:
@@ -358,23 +357,6 @@ sets of `.data` fields:
 For any Managed Identity and/or Microsoft Entra ID (Formerly Azure Active Directory) authentication method,
 the base URL can be configured using `.data.authorityHost`. If not supplied,
 [`AzurePublicCloud` is assumed](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#AuthorityHost).
-
-##### Azure example
-
-```yaml
----
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: Bucket
-metadata:
-  name: azure-public
-  namespace: default
-spec:
-  interval: 5m0s
-  provider: azure
-  bucketName: podinfo
-  endpoint: https://podinfoaccount.blob.core.windows.net
-  timeout: 30s
-```
 
 ##### Azure Service Principal Secret example
 
@@ -1003,9 +985,6 @@ the `.spec.provider` field:
   will be used for Workload Identity authentication. In this case, the controller
   feature gate `ObjectLevelWorkloadIdentity` must be enabled, otherwise the
   controller will error out.
-
-**Note:** that for a publicly accessible object storage, you don't need to
-provide a `secretRef` nor `serviceAccountName`.
 
 **Important:** `.spec.secretRef` and `.spec.serviceAccountName` are mutually
 exclusive and cannot be set at the same time. This constraint is enforced

--- a/internal/bucket/azure/blob.go
+++ b/internal/bucket/azure/blob.go
@@ -207,13 +207,8 @@ func NewClient(ctx context.Context, obj *sourcev1.Bucket, opts ...Option) (c *Bl
 		err = fmt.Errorf("failed to create environment credential chain: %w", err)
 		return nil, err
 	}
-	if token != nil {
-		c.Client, err = azblob.NewClient(obj.Spec.Endpoint, token, clientOpts)
-		return
-	}
 
-	// Fallback to simple client.
-	c.Client, err = azblob.NewClientWithNoCredential(obj.Spec.Endpoint, clientOpts)
+	c.Client, err = azblob.NewClient(obj.Spec.Endpoint, token, clientOpts)
 	return
 }
 
@@ -501,7 +496,8 @@ func sasTokenFromSecret(ep string, secret *corev1.Secret) (string, error) {
 //     environment variable, if found.
 //   - azidentity.ManagedIdentityCredential with defaults.
 //
-// If no valid token is created, it returns nil.
+// The chain always contains at least one credential, so this never returns a nil
+// TokenCredential; Azure buckets are not supported without authentication.
 func chainCredentialWithSecret(ctx context.Context, secret *corev1.Secret, opts ...auth.Option) (azcore.TokenCredential, error) {
 	var creds []azcore.TokenCredential
 
@@ -519,11 +515,7 @@ func chainCredentialWithSecret(ctx context.Context, secret *corev1.Secret, opts 
 		creds = append(creds, token)
 	}
 
-	if len(creds) > 0 {
-		return azidentity.NewChainedTokenCredential(creds, nil)
-	}
-
-	return nil, nil
+	return azidentity.NewChainedTokenCredential(creds, nil)
 }
 
 // extractAccountNameFromEndpoint extracts the Azure account name from the


### PR DESCRIPTION
Replaces #2137, which took the opposite approach. @stefanprodan and @matheuscscp both said on that PR that the docs should be corrected rather than the anonymous path restored, since no Bucket provider works without authentication — so this does that instead.

Refs #2136.

## Docs

Three claims removed from `docs/spec/v1/buckets.md`:

- "If no chain can be established, the bucket is assumed to be publicly reachable."
- The `azure-public` example Bucket, which had no `secretRef` and relied on that behaviour.
- "**Note:** that for a publicly accessible object storage, you don't need to provide a `secretRef` nor `serviceAccountName`."

That last one sat under the Service Account section and applied to all providers, not just Azure. I checked the others before removing it: `gcp.NewClient` uses a token source whenever no secret is present, and `minio.NewClient` always sets `minioOpts.Creds`. Neither has an anonymous path, which matches what you said. Say the word if you would rather I scope that removal to Azure only.

## Code

The anonymous path was unreachable anyway. `azureauth.NewTokenCredential` never returns nil, so `creds` was never empty, `chainCredentialWithSecret` could not return the documented `nil, nil`, and `azblob.NewClientWithNoCredential` was dead. Removed the fallback, the dead nil return and the `len(creds) > 0` guard so the code states the same thing as the docs.

## Left alone, tell me if you want them

- `withoutCredentials()` in `blob.go` is unexported and only called from `blob_test.go`, so it is an anonymous path reachable only by tests. It is unused in production either way; happy to remove it and adjust the tests in this PR or a follow-up.
- `Test_chainCredentialWithSecret` still passes unchanged, since the chain is still always non-empty.

## Verification

`go build ./...`, `go vet ./internal/bucket/azure/` and `go test ./internal/bucket/azure/` all clean.