### PR TITLE
docs: correct the shallow clone claim for commit plus branch

### DIFF
--- a/docs/spec/v1/gitrepositories.md
+++ b/docs/spec/v1/gitrepositories.md
@@ -607,8 +607,9 @@ spec:
 ``` 
 
 This field takes precedence over all other fields. It can be combined with
-`.spec.ref.branch` to perform a shallow clone of the branch, in which the
-commit must exist:
+`.spec.ref.branch` to restrict the clone to a single branch, in which the
+commit must exist. Note that this is not a shallow clone: the commit is
+fetched with the full history of that branch.
 
 ```yaml
 ---


### PR DESCRIPTION
Part of #2146 — the documentation half only.

The v1 GitRepository docs say that combining `.spec.ref.commit` with `.spec.ref.branch` performs a shallow clone of the branch. It does not.

In `fluxcd/pkg/git/gogit`, `cloneBranch`, `cloneTag` and `cloneSemVer` all set `Depth` from `opts.ShallowClone`. `cloneCommit` has no `Depth` field in its `CloneOptions` at all, and `Client.clone` dispatches on `Commit` before any other ref field, so a commit-pinned GitRepository always takes that path. Setting a branch alongside it only sets `SingleBranch` and `ReferenceName`, so the clone is narrowed to one branch but still fetches that branch in full.

The wording appears to predate the `gitImplementation: go-git | libgit2` split, where it was carried over from the v1beta2 field comment.

This only corrects the documentation. The bounded-depth mechanism and the `LastObservedCommit` fast path also raised in #2146 are behaviour changes in `fluxcd/pkg` and are left for maintainers to weigh in on first.